### PR TITLE
ci: pin dispatch-created release tags to the built commit

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -46,8 +46,11 @@ jobs:
             TAG_NAME=${GITHUB_REF#refs/tags/}
           fi
 
+          [[ "$TAG_NAME" == v* ]] || { echo "❌ Tag must start with v"; exit 1; }
+
           VERSION=${TAG_NAME#v}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "RELEASE_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
           echo "Using version: $VERSION"
 
       - name: Validate release type
@@ -115,6 +118,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          # Manual dispatches may create the tag at release time; without this it
+          # would be created on the default branch instead of the built commit.
+          target_commitish: ${{ env.RELEASE_SHA }}
           files: ./nupkg-github/*.nupkg
           prerelease: ${{ contains(env.VERSION, '-') }}
         env:

--- a/.github/workflows/nuget_release.yml
+++ b/.github/workflows/nuget_release.yml
@@ -46,6 +46,8 @@ jobs:
             TAG_NAME="${GITHUB_REF#refs/tags/}"
           fi
 
+          [[ "$TAG_NAME" == v* ]] || { echo "❌ Tag must start with v"; exit 1; }
+
           VERSION="${TAG_NAME#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Resolved version: $VERSION"


### PR DESCRIPTION
Manual dispatches create the release tag at release time, and without `target_commitish` the API points it at the default branch HEAD even when the build checked out the preview branch — a `v2.0.0-preview.N` dispatch would have stamped its tag onto **main**.

- Pass the checked-out SHA as `target_commitish` (ignored on tag pushes where the tag already exists)
- Fail fast in both release workflows when the dispatch tag input is missing the `v` prefix

Follow-up to #78; carries only the two workflow files so it lands on main independently of the v2 preview work. The same change reaches `preview` through the v2 branch — no back-merge from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)