### PR TITLE
Refactor mediator to resolve message resolution strategy from DI

### DIFF
--- a/src/Ergosfare.Commands/CommandMediator.cs
+++ b/src/Ergosfare.Commands/CommandMediator.cs
@@ -6,19 +6,20 @@ using Ergosfare.Core.Abstractions.Strategies;
 
 namespace Ergosfare.Commands;
 
-public class CommandMediator(IMessageMediator messageMediator) : ICommandMediator
+public class CommandMediator(
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+    IMessageMediator messageMediator) : ICommandMediator
 {
     public Task SendAsync(ICommand commandConstruct, CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
         commandMediationSettings ??= new CommandMediationSettings();
         var mediationStrategy = new SingleAsyncHandlerMediationStrategy<ICommand>();
-        var findStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
 
         var options = new MediateOptions<ICommand, Task>
         {
             MessageMediationStrategy = mediationStrategy,
-            MessageResolveStrategy = findStrategy,
+            MessageResolveStrategy = messageResolveStrategy,
             CancellationToken = cancellationToken,
             Items = commandMediationSettings.Items,
             Groups = commandMediationSettings.Filters.Groups
@@ -35,11 +36,10 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
     {
         commandMediationSettings ??= new CommandMediationSettings();
         var mediationStrategy = new SingleAsyncHandlerMediationStrategy<ICommand<TResult>, TResult>();
-        var findStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
 
         var options = new MediateOptions<ICommand<TResult>, Task<TResult>>
         {
-            MessageResolveStrategy = findStrategy,
+            MessageResolveStrategy = messageResolveStrategy,
             MessageMediationStrategy = mediationStrategy,
             CancellationToken = cancellationToken,
             Items = commandMediationSettings.Items,

--- a/src/Ergosfare.Core.Abstractions/IMessageResolveStrategies.cs
+++ b/src/Ergosfare.Core.Abstractions/IMessageResolveStrategies.cs
@@ -18,5 +18,5 @@ public interface IMessageResolveStrategy
     ///     The implementation determines the specific rules for matching a message type to a descriptor.
     ///     For example, it might look for an exact type match, or it might consider inheritance relationships.
     /// </remarks>
-    IMessageDescriptor? Find(Type messageType, IMessageRegistry messageRegistry);
+    IMessageDescriptor? Find(Type messageType);
 }

--- a/src/Ergosfare.Core.Abstractions/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategy.cs
+++ b/src/Ergosfare.Core.Abstractions/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategy.cs
@@ -15,7 +15,7 @@ namespace Ergosfare.Core.Abstractions.Strategies;
 ///     It allows messages to be handled by handlers registered for their exact type or for any base type or interface
 ///     that they implement. When multiple assignable types are found, the first one is returned.
 /// </remarks>
-public sealed class ActualTypeOrFirstAssignableTypeMessageResolveStrategy : IMessageResolveStrategy
+public sealed class ActualTypeOrFirstAssignableTypeMessageResolveStrategy(IMessageRegistry messageRegistry) : IMessageResolveStrategy
 {
     /// <summary>
     ///     Finds a message descriptor for the specified message type from the message registry.
@@ -29,7 +29,7 @@ public sealed class ActualTypeOrFirstAssignableTypeMessageResolveStrategy : IMes
     /// <remarks>
     ///     For generic types, this method uses the generic type definition for matching.
     /// </remarks>
-    public IMessageDescriptor? Find(Type messageType, IMessageRegistry messageRegistry)
+    public IMessageDescriptor? Find(Type messageType)
     {
         if (messageType.IsGenericType)
         {

--- a/src/Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -3,6 +3,7 @@ using Ergosfare.Core.Abstractions;
 using Ergosfare.Core.Abstractions.Factories;
 using Ergosfare.Core.Abstractions.Registry;
 using Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Ergosfare.Core.Abstractions.Strategies;
 using Ergosfare.Core.Internal.Factories;
 using Ergosfare.Core.Internal.Mediator;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,6 +37,7 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
         services.TryAddTransient<IMessageMediator, MessageMediator>();
         services.TryAddSingleton(messageRegistry);
         services.TryAddTransient(_ => AmbientExecutionContext.Current);
+        services.TryAddTransient<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>();
 
         foreach (var descriptor in messageRegistry)
         {

--- a/src/Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Ergosfare.Core.Abstractions.Registry;
-using Ergosfare.Core.Internal.Builders;
+﻿
 using Ergosfare.Core.Internal.Factories;
 using Ergosfare.Core.Internal.Registry;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +18,7 @@ public static class ServiceCollectionExtensions
 
         // Register it as a singleton in DI
         services.TryAddSingleton(messageRegistry);
+        
 
         // Create module registry with the shared message registry
         var ergosfareBuilder = new ModuleRegistry(services, messageRegistry);

--- a/src/Ergosfare.Core/Internal/Factories/AsyncBroadcastMediationStrategyFactory.cs
+++ b/src/Ergosfare.Core/Internal/Factories/AsyncBroadcastMediationStrategyFactory.cs
@@ -1,0 +1,6 @@
+namespace Ergosfare.Core.Internal.Factories;
+
+public class AsyncBroadcastMediationStrategyFactory
+{
+    
+}

--- a/src/Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -10,6 +10,5 @@ public sealed class MessageDependenciesFactory(IServiceProvider serviceProvider)
     public IMessageDependencies Create(Type messageType, IMessageDescriptor descriptor, IEnumerable<string> groups)
     {
         return new MessageDependencies(messageType, descriptor, serviceProvider, groups);
-
     }
 }

--- a/src/Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -27,7 +27,7 @@ internal sealed class MessageMediator(
         // Get the actual type of the message
         var messageType = message.GetType();
         
-        var descriptor = options.MessageResolveStrategy.Find(messageType, _messageRegistry);
+        var descriptor = options.MessageResolveStrategy.Find(messageType);
         
         
         if (descriptor is null)
@@ -39,7 +39,7 @@ internal sealed class MessageMediator(
 
             _messageRegistry.Register(messageType);
 
-            descriptor = options.MessageResolveStrategy.Find(messageType, _messageRegistry);
+            descriptor = options.MessageResolveStrategy.Find(messageType);
         }
 
         if (descriptor is null)

--- a/src/Ergosfare.Events/EventMediator.cs
+++ b/src/Ergosfare.Events/EventMediator.cs
@@ -7,20 +7,22 @@ namespace Ergosfare.Events;
 
 
 /// <inheritdoc cref="IEventMediator" />
-public sealed class EventMediator(IMessageMediator messageMediator) : IPublisher
+public sealed class EventMediator(
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+    IMessageMediator messageMediator) : IPublisher
 {
     public Task PublishAsync(IEvent @event,
                              EventMediationSettings? eventMediationSettings = null,
                              CancellationToken cancellationToken = default)
     {
         var mediationStrategy = new AsyncBroadcastMediationStrategy<IEvent>(eventMediationSettings ??= new EventMediationSettings());
-        var resolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+
 
         return messageMediator.Mediate(@event,
             new MediateOptions<IEvent, Task>
             {
                 MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = resolveStrategy,
+                MessageResolveStrategy = messageResolveStrategy,
                 CancellationToken = cancellationToken,
                 RegisterPlainMessagesOnSpot = !eventMediationSettings.ThrowIfNoHandlerFound,
                 Items = eventMediationSettings.Items,
@@ -33,13 +35,12 @@ public sealed class EventMediator(IMessageMediator messageMediator) : IPublisher
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
         var mediationStrategy = new AsyncBroadcastMediationStrategy<TEvent>(eventMediationSettings ??= new EventMediationSettings());
-        var resolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
 
         return messageMediator.Mediate(@event,
             new MediateOptions<TEvent, Task>
             {
                 MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = resolveStrategy,
+                MessageResolveStrategy = messageResolveStrategy,
                 CancellationToken = cancellationToken,
                 RegisterPlainMessagesOnSpot = !eventMediationSettings.ThrowIfNoHandlerFound,
                 Items = eventMediationSettings.Items,

--- a/src/Ergosfare.Logging.Abstractions/Ergosfare.Logging.Abstractions.csproj
+++ b/src/Ergosfare.Logging.Abstractions/Ergosfare.Logging.Abstractions.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>13</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    </ItemGroup>
+
+</Project>

--- a/src/Ergosfare.Logging.Extensions.MicrosoftDependencyInjection/AssemblyReference.cs
+++ b/src/Ergosfare.Logging.Extensions.MicrosoftDependencyInjection/AssemblyReference.cs
@@ -1,0 +1,3 @@
+﻿namespace Ergosfare.Logging.Extensions.MicrosfotDependencyInjection;
+
+public interface IAssemblyReference;

--- a/src/Ergosfare.Logging/Ergosfare.Logging.csproj
+++ b/src/Ergosfare.Logging/Ergosfare.Logging.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>13</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Ergosfare.Logging.Abstractions\Ergosfare.Logging.Abstractions.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    </ItemGroup>
+
+</Project>

--- a/src/Ergosfare.Queries/QueryMediator.cs
+++ b/src/Ergosfare.Queries/QueryMediator.cs
@@ -5,20 +5,21 @@ using Ergosfare.Queries.Abstractions;
 
 namespace Ergosfare.Queries;
 
-public class QueryMediator(IMessageMediator messageMediator): IQueryMediator
+public class QueryMediator(
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+    IMessageMediator messageMediator): IQueryMediator
 {
     public Task<TResult> QueryAsync<TResult>(IQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
         queryMediationSettings ??= new QueryMediationSettings();
         var mediationStrategy = new SingleAsyncHandlerMediationStrategy<IQuery<TResult>, TResult>();
-        var resolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
    
         return messageMediator.Mediate(query,
             new MediateOptions<IQuery<TResult>, Task<TResult>>
             {
                 MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = resolveStrategy,
+                MessageResolveStrategy = messageResolveStrategy,
                 CancellationToken = cancellationToken,
                 Items = queryMediationSettings.Items,
                 Groups = queryMediationSettings.Filters.Groups
@@ -30,12 +31,11 @@ public class QueryMediator(IMessageMediator messageMediator): IQueryMediator
     {
         queryMediationSettings ??= new QueryMediationSettings();
         var mediationStrategy = new SingleStreamHandlerMediationStrategy<IStreamQuery<TResult>, TResult>(cancellationToken);
-        var resolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
         return messageMediator.Mediate(query,
             new MediateOptions<IStreamQuery<TResult>, IAsyncEnumerable<TResult>>
             {
                 MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = resolveStrategy,
+                MessageResolveStrategy = messageResolveStrategy,
                 CancellationToken = cancellationToken,
                 Items = queryMediationSettings.Items,
                 Groups = queryMediationSettings.Filters.Groups

--- a/test/Ergosfare.Command.Test/CommandMediatorTests.cs
+++ b/test/Ergosfare.Command.Test/CommandMediatorTests.cs
@@ -2,6 +2,7 @@
 using Ergosfare.Commands;
 using Ergosfare.Commands.Abstractions;
 using Ergosfare.Core.Abstractions;
+using Ergosfare.Core.Abstractions.Strategies;
 using Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,7 +27,9 @@ public class CommandMediatorTests
                 }).BuildServiceProvider();
         
         var messageMediator = serviceCollection.GetService<IMessageMediator>();
-        var mediator = new CommandMediator(messageMediator!);
+        var mediator = new CommandMediator(
+            serviceCollection.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
+            messageMediator!);
         var result = mediator.SendAsync(new StubNonGenericCommand(), null,  CancellationToken.None);
         
         Assert.NotNull(result);
@@ -50,7 +53,9 @@ public class CommandMediatorTests
             }).BuildServiceProvider();
         
         var messageMediator = serviceCollection.GetRequiredService<IMessageMediator>();
-        var mediator = new CommandMediator(messageMediator!);
+        var mediator = new CommandMediator(
+            serviceCollection.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
+            messageMediator!);
         var result = mediator.SendAsync(new StubNonGenericCommandStringResult(), StubDefaultMediationSetting.CommandDefaultSetting,  CancellationToken.None);
         
         Assert.NotNull(result);

--- a/test/Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/DependencyInjectionTests.cs
+++ b/test/Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/DependencyInjectionTests.cs
@@ -32,7 +32,7 @@ public class DependencyInjectionTests
         
         var options = new MediateOptions<Message, Task>
         {
-            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(),
+            MessageResolveStrategy = serviceProvider.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
             MessageMediationStrategy = new SingleAsyncHandlerMediationStrategy<Message>(),
             CancellationToken = default,
             Groups = []

--- a/test/Ergosfare.Core.Test/MessageDependencyExtensionsTests.cs
+++ b/test/Ergosfare.Core.Test/MessageDependencyExtensionsTests.cs
@@ -33,8 +33,8 @@ public class MessageDependencyExtensionsTests
         registry.Register(typeof(StubNonGenericPreInterceptor));
         registry.Register(typeof(StubNonGenericDerivedPreInterceptor));
 
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
-        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage), registry);
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
+        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage));
         var factory = new MessageDependenciesFactory(serviceProvider);
         var dependencies = factory.Create(typeof(StubNonGenericDerivedMessage), descriptor, []);
     
@@ -79,9 +79,9 @@ public class MessageDependencyExtensionsTests
         registry.Register(typeof(StubNonGenericDerivedPostInterceptor2));
 
 
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
         
-        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage), registry);
+        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage));
 
         var dependencyFactory = new MessageDependenciesFactory(serviceProvider);
         
@@ -178,8 +178,8 @@ public class MessageDependencyExtensionsTests
         registry.Register(typeof(StubNonGenericDerivedExceptionInterceptor2));
         
 
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
-        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage), registry);
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
+        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage));
         var dependencyFactory = new MessageDependenciesFactory(serviceProvider);
         var dependencies = dependencyFactory.Create(typeof(StubNonGenericMessage), descriptor!, []);
         

--- a/test/Ergosfare.Core.Test/MessageMediatorTests.cs
+++ b/test/Ergosfare.Core.Test/MessageMediatorTests.cs
@@ -93,7 +93,7 @@ public class MessageMediatorTests
         {
             CancellationToken = CancellationToken.None,
             Items = new Dictionary<object, object?>(),
-            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy()!,
+            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry)!,
             MessageMediationStrategy = 
                 new SingleAsyncHandlerMediationStrategy<StubNonGenericMessage>(),
             Groups = []
@@ -134,7 +134,7 @@ public class MessageMediatorTests
             RegisterPlainMessagesOnSpot = false,
             CancellationToken = CancellationToken.None,
             Items = new Dictionary<object, object?>(),
-            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy()!,
+            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry)!,
             MessageMediationStrategy = 
                 new SingleAsyncHandlerMediationStrategy<StubNonGenericMessage>(),
             Groups = []

--- a/test/Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
+++ b/test/Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
@@ -152,10 +152,10 @@ public class SingleAsyncHandlerMediationStrategyTests
         registry.Register(typeof(TestExceptionMessageHandler));
         registry.Register(typeof(TestExceptionMessageDuplicateHandler));
 
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
         var strategy = new SingleAsyncHandlerMediationStrategy<TestExceptionMessage, string>();
         
-        var descriptor = resolver.Find(typeof(TestExceptionMessage), registry);
+        var descriptor = resolver.Find(typeof(TestExceptionMessage));
         var dependencies = new MessageDependenciesFactory(serviceProvider)
             .Create(typeof(TestExceptionMessage), descriptor!,[]);
         
@@ -196,10 +196,10 @@ public class SingleAsyncHandlerMediationStrategyTests
         registry.Register(typeof(TestExceptionMessagePostInterceptor));
         registry.Register(typeof(TestExceptionMessageExceptionInterceptor));
 
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
         var strategy = new SingleAsyncHandlerMediationStrategy<TestExceptionMessage, string>();
         
-        var descriptor = resolver.Find(typeof(TestExceptionMessage), registry);
+        var descriptor = resolver.Find(typeof(TestExceptionMessage));
         var dependencies = new MessageDependenciesFactory(serviceProvider)
             .Create(typeof(TestExceptionMessage), descriptor!, []);
         
@@ -266,9 +266,9 @@ public class SingleAsyncHandlerMediationStrategyTests
         messageRegistry.Register(typeof(StubNonGenericStringResultHandler));
         messageRegistry.Register(typeof(TestExceptionAborterPreInterceptor));
         
-        var  resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var  resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(messageRegistry);
 
-        var descriptor = resolver.Find(typeof(StubNonGenericMessage), messageRegistry);
+        var descriptor = resolver.Find(typeof(StubNonGenericMessage));
 
         var dependencies = new MessageDependenciesFactory(serviceProvider).Create(
             typeof(StubNonGenericMessage), descriptor!, []);
@@ -311,9 +311,9 @@ public class SingleAsyncHandlerMediationStrategyTests
         messageRegistry.Register(typeof(StubNonGenericStringResultHandler));
         messageRegistry.Register(typeof(TestExceptionAborterResultPreInterceptor));
         
-        var  resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var  resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(messageRegistry);
 
-        var descriptor = resolver.Find(typeof(StubNonGenericMessage), messageRegistry);
+        var descriptor = resolver.Find(typeof(StubNonGenericMessage));
 
         var dependencies = new MessageDependenciesFactory(serviceProvider).Create(
             typeof(StubNonGenericMessage), descriptor!, []);
@@ -356,9 +356,9 @@ public class SingleAsyncHandlerMediationStrategyTests
         messageRegistry.Register(typeof(TestUnknownExceptionPreInterceptor));
         messageRegistry.Register(typeof(TestUnknownExceptionInterceptor));
         
-        var  resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var  resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(messageRegistry);
 
-        var descriptor = resolver.Find(typeof(StubNonGenericMessage), messageRegistry);
+        var descriptor = resolver.Find(typeof(StubNonGenericMessage));
 
         var dependencies = new MessageDependenciesFactory(serviceProvider).Create(
             typeof(StubNonGenericMessage), descriptor!, []);

--- a/test/Ergosfare.Core.Test/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest.cs
+++ b/test/Ergosfare.Core.Test/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest.cs
@@ -16,10 +16,10 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
         
         registry.Register(typeof(StubNonGenericHandler));
         registry.Register(typeof(StubNonGenericHandler2));
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
         
         // act
-        var descriptor = resolver.Find(typeof(StubNonGenericMessage), registry);
+        var descriptor = resolver.Find(typeof(StubNonGenericMessage));
         
         // assert
         Assert.NotNull(descriptor);
@@ -40,10 +40,10 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
             new HandlerDescriptorBuilderFactory());
     
         registry.Register(typeof(StubNonGenericHandler)); // handles BaseMessage
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
     
         // act
-        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage), registry);
+        var descriptor = resolver.Find(typeof(StubNonGenericDerivedMessage));
     
         // assert
         Assert.NotNull(descriptor);
@@ -63,10 +63,10 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
         
         registry.Register(typeof(StubGenericHandler<string>)); // handles BaseMessage
         
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
         
         // act
-        var descriptor = resolver.Find(typeof(StubGenericMessage<string>), registry);
+        var descriptor = resolver.Find(typeof(StubGenericMessage<string>));
         
         //assert
         Assert.NotNull(descriptor);

--- a/test/Ergosfare.Core.Test/__factories__/MessageDependencyFactory.cs
+++ b/test/Ergosfare.Core.Test/__factories__/MessageDependencyFactory.cs
@@ -29,8 +29,8 @@ internal class SingleMessageDependencyMediationFactory
         }
         
         // 3. Resolve descriptor
-        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy();
-        var descriptor = resolver.Find(typeof(TMessage), registry);
+        var resolver = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry);
+        var descriptor = resolver.Find(typeof(TMessage));
         
         // 4. Create dependencies
         var dependencyFactory = new MessageDependenciesFactory(serviceProvider);

--- a/test/Ergosfare.Events.Test/AsyncBroadcastMediationStrategyTests.cs
+++ b/test/Ergosfare.Events.Test/AsyncBroadcastMediationStrategyTests.cs
@@ -29,6 +29,7 @@ public class AsyncBroadcastMediationStrategyTests
                 new MessageDependenciesFactory(services));
         
         var mediator = new EventMediator(
+            new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(messageRegistry),
             messageMediator
             );
 
@@ -64,6 +65,7 @@ public class AsyncBroadcastMediationStrategyTests
             new MessageDependenciesFactory(services));
         
         var mediator = new EventMediator(
+            new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(messageRegistry),
             messageMediator
         );
 

--- a/test/Ergosfare.Logging.Test/Ergosfare.Logging.Test.csproj
+++ b/test/Ergosfare.Logging.Test/Ergosfare.Logging.Test.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Ergosfare.Commands.Extensions.MicrosoftDependencyInjection\Ergosfare.Commands.Extensions.MicrosoftDependencyInjection.csproj" />
+      <ProjectReference Include="..\..\src\Ergosfare.Core.Extensions.MicrosoftDependencyInjection\Ergosfare.Core.Extensions.MicrosoftDependencyInjection.csproj" />
+      <ProjectReference Include="..\..\src\Ergosfare.Logging.Extensions.MicrosoftDependencyInjection\Ergosfare.Logging.Extensions.MicrosoftDependencyInjection.csproj" />
+      <ProjectReference Include="..\..\src\Ergosfare.Logging\Ergosfare.Logging.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Ergosfare.Logging.Test/UnitTest1.cs
+++ b/test/Ergosfare.Logging.Test/UnitTest1.cs
@@ -1,0 +1,33 @@
+﻿using Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Ergosfare.Logging.Abstractions;
+using Ergosfare.Logging.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Ergosfare.Logging.Test;
+
+public class ErgosfareLoggingModuleTests
+{
+    [Fact]
+    public void ShouldHaveLoggingConfiguration()
+    {
+        var services = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.AddLoggingModule();
+            })
+            .BuildServiceProvider();
+        
+        
+        var loggingConfiguration = services.GetRequiredService<IErgosfareLoggingConfiguration>();
+        Assert.NotNull(loggingConfiguration);
+        Assert.NotNull(loggingConfiguration.CommandLoggerSettings.Formatter);
+        Assert.NotNull(loggingConfiguration.EventLoggerSettings.Formatter);
+        Assert.NotNull(loggingConfiguration.QueryLoggerSettings.Formatter);
+        
+        
+        Assert.Equal(LogLevel.Information, loggingConfiguration.CommandLoggerSettings.LogLevel);
+        Assert.Equal(LogLevel.Information, loggingConfiguration.EventLoggerSettings.LogLevel);
+        Assert.Equal(LogLevel.Information, loggingConfiguration.QueryLoggerSettings.LogLevel);
+    }
+}

--- a/test/Ergosfare.Queries.Test/QueryMediatorTests.cs
+++ b/test/Ergosfare.Queries.Test/QueryMediatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Ergosfare.Core.Abstractions;
+using Ergosfare.Core.Abstractions.Strategies;
 using Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Ergosfare.Queries.Abstractions;
 using Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
@@ -12,13 +13,15 @@ public class QueryMediatorTests
     [Fact]
     public async Task ShouldResolveTQueryTResult()
     {
-        var serviceCollection = new ServiceCollection()
+        var services = new ServiceCollection()
             .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStringResultQueryHandler>()
             )).BuildServiceProvider();
         
         
-        var messageMediator = serviceCollection.GetService<IMessageMediator>();
-        var mediator = new QueryMediator(messageMediator!);
+        var messageMediator = services.GetService<IMessageMediator>();
+        var mediator = new QueryMediator(
+            services.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
+            messageMediator!);
 
         var result = mediator.QueryAsync(new StubNonGenericStringResultQuery(), null);
         
@@ -38,7 +41,9 @@ public class QueryMediatorTests
         
         
         var messageMediator = serviceCollection.GetService<IMessageMediator>();
-        var mediator = new QueryMediator(messageMediator!);
+        var mediator = new QueryMediator(
+            serviceCollection.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
+            messageMediator!);
         var expected = new []  {"Foo", "Bar", "Baz"};
         var result = new List<string>();
         // act


### PR DESCRIPTION

### What changed

* `ActualTypeOrFirstAssignableTypeMessageResolveStrategy`:

  * Uses constructor injection for `IMessageRegistry`.
  * Simplified `Find` to only require `Type`.
* `MessageMediator`:

  * Updated to call the simplified `Find(Type)`.
  * Retains support for on-the-spot registration of plain messages.
* DI:

  * Added registration for `ActualTypeOrFirstAssignableTypeMessageResolveStrategy`.
* Tests:

  * Updated to reflect the new DI-driven strategy.

### Why

* Moves message resolution into DI, reducing manual wiring.
* Simplifies `Find` API by removing unnecessary registry parameter.
* Makes strategies more idiomatic and test-friendly.

### Notes

* This change only covers the **message resolution part** of mediation.
* Other mediation concerns are still manually constructed and may be moved to DI in future steps.


