### PR TITLE
feat(ExecutionContext) added cleanest way to get and set ambient data

### DIFF
--- a/src/Ergosfare.Context/IExecutionContext.cs
+++ b/src/Ergosfare.Context/IExecutionContext.cs
@@ -13,6 +13,44 @@
 /// </remarks>
 public interface IExecutionContext
 {
+
+    /// <summary>
+    /// Stores an item in the execution context associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key used to identify the item.</param>
+    /// <param name="item">The object to store in the context.</param>
+    void Set(string key, object item);
+    
+    
+    /// <summary>
+    /// Determines whether an item with the specified key exists in the execution context.
+    /// </summary>
+    /// <param name="key">The key to check for existence.</param>
+    /// <returns><c>true</c> if an item with the key exists; otherwise, <c>false</c>.</returns>
+    bool Has(string key);
+    
+    
+    /// <summary>
+    /// Tries to retrieve an item of type <typeparamref name="TType"/> from the execution context.
+    /// </summary>
+    /// <typeparam name="TType">The expected type of the item.</typeparam>
+    /// <param name="key">The key associated with the item.</param>
+    /// <param name="item">When this method returns, contains the retrieved item if found; otherwise, the default value of <typeparamref name="TType"/>.</param>
+    /// <returns><c>true</c> if the item was found and is of type <typeparamref name="TType"/>; otherwise, <c>false</c>.</returns>
+    bool TryGet<TType>(string key, out TType item);
+    
+    
+    /// <summary>
+    /// Retrieves an item of type <typeparamref name="TType"/> from the execution context.
+    /// </summary>
+    /// <typeparam name="TType">The expected type of the item.</typeparam>
+    /// <param name="key">The key associated with the item.</param>
+    /// <returns>The item associated with the specified key.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if no item exists with the specified key.</exception>
+    /// <exception cref="InvalidCastException">Thrown if the item is not of type <typeparamref name="TType"/>.</exception>
+    TType Get<TType>(string key) where TType : notnull;
+    
+    
     /// <summary>
     ///     Gets the cancellation token associated with the execution context.
     /// </summary>
@@ -21,6 +59,7 @@ public interface IExecutionContext
     ///     Handlers should periodically check this token and abort their execution if cancellation is requested.
     /// </remarks>
     CancellationToken CancellationToken { get; }
+    
 
     /// <summary>
     ///     Gets a key/value collection that can be used to share data within the scope of this execution.
@@ -31,8 +70,8 @@ public interface IExecutionContext
     ///     different mediation operations.
     /// </remarks>
     IDictionary<object, object?> Items { get; }
-
-
+    
+    
     /// <summary>
     ///     The result of the message mediation.
     /// </summary>
@@ -42,7 +81,8 @@ public interface IExecutionContext
     ///     in certain scenarios, such as when aborting the execution.
     /// </remarks>
     object? MessageResult { get; set; }
-
+    
+    
     /// <summary>
     ///     Aborts the execution of the current mediation execution.
     /// </summary>
@@ -57,4 +97,7 @@ public interface IExecutionContext
     ///     a message result must be provided to satisfy the result type requirement.
     /// </remarks>
     void Abort(object? messageResult = null);
+    
+    
+    
 }

--- a/src/Ergosfare.Core/Internal/Contexts/ExecutionContext.cs
+++ b/src/Ergosfare.Core/Internal/Contexts/ExecutionContext.cs
@@ -10,10 +10,89 @@ internal sealed class ErgosfareExecutionContext( IDictionary<object, object?> it
     : IExecutionContext
 {
 
+    /// <summary>
+    /// Gets the <see cref="CancellationToken"/> associated with the current execution context.
+    /// This token can be used to observe cancellation requests and propagate them to handlers or interceptors.
+    /// </summary>
     public CancellationToken CancellationToken { get; } = cancellationToken;
+    
+    
+    /// <summary>
+    /// Gets a dictionary of arbitrary key-value pairs stored in the execution context.
+    /// This can be used to share data between different handlers, interceptors, or other pipeline components.
+    /// </summary>
     public IDictionary<object, object?> Items { get; } = items;
+    
+    
+    /// <summary>
+    /// Gets or sets the result produced by the message or query being processed in this execution context.
+    /// For events, this may be <c>null</c>, while for commands or queries it may hold the returned value.
+    /// </summary>
     public object? MessageResult { get; set; }
 
+    
+    /// <summary>
+    /// Stores an item in the execution context under the specified key.
+    /// If an item with the same key already exists, it will be overwritten.
+    /// </summary>
+    /// <param name="key">The unique key to associate with the item.</param>
+    /// <param name="item">The object to store in the context.</param>
+    public void Set(string key, object item)
+    {
+        Items[key] = item;
+    }
+
+    
+    /// <summary>
+    /// Checks whether an item with the specified key exists in the context.
+    /// </summary>
+    /// <param name="key">The key to check for existence.</param>
+    /// <returns><c>true</c> if an item with the given key exists; otherwise, <c>false</c>.</returns>
+    public bool Has(string key)
+    {
+        return Items.ContainsKey(key);
+    }
+
+    
+    /// <summary>
+    /// Attempts to retrieve an item of the specified type from the context using the given key.
+    /// </summary>
+    /// <typeparam name="TType">The type of the item expected.</typeparam>
+    /// <param name="key">The key associated with the item.</param>
+    /// <param name="item">
+    /// When this method returns, contains the retrieved item if found and of the correct type; otherwise, the default value for <typeparamref name="TType"/>.
+    /// </param>
+    /// <returns><c>true</c> if an item with the given key exists and is of the correct type; otherwise, <c>false</c>.</returns>
+    public TType Get<TType>(string key) where TType : notnull
+    {
+        if (!Items.TryGetValue(key, out var ıtem)) 
+            throw new InvalidOperationException("Item does not exist");
+        return (TType)ıtem!;
+    }
+
+
+    /// <summary>
+    /// Retrieves an item of the specified type from the context using the given key.
+    /// </summary>
+    /// <typeparam name="TType">The type of the item to retrieve.</typeparam>
+    /// <param name="key">The key associated with the item.</param>
+    /// <param name="item">the item to retrieve</param>
+    /// <returns>The item associated with the specified key.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown if no item exists with the specified key.</exception>
+    /// <exception cref="InvalidCastException">Thrown if the stored item cannot be cast to <typeparamref name="TType"/>.</exception>
+    public bool TryGet<TType>(string key, out TType item)
+    {
+        if (Items.TryGetValue(key, out var el))
+        {
+            item = (TType)el!;
+            return true;
+        }
+        
+        item = default!;
+        return false;
+    }
+
+    
     /// <summary>
     /// Sets <see cref="MessageResult"/> and throws <exception cref="ExecutionAbortedException"></exception>
     /// </summary>
@@ -24,4 +103,6 @@ internal sealed class ErgosfareExecutionContext( IDictionary<object, object?> it
         throw new ExecutionAbortedException();
         
     }
+    
+    
 }


### PR DESCRIPTION

## Description
IExecutionContext now includes 

- `Set(string key, object item)`
Sets an ambient data to share with pipeline
- `T Get<T>(string key)` 
Gets the ambient data
- `bool Has(string key)`
Checks if ambient data exist
- `bool TryGet<T>(string key, out T item)`
Gets ambient data, its return bool if weather item exist or not

