### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       # 1️⃣ Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/stellayazilim/Ergosfare/security/code-scanning/2](https://github.com/stellayazilim/Ergosfare/security/code-scanning/2)

To address the issue, you should add a `permissions` block to the `release` job or to the root of the workflow (`.github/workflows/github_release.yml`). This block limits the permissions granted to the `GITHUB_TOKEN` used by this workflow. The minimum required permissions should be configured. Based on the workflow's steps:

- Publishing to GitHub Packages (NuGet): requires `packages: write`.
- Creating a GitHub Release and uploading assets: requires `contents: write`.
It is best to start with the least required permissions and increase only if steps fail due to insufficient access.

**Where to change:**  
- At line 19 (inside the `release` job), insert a `permissions` block immediately above or below `runs-on: ubuntu-latest` (or, alternatively, as a root-level key above `jobs:` to apply to all jobs—here, job-level is preferred for clarity).

**Permissions block to use (minimal and necessary):**
```yaml
permissions:
  contents: write
  packages: write
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
