### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,4 +1,6 @@
 name: UnitTests
+permissions:
+  contents: read
 on:
   push: 
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/stellayazilim/Ergosfare/security/code-scanning/1](https://github.com/stellayazilim/Ergosfare/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block to the workflow or the job. Because the workflow only seems to need to read repository contents (to checkout code and run tests), setting `permissions: contents: read` is sufficient and restricts the GITHUB_TOKEN to only what is necessary. The best practice is to include this block at the root level of the workflow YAML (i.e., directly below the `name:` entry), which applies to all jobs inside the workflow unless those jobs explicitly override it. Only one region—the YAML frontmatter—needs to be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
