### PR TITLE
Refactor interceptor interfaces and unify pipeline result handling

### DIFF
--- a/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage,TResult].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage,TResult].cs
@@ -5,10 +5,15 @@ using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
 
+/// <summary>
+/// Represents an asynchronous interceptor that handles exceptions for a specific message and its strongly typed result.
+/// </summary>
+/// <typeparam name="TMessage">The type of message being processed. Must be non-nullable.</typeparam>
+/// <typeparam name="TResult">The type of the result for the message. Must be non-nullable.</typeparam>
 public interface IAsyncExceptionInterceptor<in TMessage, in TResult>: 
     IExceptionInterceptor<TMessage, TResult> where TMessage : notnull
 {
-
+    /// <inheritdoc cref="IExceptionInterceptor{TMessage, TResult}.Handle"/>
     object IExceptionInterceptor<TMessage, TResult>.Handle(
         TMessage message,
         TResult? result,
@@ -18,7 +23,20 @@ public interface IAsyncExceptionInterceptor<in TMessage, in TResult>:
         return   HandleAsync(message, result, exception, context);
     }
        
-
-    Task HandleAsync(TMessage message, TResult? result, Exception exception, IExecutionContext context);
+    /// <summary>
+    /// Handles an exception asynchronously for a specific message and its strongly typed result.
+    /// </summary>
+    /// <param name="message">The message being processed when the exception occurred.</param>
+    /// <param name="result">
+    /// The current strongly typed result of the message, if any. 
+    /// The interceptor can modify or replace this result, which will continue through the pipeline.
+    /// </param>
+    /// <param name="exception">The exception that was thrown during message processing.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation.
+    /// The result of type <typeparamref name="TResult"/> may be modified and will be propagated through the pipeline.
+    /// </returns>
+    Task<object> HandleAsync(TMessage message, TResult? result, Exception exception, IExecutionContext context);
     
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage].cs
@@ -4,10 +4,21 @@ using System.Threading.Tasks;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+/// <summary>
+/// Represents an asynchronous interceptor that handles exceptions thrown during the processing of a specific message type
+/// and can modify the resulting message result.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message being handled.</typeparam>
+/// <remarks>
+/// Implementations of this interface can inspect the exception, modify the existing result, or produce a new result
+/// to continue through the pipeline. This interface is useful for messages that do not have a strongly typed result
+/// or when the result type is <c>object</c>.
+/// </remarks>
 public interface IAsyncExceptionInterceptor<in TMessage>: IExceptionInterceptor<TMessage, object>
     where TMessage : notnull
 {
-    
+    /// <inheritdoc cref="IExceptionInterceptor{TMessage, TResult}.Handle"/>
     object IExceptionInterceptor<TMessage, object>
         .Handle(
             TMessage message, 
@@ -21,6 +32,18 @@ public interface IAsyncExceptionInterceptor<in TMessage>: IExceptionInterceptor<
             exception, context);
     }
     
+    
+    /// <summary>
+    /// Handles an exception asynchronously for a specific message and its result.
+    /// </summary>
+    /// <param name="message">The message being processed when the exception occurred.</param>
+    /// <param name="messageResult">The current result of the message, if any. Can be modified or replaced.</param>
+    /// <param name="exception">The exception that was thrown during message processing.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation.
+    /// The result of the message may be modified and will continue through the pipeline.
+    /// </returns>
     Task HandleAsync(
         TMessage message, 
         object? messageResult, 

--- a/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler.cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler.cs
@@ -2,7 +2,31 @@ using System;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents an interceptor that handles exceptions thrown during message processing in the pipeline.
+/// </summary>
+/// <remarks>
+/// Implementations of this interface can inspect the exception, modify it, or produce a new result
+/// to continue through the pipeline. The returned <see cref="object"/> is the result that will
+/// be passed to subsequent interceptors or handlers.
+///
+/// This design supports both legacy and fluent-result styles, making it flexible for pipelines
+/// where the concrete result type may only be known at runtime.
+/// </remarks>
 public interface IExceptionInterceptor
 {
+    /// <summary>
+    /// Handles an exception that occurred while processing a message.
+    /// </summary>
+    /// <param name="message">The message that was being handled when the exception occurred.</param>
+    /// <param name="messageResult">The current result of the message, if any. Can be modified or replaced.</param>
+    /// <param name="exception">The exception that was thrown during message handling.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// Returns the result of the message after handling the exception. This result will continue
+    /// through the pipeline and can be modified by subsequent interceptors or handlers.
+    /// </returns>
     object Handle(object message,  object? messageResult, Exception exception,  IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler[TMessage,TResult].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler[TMessage,TResult].cs
@@ -2,15 +2,40 @@ using System;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents an interceptor that handles exceptions thrown during the processing of a specific message type
+/// and can modify the resulting message result.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message being handled.</typeparam>
+/// <typeparam name="TResult">The type of the message result.</typeparam>
+/// <remarks>
+/// Implementations of this interface can inspect the exception, modify the existing result, or produce a new result
+/// to continue through the pipeline. This design allows support for both legacy and fluent-result styles, 
+/// making it flexible for pipelines where the concrete result type may only be known at runtime.
+/// </remarks>
 public interface IExceptionInterceptor<in TMessage, in TResult> : IExceptionInterceptor
     where TMessage : notnull
 {
-    
+    /// <inheritdoc cref="IExceptionInterceptor.Handle"/>
     object IExceptionInterceptor.Handle(object message, object? messageResult, Exception exception, IExecutionContext context)
     {
         return Handle((TMessage) message, (TResult?) messageResult, exception,  context);
     }
     
+    
+    /// <summary>
+    /// Handles an exception for a specific message and its result.
+    /// </summary>
+    /// <param name="message">The message being processed when the exception occurred.</param>
+    /// <param name="messageResult">The current result of the message, if any. Can be modified or replaced.</param>
+    /// <param name="exception">The exception that was thrown during message processing.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// Returns the modified or original message result as an <see cref="object"/>.
+    /// The returned result will continue through the pipeline and can be further processed by other interceptors or handlers.
+    /// </returns>
     object Handle(TMessage message,  TResult? messageResult, Exception exception,  IExecutionContext context);
 
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage].cs
@@ -5,15 +5,31 @@ using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
 
-
+/// <summary>
+/// Represents an asynchronous handler for messages of type <typeparamref name="TMessage"/>.
+/// Produces a <see cref="Task"/> as the result, allowing for asynchronous workflows.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message to handle. Must be non-nullable.</typeparam>
+/// <remarks>
+/// This interface extends the generic <see cref="IHandler{TMessage, TResult}"/> with <typeparamref name="TResult"/> 
+/// set to <see cref="Task"/>, enabling asynchronous message processing. 
+/// The explicit interface implementation maps the generic <see cref="IHandler{TMessage, TResult}.Handle"/> method
+/// to the strongly-typed <see cref="HandleAsync"/> method.
+/// </remarks>
 public interface IAsyncHandler<in TMessage>: IHandler<TMessage, Task>
     where TMessage : notnull
 {
+    /// <inheritdoc cref="IHandler{TMessage, TResult}.Handle"/>
     Task IHandler<TMessage, Task>.Handle(TMessage message, IExecutionContext context)
     {
         return HandleAsync(message, context);
     }
         
-        
+    /// <summary>
+    /// Handles a message of type <typeparamref name="TMessage"/> asynchronously.
+    /// </summary>
+    /// <param name="message">The message to handle.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous handling operation.</returns>   
     Task HandleAsync(TMessage message, IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/Main/IHandler[TMessage,TResult].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/Main/IHandler[TMessage,TResult].cs
@@ -3,15 +3,35 @@ using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
 
+
+/// <summary>
+/// Represents a strongly-typed handler for processing messages of type <typeparamref name="TMessage"/>
+/// and producing a result of type <typeparamref name="TResult"/>.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message to handle. Must be non-nullable.</typeparam>
+/// <typeparam name="TResult">The type of the result produced by the handler. Must be non-nullable.</typeparam>
+/// <remarks>
+/// Implementations of this interface should provide the synchronous handling logic for a message and return
+/// a strongly typed result. The non-generic <see cref="IHandler"/> interface is implemented explicitly to allow
+/// type-agnostic invocation, mapping the <paramref name="message"/> to <typeparamref name="TMessage"/> and returning
+/// the typed <typeparamref name="TResult"/> as <see cref="object"/>.
+/// </remarks>
 public interface IHandler<in TMessage, out TResult> : IHandler
     where TMessage : notnull
     where TResult : notnull
 {
     
+    /// <inheritdoc cref="IHandler.Handle"/>
     object IHandler.Handle(object message, IExecutionContext context)
     {
         return Handle((TMessage) message, context);
     }
     
+    /// <summary>
+    /// Handles a message of type <typeparamref name="TMessage"/> and returns a strongly-typed result.
+    /// </summary>
+    /// <param name="message">The message to handle.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>The result of type <typeparamref name="TResult"/> produced by handling the message.</returns>
     TResult Handle(TMessage message, IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/Main/IStreamHandler[TMessage,TResult].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/Main/IStreamHandler[TMessage,TResult].cs
@@ -1,12 +1,26 @@
 using System.Collections.Generic;
-using System.Threading;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents a handler that streams results asynchronously for messages of type <typeparamref name="TMessage"/>.
+/// Produces an <see cref="IAsyncEnumerable{TResult}"/> to enable asynchronous streaming of multiple results.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message to handle. Must be non-nullable.</typeparam>
+/// <typeparam name="TResult">The type of each item in the streamed result. Must be non-nullable.</typeparam>
+/// <remarks>
+/// This interface extends <see cref="IHandler{TMessage, TResult}"/> with <typeparamref name="TResult"/> 
+/// set to <see cref="IAsyncEnumerable{TResult}"/>, allowing the handler to produce multiple results asynchronously.
+/// The explicit interface implementation maps the generic <see cref="IHandler{TMessage, TResult}.Handle"/> method
+/// to the strongly-typed <see cref="StreamAsync"/> method.
+/// </remarks>
 public interface IStreamHandler<in TMessage, out TResult>
     :IHandler<TMessage, IAsyncEnumerable<TResult>>
         where TMessage : notnull
 {
+    /// <inheritdoc cref="IHandler{TMessage, TResult}.Handle"/>
     IAsyncEnumerable<TResult> IHandler<TMessage, IAsyncEnumerable<TResult>>.Handle(
         TMessage message, 
         IExecutionContext context)
@@ -14,5 +28,14 @@ public interface IStreamHandler<in TMessage, out TResult>
         return StreamAsync(message, context);
     }
     
+    
+    /// <summary>
+    /// Streams results asynchronously for a given message.
+    /// </summary>
+    /// <param name="message">The message to handle.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// An <see cref="IAsyncEnumerable{TResult}"/> representing the streamed asynchronous results of the message handling.
+    /// </returns>
     IAsyncEnumerable<TResult> StreamAsync(TMessage message,IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage,TResult].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage,TResult].cs
@@ -3,22 +3,45 @@ using System.Threading.Tasks;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents an asynchronous post-interceptor for a specific message type and its result type.
+/// Executes after the main handler has processed the message and allows inspecting or modifying the result.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message being handled.</typeparam>
+/// <typeparam name="TResult">The type of the result produced by the main handler.</typeparam>
+/// <remarks>
+/// This interface allows performing asynchronous operations after a message has been handled. 
+/// The interceptor can inspect or modify the <typeparamref name="TResult"/> value.
+/// 
+/// The <see cref="IPostInterceptor{TMessage, TResult}.Handle"/> implementation delegates to <see cref="HandleAsync"/>.
+/// Returning <c>null</c> is allowed only if it matches the intended pipeline behavior; otherwise, a meaningful object should be returned.
+/// </remarks>
 public interface IAsyncPostInterceptor<in TMessage, in TResult>
     :IPostInterceptor<TMessage, TResult>
     where TMessage : notnull 
     where TResult: notnull
 {
-    
+    /// <inheritdoc cref="IPostInterceptor{TMessage, TResult}.Handle"/>
     object IPostInterceptor<TMessage, TResult>.Handle(
         TMessage message, 
         TResult? messageResult, 
         IExecutionContext context)
     {
-        return HandleAsync(
-            message, 
-            messageResult, 
-            AmbientExecutionContext.Current);
+        return HandleAsync(message,  messageResult, AmbientExecutionContext.Current);
     }
     
-    Task HandleAsync(TMessage message, TResult? messageResult, IExecutionContext context);
+    /// <inheritdoc cref="IPostInterceptor{TMessage,TResult}.Handle"/> 
+    /// <summary>
+    /// Handles a message asynchronously after it has been processed by the main handler.
+    /// </summary>
+    /// <param name="message">The message that was handled by the main handler.</param>
+    /// <param name="messageResult">The result produced by the main handler, which can be inspected or modified.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="Task{Object}"/> representing the asynchronous operation.
+    /// The returned object should represent the modified result to continue through the pipeline.
+    /// </returns>
+    Task<object> HandleAsync(TMessage message, TResult? messageResult, IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage].cs
@@ -1,11 +1,38 @@
-using System.Threading;
+using System;
 using System.Threading.Tasks;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents an asynchronous post-interceptor for a specific message type that does not produce a meaningful result.
+/// Executes after the main handler has processed the message.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message being handled.</typeparam>
+/// <remarks>
+/// This interface allows performing asynchronous side-effects or additional processing after a message has been handled.
+/// The <paramref name="_"/> parameter represents the main handler's result but is ignored, since there is no meaningful result.
+/// The <see cref="IPostInterceptor{TMessage, object}.Handle"/> implementation delegates to <see cref="HandleAsync"/>.
+/// </remarks>
 public interface IAsyncPostInterceptor<in TMessage>
     : IPostInterceptor<TMessage, object>
     where TMessage : notnull
 {
-    Task HandleAsync(TMessage message, object? messageResult, IExecutionContext context);
+    /// <inheritdoc cref="IPostInterceptor{TMessage, TResult}.Handle"/>
+    object IPostInterceptor<TMessage, object>.Handle(TMessage message, object? _, IExecutionContext context)
+    {
+        return HandleAsync(message, _, context);
+    }
+    
+    /// <summary>
+    /// Handles a message asynchronously after it has been processed by its main handler.
+    /// </summary>
+    /// <param name="message">The message that was handled by the main handler.</param>
+    /// <param name="_">
+    /// The result produced by the main handler. For messages without a meaningful result, this can be <c>null</c> and should be ignored.
+    /// </param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task HandleAsync(TMessage message, object? _, IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor.cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor.cs
@@ -1,7 +1,31 @@
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents a post-interceptor in the pipeline, which executes after the main handler has processed a message.
+/// </summary>
+/// <remarks>
+/// The <see cref="Handle"/> method allows inspecting or modifying the result of a message after it has been handled.
+/// The return type is <see cref="object"/> to remain type-agnostic and support pipelines where the concrete result type
+/// may only be known at runtime. This enables both legacy and generic/fluent-result approaches without forcing the interceptor
+/// to know the exact result type at compile time.
+/// </remarks>
 public interface IPostInterceptor
 {
+    
+    /// <summary>
+    /// Handles a message after it has been processed by the main handler.
+    /// </summary>
+    /// <param name="message">The message that was handled by the main handler.</param>
+    /// <param name="messageResult">
+    /// The result produced by the main handler. Interceptors can inspect, modify, or replace this result.
+    /// </param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// Returns the (possibly modified) result as <see cref="object"/>. It is expected that the actual result matches the
+    /// type produced by the main handler.
+    /// </returns>
     object Handle(object message, object? messageResult, IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor[TMessage,TResult].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor[TMessage,TResult].cs
@@ -1,16 +1,30 @@
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents a post-interceptor for a specific message and result type, executing after the main handler has processed the message.
+/// </summary>
+/// <typeparam name="TMessage">The type of the message being handled.</typeparam>
+/// <typeparam name="TResult">The type of the result produced by the main handler.</typeparam>
+/// <remarks>
+/// This interface allows inspecting, modifying, or replacing the result of a message after it has been processed by its main handler.
+/// The <see cref="Handle"/> method returns <see cref="object"/> to remain compatible with runtime-typed pipelines, 
+/// while the generic parameters provide compile-time context for IntelliSense and safer casting.
+/// 
+/// Implementers should ensure that the returned object matches the expected <typeparamref name="TResult"/> type, 
+/// otherwise an exception may be thrown at runtime.
+/// </remarks>
 public interface IPostInterceptor<in TMessage,in TResult>
     : IPostInterceptor where TMessage : notnull
 {
 
-
+    /// <inheritdoc cref="IPostInterceptor.Handle"/>
     object IPostInterceptor.Handle(object message, object? messageResult, IExecutionContext context)
     {
         return Handle((TMessage) message, (TResult?) messageResult, AmbientExecutionContext.Current);
     }
 
     object Handle(TMessage message, TResult? messageResult, IExecutionContext context);
-
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IAsyncPreInterceptor[TMessage].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IAsyncPreInterceptor[TMessage].cs
@@ -1,18 +1,42 @@
-using System.Threading;
 using System.Threading.Tasks;
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents an asynchronous pre-processing interceptor for messages of type <typeparamref name="TMessage"/>.
+/// Executed before the main handler processes the message, allowing inspection, validation, or modification of the input.
+/// </summary>
+/// <typeparam name="TMessage">The type of message this interceptor handles.</typeparam>
+/// <remarks>
+/// The <see cref="HandleAsync"/> method returns <see cref="object"/> to allow returning a modified version of the input message.
+/// - This supports pipelines where messages may be transformed before handling.
+/// - Runtime vali
+/// /// </remarks>
+
 public interface IAsyncPreInterceptor<in TMessage>:
     IPreInterceptor<TMessage> 
     where TMessage : notnull
 {
+    /// <inheritdoc cref="IPreInterceptor{TMessage}.Handle" />
     object IPreInterceptor<TMessage>.Handle(
         TMessage message,  IExecutionContext context) => HandleAsync(
             message, 
             context);
     
-    Task HandleAsync(
+    
+    /// <summary>
+    /// Handles a message asynchronously before it reaches the main handler.
+    /// </summary>
+    /// <param name="message">The input message to be processed.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="Task{Object}"/> representing the asynchronous operation.
+    /// The returned <see cref="object"/> is actually of type <typeparamref name="TMessage"/> (the input message type). 
+    /// This allows the interceptor to return either the original message or a modified version, which will continue through the pipeline.
+    /// </returns>
+    Task<object> HandleAsync(
         TMessage message, 
         IExecutionContext context);
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor.cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor.cs
@@ -1,7 +1,25 @@
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+/// <summary>
+/// Represents a non-generic pre-processing interceptor for messages.
+/// </summary>
+/// <remarks>
+/// Pre-interceptors are executed before the main handler processes a message. 
+/// They allow you to inspect, validate, enrich, or replace the message before it reaches the handler.
+/// </remarks>
 public interface IPreInterceptor
 {
+    
+    /// <summary>
+    /// Handles a message before it is processed by its main handler.
+    /// </summary>
+    /// <param name="message">The message to be processed. Can be modified or replaced by the interceptor.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// Returns the original or modified message as <see cref="object"/>. 
+    /// Using <see cref="object"/> allows runtime flexibility for pipelines with unknown concrete message types.
+    /// </returns>
     object Handle(object message, IExecutionContext context) ;
 }

--- a/src/Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor[TMessage].cs
+++ b/src/Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor[TMessage].cs
@@ -1,14 +1,45 @@
 using Ergosfare.Context;
 
 namespace Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Represents a pre-processing interceptor for messages of type <typeparamref name="TMessage"/>.
+/// Executed before the main handler processes the message, allowing inspection, validation, enrichment,
+/// or even rejection of the input message.
+/// </summary>
+/// <typeparam name="TMessage">The type of message this interceptor handles.</typeparam>
+/// <remarks>
+/// <inheritdoc />
+/// <para>
+/// The <see cref="Handle"/> method returns <see cref="object"/> instead of <typeparamref name="TMessage"/> 
+/// to support scenarios where the input message can be transformed or replaced before passing to the handler.
+/// This provides flexibility for pipelines with runtime-typed messages, while maintaining type safety
+/// when the pipeline is executed.
+/// </para>
+/// <para>
+/// Use <see cref="AmbientExecutionContext.Current"/> when accessing ambient or contextual information
+/// during message processing.
+/// </para>
+/// </remarks>
 public interface IPreInterceptor<in TMessage> : IPreInterceptor 
     where TMessage : notnull
 {
-
+    /// <inheritdoc cref="IPreInterceptor.Handle" />
     object IPreInterceptor.Handle(object message,  IExecutionContext context)
     {
         return Handle((TMessage)message, AmbientExecutionContext.Current);
     }
+    
+    
+    /// <summary>
+    /// Handles a message before it reaches the main handler.
+    /// </summary>
+    /// <param name="message">The input message to process.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// Returns the original or a modified message as <see cref="object"/> to allow pipeline transformations.
+    /// </returns>
     object Handle(TMessage message, IExecutionContext context);
 }
 

--- a/src/Ergosfare.Core/EventHub/EventHub.cs
+++ b/src/Ergosfare.Core/EventHub/EventHub.cs
@@ -106,28 +106,23 @@ public class EventHub: IEventHub, IHasProxyEvents
     public ProxyEvent<FinishPreInterceptorInvocationEvent> FinishPreInterceptorInvocationEvent { get; }
     public ProxyEvent<FinishPreInterceptingWithExceptionEvent> FinishPreInterceptingWithExceptionEvent { get; }
     public ProxyEvent<FinishPreInterceptingEvent>  FinishPreInterceptingEvent { get; }
-    
-    
     // handler events
     public ProxyEvent<BeginHandlingEvent> BeginHandlingEvent { get; }
     public ProxyEvent<BeginHandlerInvocationEvent> BeginHandlerInvocationEvent { get; }
     public ProxyEvent<FinishHandlerInvocationEvent> FinishHandlerInvocationEvent { get; }
     public ProxyEvent<FinishHandlingWithExceptionEvent> FinishHandlingWithExceptionEvent { get; }
     public ProxyEvent<FinishHandlingEvent>  FinishHandlingEvent { get; }
-    
     // post intercepting
     public ProxyEvent<BeginPostInterceptingEvent> BeginPostInterceptingEvent { get; }
     public ProxyEvent<BeginPostInterceptorInvocationEvent> BeginPostInterceptorInvocationEvent { get; }
     public ProxyEvent<FinishPostInterceptorInvocationEvent> FinishPostInterceptorInvocationEvent { get; }
     public ProxyEvent<FinishPostInterceptingWithExceptionEvent> FinishPostInterceptingWithExceptionEvent { get; }
     public ProxyEvent<FinishPostInterceptingEvent> FinishPostInterceptingEvent { get; }
-    
     // exception intercepting 
     public ProxyEvent<BeginExceptionInterceptingEvent> BeginExceptionInterceptingEvent { get; }
     public ProxyEvent<BeginExceptionInterceptorInvocationEvent> BeginExceptionInterceptorInvocationEvent { get; }
     public ProxyEvent<FinishExceptionInterceptorInvocationEvent> FinishExceptionInterceptorInvocationEvent { get; }
     public ProxyEvent<FinishExceptionInterceptingEvent> FinishExceptionInterceptingEvent { get; }
-    
     // finish pipeline
     public ProxyEvent<FinishPipelineEvent> FinishPipelineEvent { get; }
 }

--- a/test/Ergosfare.Command.Test/__stubs__/PreInterceptorStubs.cs
+++ b/test/Ergosfare.Command.Test/__stubs__/PreInterceptorStubs.cs
@@ -10,10 +10,10 @@ namespace Ergosfare.Command.Test.__stubs__;
 public class StubCommandPreInterceptor1: ICommandPreInterceptor<StubNonGenericCommand>
 {
     public static  bool HasCalled;
-    public virtual Task HandleAsync(StubNonGenericCommand message, IExecutionContext context)
+    public virtual Task<object> HandleAsync(StubNonGenericCommand message, IExecutionContext context)
     {
         HasCalled = true;
-        return Task.CompletedTask;
+        return Task.FromResult<object>(message);
     }
 }
 
@@ -24,9 +24,9 @@ public class StubCommandPreInterceptor2: ICommandPreInterceptor<StubNonGenericCo
 {
    
     public static bool HasCalled;
-    public virtual Task HandleAsync(StubNonGenericCommand message, IExecutionContext context)
+    public virtual Task<object>  HandleAsync(StubNonGenericCommand message, IExecutionContext context)
     {
         HasCalled = true;
-        return Task.CompletedTask;
+        return Task.FromResult<object>(message);
     }
 }

--- a/test/Ergosfare.Core.Test/EventHub/ProxyEventTests.cs
+++ b/test/Ergosfare.Core.Test/EventHub/ProxyEventTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using Ergosfare.Core.EventHub;
+using Ergosfare.Core.Events;
 
 namespace Ergosfare.Core.Test.EventHub;
 
@@ -31,9 +33,33 @@ public class ProxyEventTests
             new object[] { nameof(_hub.FinishPreInterceptingWithExceptionEvent) },
             new object[] { nameof(_hub.FinishPreInterceptorInvocationEvent) }
         };
+    
+        
+    [Fact]
+    [Trait("Category", "Coverage")]
+    [Trait("Category", "Unit")]
+    public void All_ProxyEvent_Properties_Should_Be_Initialized()
+    {
+        // Arrange
+        var hub = new Core.EventHub.EventHub();
+        var properties = typeof(Core.EventHub.EventHub).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // Act & Assert
+        foreach (var prop in properties)
+        {
+            // Only test ProxyEvent<> properties
+            if (!prop.PropertyType.IsGenericType) continue;
+            if (prop.PropertyType.GetGenericTypeDefinition() != typeof(ProxyEvent<>)) continue;
+
+            var value = prop.GetValue(hub);
+            Assert.NotNull(value);
+        }
+    }
 
         [Theory]
         [MemberData(nameof(ProxyEventData))]
+        [Trait("Category", "Coverage")]
+        [Trait("Category", "Unit")]
         public void ProxyEvent_Should_Invoke_Handler_When_Raised(string propertyName)
         {
             // Arrange
@@ -41,4 +67,7 @@ public class ProxyEventTests
             // Assert
             Assert.NotNull(property);
         }
+        
+    
+
 }

--- a/test/Ergosfare.Core.Test/IExceptionInterseptorTests.cs
+++ b/test/Ergosfare.Core.Test/IExceptionInterseptorTests.cs
@@ -35,9 +35,9 @@ public class ExceptionInterceptorTests
     }
 
     
-    private class TestExceptionInterceptor4: IAsyncExceptionInterceptor<StubNonGenericMessage, Task>
+    private class TestExceptionInterceptor4: IAsyncExceptionInterceptor<StubNonGenericMessage>
     {
-        public Task HandleAsync(StubNonGenericMessage message, Task? result, Exception exception, IExecutionContext context)
+        public Task HandleAsync(StubNonGenericMessage message, object? result, Exception exception, IExecutionContext context)
         {
             return Task.CompletedTask;
         }

--- a/test/Ergosfare.Core.Test/PreInterceptorTests.cs
+++ b/test/Ergosfare.Core.Test/PreInterceptorTests.cs
@@ -19,9 +19,9 @@ public class PreInterceptorTests
     
     private class TestIAsyncPreInterceptorTMessageHandler: IAsyncPreInterceptor<IMessage>
     {
-        public Task HandleAsync(IMessage message, IExecutionContext context)
+        public Task<object> HandleAsync(IMessage message, IExecutionContext context)
         {
-            return Task.CompletedTask;
+            return Task.FromResult<object>(message);
         }
     }
 

--- a/test/Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
+++ b/test/Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
@@ -48,25 +48,25 @@ public class SingleAsyncHandlerMediationStrategyTests
 
     private class TestExceptionMessagePreInterceptor: IAsyncPreInterceptor<TestExceptionMessage>
     {
-        public Task HandleAsync(TestExceptionMessage message, IExecutionContext context)
+        public Task<object> HandleAsync(TestExceptionMessage message, IExecutionContext context)
         {
-            return Task.CompletedTask;
+            return Task.FromResult<object>(message);
         }
     }
     
     private class TestExceptionMessagePostInterceptor: IAsyncPostInterceptor<TestExceptionMessage, string>
     {
-        public Task HandleAsync(TestExceptionMessage message, string? messageResult, IExecutionContext context)
+        public Task<object> HandleAsync(TestExceptionMessage message, string? messageResult, IExecutionContext context)
         {
-            return Task.CompletedTask;
+            return Task.FromResult<object>(messageResult);
         }
     }
     
     private class TestExceptionMessageExceptionInterceptor: IAsyncExceptionInterceptor<TestExceptionMessage, string>
     {
-        public Task HandleAsync(TestExceptionMessage message, string? result, Exception exception, IExecutionContext context)
+        public Task<object> HandleAsync(TestExceptionMessage message, string? result, Exception exception, IExecutionContext context)
         {
-            return Task.CompletedTask;
+            return Task.FromResult<object>(result);
         }
     }
     

--- a/test/Ergosfare.Core.Test/__stubs__/Common/StubGenericExceptionInterceptor.cs
+++ b/test/Ergosfare.Core.Test/__stubs__/Common/StubGenericExceptionInterceptor.cs
@@ -3,9 +3,10 @@ using Ergosfare.Core.Abstractions.Handlers;
 
 namespace Ergosfare.Core.Test.__stubs__;
 
-public class StubGenericExceptionInterceptor<TArg>: IAsyncExceptionInterceptor<StubNonGenericMessage, Task>
+public class StubGenericExceptionInterceptor<TArg>: IAsyncExceptionInterceptor<StubNonGenericMessage>
 {
-    public Task HandleAsync(StubNonGenericMessage message, Task? result, Exception exception, IExecutionContext context)
+    
+    public Task HandleAsync(StubNonGenericMessage message, object? messageResult, Exception exception, IExecutionContext context)
     {
         return Task.CompletedTask;
     }

--- a/test/Ergosfare.Core.Test/__stubs__/Common/StubGenericPostInterceptor.cs
+++ b/test/Ergosfare.Core.Test/__stubs__/Common/StubGenericPostInterceptor.cs
@@ -3,10 +3,15 @@ using Ergosfare.Core.Abstractions.Handlers;
 
 namespace Ergosfare.Core.Test.__stubs__;
 
-internal class StubGenericPostInterceptor<TArg>: IAsyncPostInterceptor<StubNonGenericMessage, Task>
+internal class StubGenericPostInterceptor<TArg>: IAsyncPostInterceptor<StubNonGenericMessage>
 {
-    public Task HandleAsync(StubNonGenericMessage message, Task? messageResult, IExecutionContext context)
+    public Task HandleAsync(StubNonGenericMessage message, object? messageResult, IExecutionContext context)
     {
         return Task.CompletedTask;
+    }
+
+    public object Handle(StubNonGenericMessage message, object? messageResult, IExecutionContext context)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/test/Ergosfare.Core.Test/__stubs__/Common/StubGenericPreInterceptor.cs
+++ b/test/Ergosfare.Core.Test/__stubs__/Common/StubGenericPreInterceptor.cs
@@ -5,8 +5,8 @@ namespace Ergosfare.Core.Test.__stubs__;
 
 internal class StubGenericPreInterceptor<TArg> : IAsyncPreInterceptor<StubNonGenericMessage>
 {
-    public Task HandleAsync(StubNonGenericMessage message, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericMessage message, IExecutionContext context)
     {
-        return Task.CompletedTask;
+        return Task.FromResult<object>(message);
     }
 }

--- a/test/Ergosfare.Core.Test/__stubs__/Common/StubNonGenericExceptionInterceptor.cs
+++ b/test/Ergosfare.Core.Test/__stubs__/Common/StubNonGenericExceptionInterceptor.cs
@@ -43,9 +43,9 @@ internal class StubNonGenericAsyncExceptionInterceptor: IAsyncExceptionIntercept
 
 public class StubNonGenericAsyncStringResultExceptionInterceptor: IAsyncExceptionInterceptor<StubNonGenericMessage, string>
 {
-    public Task HandleAsync(StubNonGenericMessage message, string? result, Exception exception, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericMessage message, string? result, Exception exception, IExecutionContext context)
     {
-        return Task.CompletedTask;
+        return Task.FromResult((object)result);
     }
 }
 

--- a/test/Ergosfare.Core.Test/__stubs__/Common/StubNonGenericPostInterceptor.cs
+++ b/test/Ergosfare.Core.Test/__stubs__/Common/StubNonGenericPostInterceptor.cs
@@ -3,32 +3,34 @@ using Ergosfare.Core.Abstractions.Handlers;
 
 namespace Ergosfare.Core.Test.__stubs__;
 
-internal class StubNonGenericPostInterceptor: IAsyncPostInterceptor<StubNonGenericMessage,Task>
+internal class StubNonGenericPostInterceptor: IAsyncPostInterceptor<StubNonGenericMessage>
 {
-    public async Task HandleAsync(StubNonGenericMessage message, Task? messageResult, IExecutionContext context)
+ 
+    public Task HandleAsync(StubNonGenericMessage message, object? _, IExecutionContext context)
     {
-        await Task.Yield();
-               
+        return Task.CompletedTask;
     }
 }
 
 
-internal class StubNonGenericDerivedPostInterceptor: IAsyncPostInterceptor<StubNonGenericDerivedMessage,Task>
+internal class StubNonGenericDerivedPostInterceptor: IAsyncPostInterceptor<StubNonGenericDerivedMessage>
 {
-    public async Task HandleAsync(StubNonGenericDerivedMessage message, Task? messageResult, IExecutionContext context)
+    public Task HandleAsync(StubNonGenericDerivedMessage message, object? messageResult, IExecutionContext context)
     {
-        await Task.Yield();
+        return Task.CompletedTask;
     }
+
+   
 }
 
 
 internal class StubNonGenericStreamPostInterceptorsAbortExecution: IAsyncPostInterceptor<StubNonGenericMessage,IAsyncEnumerable<string>>
 {
 
-    public Task HandleAsync(StubNonGenericMessage message, IAsyncEnumerable<string>? messageResult, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericMessage message, IAsyncEnumerable<string>? messageResult, IExecutionContext context)
     {
         context.Abort();
-        return Task.CompletedTask;
+        return Task.FromResult<object>(messageResult ?? throw new ArgumentNullException(nameof(messageResult)));
     }
 }
 
@@ -37,7 +39,7 @@ internal class StubNonGenericStreamPostInterceptorThrowsException: IAsyncPostInt
 {
 
 
-    public Task HandleAsync(StubNonGenericMessage message, IAsyncEnumerable<string>? messageResult, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericMessage message, IAsyncEnumerable<string>? messageResult, IExecutionContext context)
     {
         throw new Exception("post exception");
     }

--- a/test/Ergosfare.Core.Test/__stubs__/Common/StubNonGenericPreInterceptor.cs
+++ b/test/Ergosfare.Core.Test/__stubs__/Common/StubNonGenericPreInterceptor.cs
@@ -5,9 +5,9 @@ namespace Ergosfare.Core.Test.__stubs__;
 
 internal class StubNonGenericPreInterceptor: IAsyncPreInterceptor<StubNonGenericMessage>
 {
-    public Task HandleAsync(StubNonGenericMessage message, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericMessage message, IExecutionContext context)
     {
-        return Task.CompletedTask;
+        return Task.FromResult<object>(message);
     }
 }
 
@@ -15,19 +15,19 @@ internal class StubNonGenericPreInterceptor: IAsyncPreInterceptor<StubNonGeneric
 
 internal class StubNonGenericDerivedPreInterceptor: IAsyncPreInterceptor<StubNonGenericDerivedMessage>
 {
-    public Task HandleAsync(StubNonGenericDerivedMessage message, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericDerivedMessage message, IExecutionContext context)
     {
-        return Task.CompletedTask;
+        return Task.FromResult<object>(message);
     }
 }
 
 
 internal class StubNonGenericStreamPreInterceptorAbortExecution: IAsyncPreInterceptor<StubNonGenericMessage>
 {
-    public Task HandleAsync(StubNonGenericMessage message, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericMessage message, IExecutionContext context)
     {
         context.Abort();
-        return Task.CompletedTask;
+        return Task.FromResult<object>(message);
     }
 }
 internal class StubNonGenericPreInterceptor2 : StubNonGenericPreInterceptor;

--- a/test/Ergosfare.Events.Test/EventHandlers.cs
+++ b/test/Ergosfare.Events.Test/EventHandlers.cs
@@ -45,9 +45,9 @@ public sealed class StubNonGenericEventExceptionInterceptor: IEventExceptionInte
     public static bool IsRuned { get; private set; }
 
 
-    public Task HandleAsync(StubNonGenericEventThrows message, object? messageResult, Exception exception, IExecutionContext context)
+    public Task<object> HandleAsync(StubNonGenericEventThrows message, object? messageResult, Exception exception, IExecutionContext context)
     {
         IsRuned = true;
-        return Task.CompletedTask;
+        return Task.FromResult<object>(messageResult);
     }
 }

--- a/test/Ergosfare.Queries.Test/QueryHandlerTest.cs
+++ b/test/Ergosfare.Queries.Test/QueryHandlerTest.cs
@@ -1,0 +1,6 @@
+namespace Ergosfare.Queries.Test;
+
+public class QueryHandlerTest
+{
+    
+}


### PR DESCRIPTION

## Description
This PR refactors Ergosfare’s interceptor interfaces to simplify pipeline handling and improve clarity:

- Pre-interceptors now return the updated input instead of modifying it by reference.

- Post- and exception interceptors now return the result, allowing modifications to flow through the pipeline.

- Interfaces for async and generic scenarios have been unified and documented.

- Added XML comments to clarify usage, return values, and why some methods return object.

- Lays groundwork for FinalInterceptor and better type-safe pipeline execution.

These changes make writing and maintaining interceptors more intuitive, while keeping backward compatibility with existing pipelines.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Other

## Testing
- [x] I have added tests that prove my changes work
- [x] All existing tests pass


