### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nuget_release.yml
+++ b/.github/workflows/nuget_release.yml
@@ -1,4 +1,6 @@
 name: NugetPackagesRelease
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/stellayazilim/Ergosfare/security/code-scanning/3](https://github.com/stellayazilim/Ergosfare/security/code-scanning/3)

**General fix:**  
Explicitly specify the `permissions` block at the workflow or job level to restrict the `GITHUB_TOKEN`'s privileges to the least required for the workflow to work. If the entire workflow only needs certain permissions, add the block at the workflow root (top-level). If only one job needs stronger permissions, add per-job blocks.

**Best fix for this code:**  
In this workflow, at least one job ("release") uses `softprops/action-gh-release`, which requires `contents: write` (to create releases and upload release assets). No other permission appears necessary (e.g., no editing of issues, discussions, etc.). Therefore, add a top-level `permissions` block with `contents: write` to the workflow, just below the `name:` key.

**Where to change:**  
Insert the following lines after line 1 (`name: ...`):

```yaml
permissions:
  contents: write
```

**What's needed:**  
No additional methods, imports, or complex edits—just the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
