### PR TITLE
ci: fix coverage badge crash under Node 24

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -68,8 +68,16 @@ jobs:
         with:
           branch-name: badges
 
+      # 0.5.0 is the node24-native build; 0.3.1's node20 bundle crashed once GitHub
+      # started forcing Node 24. The file-name/badge-branch/github-token inputs are
+      # consumed by the action even though its action.yml does not declare them — the
+      # runner's "unexpected input" warning is cosmetic, but omitting github-token
+      # makes the badge upload crash.
       - name: Generate coverage badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: action-badges/cobertura-coverage-xml-badges@0.3.1
+        uses: action-badges/cobertura-coverage-xml-badges@0.5.0
         with:
           coverage-file-name: ./.coverage/Cobertura.xml
+          file-name: coverage.svg
+          badge-branch: badges
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Fixes the coverage badge step crashing on main pushes (run 29942795013).

Two compounding causes:

1. **Node 24 forcing:** `action-badges/cobertura-coverage-xml-badges@0.3.1` ships a Node 20 bundle; GitHub now runs node20 actions on Node 24 by default (Sept 2025 deprecation). The upstream project released **0.5.0 (July 2026)** as the node24-native build — bumped.
2. **Undeclared-but-consumed inputs:** the action's `action.yml` declares only `coverage-file-name`, but its README-documented usage also passes `file-name`, `badge-branch` and `github-token`, which the action reads at runtime (the runner's "Unexpected input(s)" warning is cosmetic — inputs are still forwarded). PR #78 removed them trusting the declared schema; without `github-token` the badge upload crashes with an unhandled exception. Restored all three with an explanatory comment.

The badge step remains gated to pushes on `main`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Related Issue
None (follow-up to #78).

## Testing
- [ ] I have added tests that prove my changes work (workflow-only; will be validated by the badge step on the merge push to main)
- [x] All existing tests pass (no code changes)

## Checklist
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
