### PR TITLE
ci: prepare release workflows for the preview line

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'preview'
     paths-ignore:
       - '.badges/chore_workflows/coverage.svg'
   pull_request:

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -16,31 +16,27 @@ on:
 
 jobs:
   release:
+    # Single job with both SDKs: the per-SDK matrix ran every step twice, and the
+    # duplicated release steps raced each other uploading the same assets — the
+    # cause of the v1.4.0 failure.
     runs-on: ubuntu-latest
     environment: publish
-    strategy:
-      matrix:
-        dotnet-version: [ 9.0.x, 10.0.x ]   # .NET 9 ve 10
     permissions:
       contents: write
       packages: write
       id-token: write
     steps:
-      - name: Resolve branch
-        run: |
-          if [ -n "${{ github.event.inputs.branch }}" ]; then
-            echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
-          else
-            echo "branch=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          fi
-      
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ env.branch }}
+          # Tag pushes check out the tag; manual dispatches check out the given branch.
+          ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            9.0.x
+            10.0.x
 
       - name: Set version
         run: |
@@ -56,13 +52,20 @@ jobs:
 
       - name: Validate release type
         run: |
-          if [[ "${{ env.branch }}" == "main" ]] && [[ "$VERSION" == *-* ]]; then
-            echo "❌ RC tag from main branch is not allowed" && exit 1
+          git fetch origin main --quiet
+          git fetch origin preview --quiet || true
+          if [[ "$VERSION" == *-* ]]; then
+            # Pre-release (-preview.N / -rc.N) tags must come from the preview line.
+            if git rev-parse --verify --quiet origin/preview > /dev/null; then
+              git merge-base --is-ancestor HEAD origin/preview \
+                || { echo "❌ Pre-release tags must point at commits on the preview branch"; exit 1; }
+            fi
+            echo "✔ Pre-release tag validated"
+          else
+            git merge-base --is-ancestor HEAD origin/main \
+              || { echo "❌ Stable tags must point at commits on main"; exit 1; }
+            echo "✔ Stable tag validated"
           fi
-          if [[ "${{ env.branch }}" =~ rc[0-9]+ ]] && [[ "$VERSION" != *-* ]]; then
-            echo "❌ Stable tag from RC branch is not allowed" && exit 1
-          fi
-          echo "✔ GitHub release validation passed"
 
       - name: Restore & Build
         run: |
@@ -93,7 +96,7 @@ jobs:
             dotnet pack "$proj" -c Release -o ./nupkg-github /p:Version=${{ env.VERSION }} /p:IncludeSymbols=true /p:IncludeSource=true --no-build
           done
 
-      - name: Pack fixtures (GitHub only)
+      - name: Pack test fixtures (GitHub only)
         run: |
           dotnet pack ./test/Stella.Ergosfare.Test.Fixtures/Stella.Ergosfare.Test.Fixtures.csproj \
             -c Release -o ./nupkg-github /p:Version=${{ env.VERSION }} \
@@ -109,23 +112,10 @@ jobs:
           done
 
       - name: Create GitHub Release (with pkg attachments)
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: ./nupkg-github/*.nupkg
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pack test fixtures (GitHub only)
-        run: |
-          dotnet pack ./test/Stella.Ergosfare.Test.Fixtures/Stella.Ergosfare.Test.Fixtures.csproj \
-            -c Release -o ./nupkg-github /p:Version=${{ env.VERSION }} \
-            /p:IncludeSymbols=true /p:IncludeSource=true --no-build
-
-      - name: Create GitHub Release with fixtures
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: ./nupkg-github/*.nupkg
+          prerelease: ${{ contains(env.VERSION, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -55,7 +55,7 @@ jobs:
           git fetch origin main --quiet
           git fetch origin preview --quiet || true
           if [[ "$VERSION" == *-* ]]; then
-            # Pre-release (-preview.N / -rc.N) tags must come from the preview line.
+            # Pre-release (-preview.N) tags must come from the preview line.
             if git rev-parse --verify --quiet origin/preview > /dev/null; then
               git merge-base --is-ancestor HEAD origin/preview \
                 || { echo "❌ Pre-release tags must point at commits on the preview branch"; exit 1; }

--- a/.github/workflows/nuget_release.yml
+++ b/.github/workflows/nuget_release.yml
@@ -18,31 +18,25 @@ on:
 
 jobs:
   release:
+    # Single job with both SDKs: the solution multi-targets net9.0/net10.0, and a
+    # per-SDK matrix packed and pushed every package twice.
     runs-on: ubuntu-latest
     environment: publish
     permissions:
       contents: read
       id-token: write
-    strategy:
-      matrix:
-        dotnet-version: [9.0.x, 10.0.x]
     steps:
-      - name: Determine branch
-        id: resolve_branch
-        run: |
-          if [ -n "${{ github.event.inputs.branch }}" ]; then
-            echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
-          else
-            echo "branch=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          fi
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ env.branch }}
+          # Tag pushes check out the tag; manual dispatches check out the given branch.
+          ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            9.0.x
+            10.0.x
 
       - name: Set version
         run: |
@@ -58,13 +52,20 @@ jobs:
 
       - name: Validate release type
         run: |
-          if [[ "${{ env.branch }}" == "main" ]] && [[ "$VERSION" == *-* ]]; then
-            echo "❌ RC tag from main branch is not allowed" && exit 1
+          git fetch origin main --quiet
+          git fetch origin preview --quiet || true
+          if [[ "$VERSION" == *-* ]]; then
+            # Pre-release (-preview.N / -rc.N) tags must come from the preview line.
+            if git rev-parse --verify --quiet origin/preview > /dev/null; then
+              git merge-base --is-ancestor HEAD origin/preview \
+                || { echo "❌ Pre-release tags must point at commits on the preview branch"; exit 1; }
+            fi
+            echo "✔ Pre-release tag validated"
+          else
+            git merge-base --is-ancestor HEAD origin/main \
+              || { echo "❌ Stable tags must point at commits on main"; exit 1; }
+            echo "✔ Stable tag validated"
           fi
-          if [[ "${{ env.branch }}" =~ rc[0-9]+ ]] && [[ "$VERSION" != *-* ]]; then
-            echo "❌ Stable tag from RC branch is not allowed" && exit 1
-          fi
-          echo "✔ Release validation passed"
 
       - name: Restore
         run: dotnet restore ./Stella.Ergosfare.slnx
@@ -102,8 +103,9 @@ jobs:
         with:
           user: ${{ secrets.NUGET_USER }}
 
-      - name: Push packages to NuGet (only stable)
-        if: ${{ !contains(env.VERSION, '-') }}
+      # Pre-release versions are pushed too: nuget.org only surfaces them to users
+      # who opt into "include prerelease", so the stable channel stays clean.
+      - name: Push packages to NuGet
         run: |
           for pkg in ./nupkg-release/*.nupkg; do
             dotnet nuget push "$pkg" \
@@ -111,5 +113,3 @@ jobs:
               --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
               --skip-duplicate
           done
-
-   

--- a/.github/workflows/nuget_release.yml
+++ b/.github/workflows/nuget_release.yml
@@ -55,7 +55,7 @@ jobs:
           git fetch origin main --quiet
           git fetch origin preview --quiet || true
           if [[ "$VERSION" == *-* ]]; then
-            # Pre-release (-preview.N / -rc.N) tags must come from the preview line.
+            # Pre-release (-preview.N) tags must come from the preview line.
             if git rev-parse --verify --quiet origin/preview > /dev/null; then
               git merge-base --is-ancestor HEAD origin/preview \
                 || { echo "❌ Pre-release tags must point at commits on the preview branch"; exit 1; }


### PR DESCRIPTION
## Description

Groundwork for the v2 `preview` release line (per the two-track plan: v2 development on `preview` with obsolete APIs removed, stable fixes on `main`, regular `main -> preview` merges).

**Release workflow consolidation (also fixes the v1.4.0 failure):**
- Both release workflows ran a dotnet 9/10 **matrix**, packing and pushing every package twice. `github_release.yml` additionally contained **duplicated fixture-pack and release steps**, so four steps raced uploading the same assets to one GitHub release — the `v1.4.0` GitHubPackagesRelease run failed exactly there. Both workflows are now a single job with both SDKs installed.
- `softprops/action-gh-release` bumped to v2; checkout/setup-dotnet to v4.

**Preview line support:**
- **Validation by commit ancestry** instead of the previous ref-name heuristic (which compared against the *tag name* on tag pushes): stable tags must point at commits on `main`; pre-release tags (`v2.0.0-preview.N` / `-rc.N`) must point at commits on `preview` (tolerated until the branch exists).
- **Pre-release packages are now pushed to nuget.org too** — nuget.org surfaces them only to users who opt into "include prerelease", so the stable channel stays clean. GitHub releases are marked `prerelease` automatically when the version carries a suffix.
- Coverage workflow also runs on `preview` pushes; the badge remains main-only.

After merge, the `preview` branch will be created from `main`; its first change removes the obsolete APIs (`AmbientExecutionContext`, three-parameter interceptors) for a clean v2 codebase.

## Type of Change
- [x] Bug fix (duplicate release-asset race)
- [ ] New feature
- [ ] Documentation update
- [x] Other (release engineering for the preview line)

## Related Issue
None.

## Testing
- [ ] I have added tests that prove my changes work (workflow-only change; validated against the v1.4.0 failure logs)
- [x] All existing tests pass (no code changes)

## Checklist
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
