### PR TITLE
chore: workflows/coverage updated 

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -2,6 +2,9 @@ name: Coverage
 on:
   push:
     branches:
+      - 'main'
+  pull_request: 
+    branches:
       - '*'
     paths-ignore:
       - '.badges/chore_workflows/coverage.svg'

--- a/Stella.Ergosfare.slnx
+++ b/Stella.Ergosfare.slnx
@@ -35,5 +35,10 @@
     <File Path="test\Directory.Packages.props" />
     <File Path="coverlet.runsettings" />
   </Folder>
-  <Folder Name="/workflows/" />
+  <Folder Name="/workflows/">
+    <File Path=".github\workflows\coverage_tests.yml" />
+    <File Path=".github\workflows\github_release.yml" />
+    <File Path=".github\workflows\nuget_release.yml" />
+    <File Path=".github\workflows\unit_tests.yml" />
+  </Folder>
 </Solution>


### PR DESCRIPTION
- we dont want burn github datacenter with unnecessary workflow runs,
- it was polluting branches with generated badge
