### PR TITLE
docs: add SECURITY.md with reporting guidelines and supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,45 @@
-# Security Policy
+# Ergosfare Security Policy
 
-## Supported Versions
+## 1. Purpose
+This document defines the security standards for the Ergosfare platform, aiming to protect data, maintain system integrity, and guide responsible reporting of vulnerabilities.
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+## 2. Scope
+This policy applies to:
+- Ergosfare software and services
+- Employees, contractors, and contributors
+- Third-party integrations and plugins
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+## 3. Supported Versions
+Security fixes are actively maintained **only for the latest release** of Ergosfare until the first stable version is released.  
+Users of older versions are encouraged to upgrade to the latest release to receive security updates.
 
-## Reporting a Vulnerability
+## 4. Responsible Disclosure
+If you discover a security vulnerability:
+- **Do not exploit it.**
+- Report it immediately via **a.cetinbas@icloud.com** or by opening a **private issue** in the Ergosfare GitHub repository.
+- Provide detailed steps, potential impact, and any relevant proof-of-concept.
+- Ergosfare will respond promptly and coordinate remediation efforts.
 
-Use this section to tell people how to report a vulnerability.
+## 5. Reporting Guidelines
+When reporting a security issue, include:
+- A clear description of the issue
+- Steps to reproduce
+- Screenshots or logs if possible
+- Avoid public disclosure until the issue is resolved
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## 6. Contact
+- **Email:** a.cetinbas@icloud.com
+- **GitHub:** Private issues in the Ergosfare repository
+
+## 7. Acknowledgment
+Ergosfare may acknowledge contributors who responsibly report security vulnerabilities, with consent.
+
+## 8. Security Best Practices
+- Validate and sanitize all inputs
+- Avoid storing sensitive data (passwords, tokens) in plaintext
+- Use safe defaults for authentication, access control, and configuration
+- Follow [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices/) where applicable
+- **Third-party / n-party plugins:** Only use plugins verified by the Ergosfare team. Unverified n-party plugins may introduce security risks and are the responsibility of the user to assess
+
+## 9. Updates to Security Policy
+This policy may be updated periodically. Users are encouraged to review the latest version.


### PR DESCRIPTION
- Defines supported version policy (latest until first stable release)
- Specifies vulnerability reporting via GitHub issues or personal email
- References n-party plugins not verified by Ergosfare team
- Outlines security best practices for users and contributors