### PR TITLE
refactor!: per-message-type executor dispatch — remove the object bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased — v2 preview line
 
+### Executor dispatch — the object bridge is gone
+
+* **Per-message-type pipeline executors.** Dispatch now goes through a pipeline closed over the message's *runtime* type, built once per (message type, result type, group set) and cached process-wide (`IPipelineExecutor`, `IMessageMediator.DispatchAsync`). The mediator facades resolve the executor with a dictionary lookup — no per-call options object, no interface-erased strategy, and the handler's `ValueTask` never crosses an object-typed bridge. Events and streaming queries use the same pattern via per-type invokers that carry their per-call state (settings / cancellation token).
+* **Independent sync/async handler contracts.** `IHandler` is now an empty marker; `IHandler<TMessage, TResult>` is a pure synchronous contract returning `TResult` directly; `IAsyncHandler<TMessage>` / `IAsyncHandler<TMessage, TResult>` are standalone `ValueTask` contracts. All default interface implementations and the object-typed `Handle(object, ...)` root member are removed — the pipeline invokes handlers exclusively through their typed members, and synchronous handlers run with zero async machinery.
+* Interface-erased dispatch (e.g. `Mediate` with `TMessage = ICommand<T>` against concrete-typed handlers) is no longer supported and throws `NotSupportedException` with guidance; all first-party facades dispatch concretely.
+* Benchmark (100k no-op dispatches, 7800X3D/.NET 9): public `SendAsync` **11.4 → 5.34 MB** — byte-identical to the raw mediator path (handler-side allocation is now zero; the remainder is the per-dispatch execution context and transient handler instance); scope-per-dispatch **47.3 → 41.96 MB** after the facades stopped resolving per-scope strategy state. MediatR on the same shapes: 18.31 MB / 33.57 MB.
+* The reflective executor construction (one `MakeGenericType` per message type) is the JIT fallback the source generator will replace with concrete instantiations — completing the Native AOT story.
+
 ### Removed
 
 * `AmbientExecutionContext` and `EnableAmbientExecutionContext()` (deprecated since v1.2.0) are removed. The execution context is passed to every handler and interceptor as a parameter; `IExecutionContext` can no longer be resolved from DI. `NoExecutionContextException` is removed with it, and no `AsyncLocal` publication remains anywhere on the dispatch path.

--- a/readme.md
+++ b/readme.md
@@ -78,22 +78,21 @@ dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking
 ```
 
 Environment: BenchmarkDotNet v0.15.8 · Windows 11 · AMD Ryzen 7 7800X3D · .NET 9.0.11
-(RyuJIT x86-64-v4). Measured on the `preview` branch (ValueTask-first surface), 2026-07-23.
+(RyuJIT x86-64-v4). Measured on the `preview` branch (executor dispatch), 2026-07-23.
 
 | Scenario (100k dispatches/op) | Mean | Allocated |
 |---|---:|---:|
-| `StellaErgosfare` — raw `IMessageMediator` loop | 6.47 ms | 5.34 MB |
-| `StellaErgosfare_PublicApi` — `ICommandMediator.SendAsync` | 7.89 ms | 14.5 MB |
-| `MediatR` — `IMediator.Send` | 6.03 ms | 18.31 MB |
-| `LiteBus_PublicApi` — `ICommandMediator.SendAsync` | 146.91 ms | 714.87 MB |
-| `StellaErgosfare_PublicApi_ScopePerDispatch` — fresh scope each dispatch | 19.25 ms | 55.69 MB |
-| `MediatR_ScopePerDispatch` — fresh scope each dispatch | 10.45 ms | 33.57 MB |
+| `StellaErgosfare` — raw `IMessageMediator` loop | 6.33 ms | 5.34 MB |
+| `StellaErgosfare_PublicApi` — `ICommandMediator.SendAsync` | 7.19 ms | 5.34 MB |
+| `MediatR` — `IMediator.Send` | 6.24 ms | 18.31 MB |
+| `LiteBus_PublicApi` — `ICommandMediator.SendAsync` | 148.89 ms | 714.87 MB |
+| `StellaErgosfare_PublicApi_ScopePerDispatch` — fresh scope each dispatch | 18.42 ms | 41.96 MB |
+| `MediatR_ScopePerDispatch` — fresh scope each dispatch | 11.26 ms | 33.57 MB |
 
-The facade rows currently pay one boxed `ValueTask` per dispatch (~32 B): the mediator
-facades dispatch through the contract interfaces, so the handler's `ValueTask` crosses the
-object-typed bridge once. Concrete-typed dispatch (the raw row today, source-generated
-dispatch tomorrow) skips the bridge entirely — there, synchronously completing handlers
-allocate nothing, which a `Task`-based surface cannot do.
+All rows dispatch through pipelines closed over the message's concrete type (cached
+executors) — there is no object-typed bridge anywhere on the dispatch path, and the
+public facade allocates exactly what the raw mediator does. Synchronously completing
+handlers allocate nothing on the handler side, which a `Task`-based surface cannot do.
 
 Scenario notes:
 

--- a/src/Stella.Ergosfare.Commands/CommandMediator.cs
+++ b/src/Stella.Ergosfare.Commands/CommandMediator.cs
@@ -1,85 +1,44 @@
-using System.Collections.Concurrent;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.Strategies;
 
 namespace Stella.Ergosfare.Commands;
 
 /// <summary>
-/// Mediates command messages through the configured pipeline, including signal dispatching,
-/// mediation strategies, and optional result adaptation.
+/// Mediates command messages through the pipeline executor closed over the command's
+/// runtime type: handlers are always invoked through their typed members, and the dispatch
+/// path carries no object-typed bridge, options object, or erased strategy.
 /// </summary>
-public class CommandMediator(
-    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
-    IResultAdapterService? resultAdapterService,
-    IMessageMediator messageMediator) : ICommandMediator
+public class CommandMediator(IMessageMediator messageMediator) : ICommandMediator
 {
-    private static readonly string[] EmptyGroups = [];
-
     /// <summary>
-    /// Mediation strategy for non-generic commands; stateless, so shared across calls.
-    /// </summary>
-    private readonly SingleAsyncHandlerMediationStrategy<ICommand> _mediationStrategy = new(resultAdapterService);
-
-    /// <summary>
-    /// Mediation strategies for typed commands, one per result type; stateless, so shared
-    /// across calls. Created lazily so mediators in short-lived scopes that never send
-    /// typed commands pay nothing.
-    /// </summary>
-    private ConcurrentDictionary<Type, object>? _typedMediationStrategies;
-
-    /// <summary>
-    /// Mediates command messages through the configured pipeline, including signal dispatching,
-    /// mediation strategies, and optional result adaptation.
+    /// Sends a void command through the executor pipeline.
     /// </summary>
     public ValueTask SendAsync(ICommand commandConstruct, CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-
-        var options = new MediateOptions<ICommand, ValueTask>
-        {
-            MessageMediationStrategy = _mediationStrategy,
-            MessageResolveStrategy = messageResolveStrategy,
-            CancellationToken = cancellationToken,
-            Items = commandMediationSettings?.Items,
-            Groups = commandMediationSettings?.Filters.Groups ?? EmptyGroups
-        };
-        var result =  messageMediator.Mediate(commandConstruct, options);
-        return result;
+        return messageMediator.DispatchAsync(
+            commandConstruct,
+            commandMediationSettings?.Items,
+            cancellationToken,
+            commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
-    /// Sends a typed command asynchronously and returns a strongly typed result.
+    /// Sends a typed command through the executor pipeline and returns its result.
     /// </summary>
     /// <typeparam name="TResult">The expected result type of the command.</typeparam>
     /// <param name="commandConstruct">The command to send.</param>
     /// <param name="commandMediationSettings">Optional settings for command mediation, such as filtering or additional items.</param>
     /// <param name="cancellationToken">Cancellation token for aborting the operation.</param>
     /// <returns>A <see cref="ValueTask{TResult}"/> representing the asynchronous operation and containing the command result.</returns>
-
     public ValueTask<TResult> SendAsync<TResult>(ICommand<TResult> commandConstruct,
         CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        var typedMediationStrategies = LazyInitializer.EnsureInitialized(ref _typedMediationStrategies);
-
-        if (!typedMediationStrategies.TryGetValue(typeof(TResult), out var mediationStrategy))
-        {
-            mediationStrategy = typedMediationStrategies.GetOrAdd(typeof(TResult),
-                new SingleAsyncHandlerMediationStrategy<ICommand<TResult>, TResult>(resultAdapterService));
-        }
-
-        var options = new MediateOptions<ICommand<TResult>, ValueTask<TResult>>
-        {
-            MessageResolveStrategy = messageResolveStrategy,
-            MessageMediationStrategy = (SingleAsyncHandlerMediationStrategy<ICommand<TResult>, TResult>)mediationStrategy,
-            CancellationToken = cancellationToken,
-            Items = commandMediationSettings?.Items,
-            Groups = commandMediationSettings?.Filters.Groups ?? EmptyGroups
-        };
-
-        return messageMediator.Mediate(commandConstruct, options);
+        return messageMediator.DispatchAsync<TResult>(
+            commandConstruct,
+            commandMediationSettings?.Items,
+            cancellationToken,
+            commandMediationSettings?.Filters.Groups);
     }
-
-
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage,TResult].cs
@@ -19,30 +19,9 @@ namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 ///     implementations that already hold a <see cref="Task{TResult}"/> can wrap it
 ///     allocation-free via <c>new ValueTask&lt;TResult&gt;(task)</c>.
 /// </remarks>
-public interface IAsyncHandler<in TMessage,  TResult>: IHandler<TMessage, ValueTask<TResult>>
+public interface IAsyncHandler<in TMessage,  TResult>: IHandler
     where TMessage : notnull
 {
-
-
-    /// <summary>
-    ///     Implements the Handle method from the inherited interface by forwarding to the
-    ///     strongly-typed <see cref="HandleAsync"/> member.
-    /// </summary>
-    /// <param name="message">The message to be handled.</param>
-    /// <param name="context">Current execution context</param>
-    /// <returns>
-    ///     A task representing the asynchronous handling operation, which upon completion yields the result of the
-    ///     handling process.
-    /// </returns>
-    /// <remarks>
-    ///     This method bridges the generic handling member with the asynchronous handling method by internally invoking
-    ///     HandleAsync, enabling a unified approach to message handling.
-    /// </remarks>
-    ValueTask<TResult> IHandler<TMessage, ValueTask<TResult>>.Handle(TMessage message, IExecutionContext context)
-    {
-        return HandleAsync(message, context);
-    }
-
 
     /// <summary>
     ///     Defines a method to handle messages asynchronously and produce a result.

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage].cs
@@ -15,15 +15,9 @@ namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 /// The explicit interface implementation maps the generic <see cref="IHandler{TMessage, TResult}.Handle"/> method
 /// to the strongly-typed <see cref="HandleAsync"/> method.
 /// </remarks>
-public interface IAsyncHandler<in TMessage>: IHandler<TMessage, ValueTask>
+public interface IAsyncHandler<in TMessage>: IHandler
     where TMessage : notnull
 {
-    /// <inheritdoc cref="IHandler{TMessage, TResult}.Handle"/>
-    ValueTask IHandler<TMessage, ValueTask>.Handle(TMessage message, IExecutionContext context)
-    {
-        return HandleAsync(message, context);
-    }
-
     /// <summary>
     /// Handles a message of type <typeparamref name="TMessage"/> asynchronously.
     /// </summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IHandler.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IHandler.cs
@@ -1,22 +1,12 @@
-﻿namespace Stella.Ergosfare.Core.Abstractions.Handlers;
+namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 
 
 /// <summary>
-///     Represents the non-generic base interface for all message handlers, facilitating handling operations for messages
-///     of any type.
+///     Marker interface identifying message handlers for registration and storage. The
+///     pipeline never invokes handlers through this interface — dispatch goes through the
+///     typed members of <see cref="IHandler{TMessage, TResult}"/> (synchronous) or
+///     <c>IAsyncHandler</c> (asynchronous); the object-typed bridge member was removed with
+///     the v2 executor dispatch.
 /// </summary>
-public interface IHandler
-{
-    /// <summary>
-    ///     Handles the incoming message and facilitates the necessary operations or transformations as defined by the specific
-    ///     handler implementation.
-    /// </summary>
-    /// <param name="message">The message to be handled, represented as an object which can be of any type.</param>
-    /// <param name="context">Current execution context</param>
-    /// <returns>
-    ///     An object representing the outcome of the handling operation, which might include results of processing,
-    ///     transformed message, or other related data depending on the specific handler's implementation.
-    /// </returns>
-    object Handle(object message, IExecutionContext context);
-}
+public interface IHandler;

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IHandler[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IHandler[TMessage,TResult].cs
@@ -8,22 +8,15 @@
 /// <typeparam name="TMessage">The type of the message to handle. Must be non-nullable.</typeparam>
 /// <typeparam name="TResult">The type of the result produced by the handler. Must be non-nullable.</typeparam>
 /// <remarks>
-/// Implementations of this interface should provide the synchronous handling logic for a message and return
-/// a strongly typed result. The non-generic <see cref="IHandler"/> interface is implemented explicitly to allow
-/// type-agnostic invocation, mapping the <paramref name="message"/> to <typeparamref name="TMessage"/> and returning
-/// the typed <typeparamref name="TResult"/> as <see cref="object"/>.
+/// Implementations of this interface provide synchronous handling logic and return the
+/// typed result directly — there is no object-typed bridge member; the pipeline invokes
+/// handlers exclusively through their typed members.
 /// </remarks>
 public interface IHandler<in TMessage, out TResult> : IHandler
     where TMessage : notnull
     where TResult : notnull
 {
-    
-    /// <inheritdoc cref="IHandler.Handle"/>
-    object IHandler.Handle(object message, IExecutionContext context)
-    {
-        return Handle((TMessage) message, context);
-    }
-    
+
     /// <summary>
     /// Handles a message of type <typeparamref name="TMessage"/> and returns a strongly-typed result.
     /// </summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/IMessageMediator.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IMessageMediator.cs
@@ -1,4 +1,8 @@
-﻿namespace Stella.Ergosfare.Core.Abstractions;
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stella.Ergosfare.Core.Abstractions;
 
 
 /// <summary>
@@ -7,6 +11,27 @@
 /// </summary>
 public interface IMessageMediator
 {
+    /// <summary>
+    /// Dispatches <paramref name="message"/> through the cached pipeline executor closed over
+    /// its runtime type. The handler is invoked through its typed member — no object-typed
+    /// bridge. Serves default-group dispatches; group-filtered dispatches go through
+    /// <see cref="Mediate{TMessage, TMessageResult}"/>.
+    /// </summary>
+    /// <param name="message">The message instance to dispatch.</param>
+    /// <param name="items">Optional items exposed on the execution context.</param>
+    /// <param name="cancellationToken">Cancellation token exposed on the execution context.</param>
+    ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null);
+
+    /// <summary>
+    /// Dispatches <paramref name="message"/> through the cached result-producing pipeline
+    /// executor closed over its runtime type; see <see cref="DispatchAsync"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The result type produced by the pipeline.</typeparam>
+    /// <param name="message">The message instance to dispatch.</param>
+    /// <param name="items">Optional items exposed on the execution context.</param>
+    /// <param name="cancellationToken">Cancellation token exposed on the execution context.</param>
+    ValueTask<TResult> DispatchAsync<TResult>(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null);
+
     
     /// <summary>
     /// Dispatches a message of type <typeparamref name="TMessage"/> to the appropriate handler(s)

--- a/src/Stella.Ergosfare.Core.Abstractions/IPipelineExecutor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IPipelineExecutor.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Stella.Ergosfare.Core.Abstractions;
+
+/// <summary>
+/// A message pipeline closed over its concrete message type, built once per message type
+/// and cached process-wide. <see cref="Execute{TResult}"/> receives the message as
+/// <see cref="object"/> and performs a single cast to the concrete type internally, so the
+/// handler is always invoked through its typed member — no object-typed bridge, no boxing
+/// of the handler's <see cref="ValueTask"/>.
+/// </summary>
+/// <remarks>
+/// This is the dispatch seam source-generated code will eventually implement directly;
+/// the runtime builds executors reflectively (one generic instantiation per message type)
+/// as the fallback.
+/// </remarks>
+public interface IPipelineExecutor
+{
+    /// <summary>
+    /// Executes the void pipeline for <paramref name="message"/>.
+    /// </summary>
+    /// <param name="message">The message instance; its runtime type is the executor's closed message type (or derived).</param>
+    /// <param name="context">The execution context for this dispatch.</param>
+    /// <param name="serviceProvider">The provider of the scope the dispatch runs in.</param>
+    ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider);
+}
+
+/// <summary>
+/// A result-producing message pipeline closed over its concrete message type; see
+/// <see cref="IPipelineExecutor"/>.
+/// </summary>
+/// <typeparam name="TResult">The result type produced by the pipeline.</typeparam>
+public interface IPipelineExecutor<TResult>
+{
+    /// <inheritdoc cref="IPipelineExecutor.Execute"/>
+    ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider);
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -84,9 +84,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
             // dispatches (TMessage = ICommand<T> etc.) fall back to the bridge.
             var fastHandler = messageDependencies.Handlers[0].Resolve(serviceProvider);
 
-            var fastResult = fastHandler is IHandler<TMessage, ValueTask<TResult>> fastTyped
-                ? await fastTyped.Handle(message, context)
-                : await (ValueTask<TResult>)fastHandler.Handle(message, context);
+            var fastResult = await InvokeHandler(fastHandler, message, context);
 
             var fastEx = resultAdapterService?.LookupException(fastResult);
             if (fastEx is not null) throw fastEx;
@@ -106,9 +104,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
 
             var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
 
-            result = handler is IHandler<TMessage, ValueTask<TResult>> typed
-                ? await typed.Handle(message, context)
-                : await (ValueTask<TResult>)handler.Handle(message, context);
+            result = await InvokeHandler(handler, message, context);
 
             var ex = resultAdapterService?.LookupException(result);
             if (ex is not null) throw ex;
@@ -156,4 +152,24 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
 
         return result;
     }
+
+    /// <summary>
+    /// Invokes the handler through its typed contract. There is no object-typed bridge:
+    /// asynchronous handlers are called via <c>IAsyncHandler</c>, synchronous handlers via
+    /// <see cref="IHandler{TMessage, TResult}"/> (`in TMessage` variance admits handlers
+    /// registered for base message types). Interface-erased dispatch is unsupported —
+    /// dispatch with the concrete message type (the executor path) instead.
+    /// </summary>
+#pragma warning disable CS8714 // TResult is used as a pattern type argument; handlers declare notnull results
+    private static ValueTask<TResult> InvokeHandler(object handler, TMessage message, IExecutionContext context)
+        => handler switch
+        {
+            IAsyncHandler<TMessage, TResult> asyncHandler => asyncHandler.HandleAsync(message, context),
+            IHandler<TMessage, ValueTask<TResult>> valueTaskShaped => valueTaskShaped.Handle(message, context),
+            IHandler<TMessage, TResult> syncHandler => ValueTask.FromResult(syncHandler.Handle(message, context)),
+            _ => throw new NotSupportedException(
+                $"'{handler.GetType()}' does not implement a supported handler contract for message '{typeof(TMessage)}' and result '{typeof(TResult)}'. " +
+                "Interface-erased dispatch is not supported; dispatch with the concrete message type."),
+        };
+#pragma warning restore CS8714
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -79,10 +79,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
             // for a ValueTask slot). Interface-erased dispatches fall back to the DIM bridge.
             var fastHandler = messageDependencies.Handlers[0].Resolve(serviceProvider);
 
-            var fastResult = fastHandler is IHandler<TMessage, ValueTask> fastTyped
-                ? fastTyped.Handle(message, context)
-                : (ValueTask)fastHandler.Handle(message, context);
-            await fastResult;
+            await InvokeHandler(fastHandler, message, context);
 
             var fastEx = resultAdapterService?.LookupException(CompletedResultBox);
 
@@ -109,10 +106,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
 
             var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
 
-            var handled = handler is IHandler<TMessage, ValueTask> typed
-                ? typed.Handle(message, context)
-                : (ValueTask)handler.Handle(message, context);
-            await handled;
+            await InvokeHandler(handler, message, context);
             result = ValueTask.CompletedTask;
 
             var ex = resultAdapterService?.LookupException(CompletedResultBox);
@@ -153,5 +147,27 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
             }
         }
 
+    }
+
+    /// <summary>
+    /// Invokes the handler through its typed contract — no object-typed bridge; see the
+    /// result-producing strategy for the dispatch rules.
+    /// </summary>
+    private static ValueTask InvokeHandler(object handler, TMessage message, IExecutionContext context)
+    {
+        switch (handler)
+        {
+            case IAsyncHandler<TMessage> asyncHandler:
+                return asyncHandler.HandleAsync(message, context);
+            case IHandler<TMessage, ValueTask> valueTaskShaped:
+                return valueTaskShaped.Handle(message, context);
+            case IHandler<TMessage, object> syncHandler:
+                syncHandler.Handle(message, context);
+                return ValueTask.CompletedTask;
+            default:
+                throw new NotSupportedException(
+                    $"'{handler.GetType()}' does not implement a supported handler contract for message '{typeof(TMessage)}'. " +
+                    "Interface-erased dispatch is not supported; dispatch with the concrete message type.");
+        }
     }
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
@@ -69,12 +69,14 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
             message =  (TMessage)await preInvoker.Invoke(message, context) ;
 
 
-            // Typed seam: direct typed invocation when the dispatch TMessage satisfies the
-            // handler's message type (`in TMessage` variance; IAsyncEnumerable<out T>
-            // covariance admits derived elements). Erased dispatches use the DIM bridge.
+            // Typed dispatch only — no object bridge. `in TMessage` variance admits handlers
+            // registered for base message types; IAsyncEnumerable<out T> covariance admits
+            // derived elements.
             enumerable = handler is IHandler<TMessage, IAsyncEnumerable<TResult>> typed
                 ? typed.Handle(message, context)
-                : (IAsyncEnumerable<TResult>?)handler.Handle(message, context);
+                : throw new NotSupportedException(
+                    $"'{handler.GetType()}' does not implement a supported stream handler contract for message '{typeof(TMessage)}'. " +
+                    "Interface-erased dispatch is not supported; dispatch with the concrete message type.");
            
 
         }

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -64,6 +64,7 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
         // context's provider. The mediator stays scoped only to capture the calling
         // scope's provider into that context — it is a thin, cheap wrapper.
         services.TryAddSingleton<IMessageDependenciesFactory, MessageDependenciesFactory>();
+        services.TryAddSingleton<PipelineExecutorCache>();
         services.TryAddScoped<IMessageMediator, MessageMediator>();
         services.TryAddSingleton<IDescriptorCacheStrategy, LruCacheStrategy>();
         services.TryAddSingleton<MessageDescriptorCache>();

--- a/src/Stella.Ergosfare.Core/Internal/Builders/HandlerDescriptorBuilder.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Builders/HandlerDescriptorBuilder.cs
@@ -29,23 +29,50 @@ internal sealed class HandlerDescriptorBuilder: IHandlerDescriptorBuilder
     /// </summary>
     /// <param name="handlerType">The handler type from which to build descriptors.</param>
     /// <returns>A collection of <see cref="MainHandlerDescriptor"/> instances representing the handler.</returns>
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "ValueTask<TResult> descriptor result types are metadata only; the pipeline never instantiates them reflectively.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "ValueTask<TResult> descriptor result types are metadata only; the pipeline never instantiates them reflectively.")]
     public IEnumerable<IHandlerDescriptor> Build([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicConstructors)] Type handlerType)
     {
-        var interfaces = handlerType.GetInterfacesEqualTo(typeof(IHandler<,>));
-
         var weight = handlerType.GetWeightFromAttribute();
-        
-        foreach (var @interface in interfaces)
+
+        // Synchronous handlers: the second argument IS the result type.
+        foreach (var @interface in handlerType.GetInterfacesEqualTo(typeof(IHandler<,>)))
         {
-            var messageType = @interface.GetGenericArguments()[0];
-            var resultType = @interface.GetGenericArguments()[1];
-            var groups = handlerType.GetGroupsFromAttribute();
             yield return new MainHandlerDescriptor
             {
                 Weight = weight,
-                Groups = groups,
-                MessageType = messageType,
-                ResultType = resultType,
+                Groups = handlerType.GetGroupsFromAttribute(),
+                MessageType = @interface.GetGenericArguments()[0],
+                ResultType = @interface.GetGenericArguments()[1],
+                HandlerType = handlerType,
+            };
+        }
+
+        // Asynchronous handlers are standalone contracts (no object-typed root); their
+        // descriptors record the ValueTask carrier as the result type for parity with the
+        // pre-severance descriptor shape.
+        foreach (var @interface in handlerType.GetInterfacesEqualTo(typeof(IAsyncHandler<>)))
+        {
+            yield return new MainHandlerDescriptor
+            {
+                Weight = weight,
+                Groups = handlerType.GetGroupsFromAttribute(),
+                MessageType = @interface.GetGenericArguments()[0],
+                ResultType = typeof(ValueTask),
+                HandlerType = handlerType,
+            };
+        }
+
+        foreach (var @interface in handlerType.GetInterfacesEqualTo(typeof(IAsyncHandler<,>)))
+        {
+            yield return new MainHandlerDescriptor
+            {
+                Weight = weight,
+                Groups = handlerType.GetGroupsFromAttribute(),
+                MessageType = @interface.GetGenericArguments()[0],
+                ResultType = typeof(ValueTask<>).MakeGenericType(@interface.GetGenericArguments()[1]),
                 HandlerType = handlerType,
             };
         }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -22,9 +22,43 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 internal sealed class MessageMediator(
     IMessageRegistry messageRegistry,
     IMessageDependenciesFactory messageDependenciesFactory,
-    IServiceProvider serviceProvider)
+    IServiceProvider serviceProvider,
+    PipelineExecutorCache? executorCache = null)
     : IMessageMediator
 {
+    /// <summary>
+    /// Process-wide executor cache used by the <see cref="DispatchAsync(object, IDictionary{object, object?}?, CancellationToken)"/>
+    /// path. Optional so directly-constructed mediators (tests) keep working; the DI
+    /// registration always supplies it.
+    /// </summary>
+    private readonly PipelineExecutorCache? _executorCache = executorCache;
+
+    /// <inheritdoc />
+    public ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = RequireExecutorCache().GetVoidExecutor(message.GetType(), groups);
+        var context = new ErgosfareExecutionContext(items, cancellationToken);
+
+        return executor.Execute(message, context, _serviceProvider);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<TResult> DispatchAsync<TResult>(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = RequireExecutorCache().GetExecutor<TResult>(message.GetType(), groups);
+        var context = new ErgosfareExecutionContext(items, cancellationToken);
+
+        return executor.Execute(message, context, _serviceProvider);
+    }
+
+    private PipelineExecutorCache RequireExecutorCache()
+        => _executorCache ?? throw new InvalidOperationException(
+            "Executor dispatch requires the PipelineExecutorCache; register Ergosfare through AddErgosfare or use Mediate with explicit options.");
+
 
     /// <summary>
     /// Registry used to keep track of registered message types.

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -1,0 +1,138 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Abstractions.Factories;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+
+namespace Stella.Ergosfare.Core.Internal.Mediator;
+
+/// <summary>
+/// Result-producing pipeline closed over the concrete <typeparamref name="TMessage"/>.
+/// Because <typeparamref name="TMessage"/> is the message's runtime type here, the mediation
+/// strategy's typed seam always hits — the handler is invoked through its typed member and
+/// its <see cref="ValueTask{TResult}"/> never crosses an object-typed bridge.
+/// </summary>
+internal sealed class ResultPipelineExecutor<TMessage, TResult>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups) : IPipelineExecutor<TResult>
+    where TMessage : notnull
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);
+
+    public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        // The factory caches per (message type, groups) and re-validates against the
+        // registry version, mirroring the Mediate path's per-dispatch behavior.
+        var dependencies = dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+}
+
+/// <summary>
+/// Void pipeline closed over the concrete <typeparamref name="TMessage"/>; see
+/// <see cref="ResultPipelineExecutor{TMessage, TResult}"/>.
+/// </summary>
+internal sealed class VoidPipelineExecutor<TMessage>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups) : IPipelineExecutor
+    where TMessage : IMessage
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);
+
+    public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+}
+
+/// <summary>
+/// Process-wide cache of pipeline executors, one per (message runtime type, result type,
+/// group set). Executor construction closes the generic executor over the message's runtime
+/// type — one <see cref="Type.MakeGenericType"/> per message type, consistent with the
+/// pipeline plan premise that all dispatch-shape work happens once per message type.
+/// </summary>
+internal sealed class PipelineExecutorCache(
+    IMessageDependenciesFactory dependenciesFactory,
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+    IResultAdapterService? resultAdapterService = null)
+{
+    internal static readonly string[] EmptyGroups = [];
+
+    private readonly ConcurrentDictionary<(Type MessageType, string GroupsKey), IPipelineExecutor> _voidExecutors = new();
+    private readonly ConcurrentDictionary<(Type MessageType, Type ResultType, string GroupsKey), object> _resultExecutors = new();
+
+    public IPipelineExecutor GetVoidExecutor(Type messageType, IEnumerable<string>? groups = null)
+    {
+        var key = (messageType, GroupsKey(groups));
+        if (!_voidExecutors.TryGetValue(key, out var executor))
+        {
+            executor = _voidExecutors.GetOrAdd(key,
+                static (k, state) => state.Cache.CreateVoidExecutor(k.MessageType, state.Groups),
+                (Cache: this, Groups: MaterializeGroups(groups)));
+        }
+
+        return executor;
+    }
+
+    public IPipelineExecutor<TResult> GetExecutor<TResult>(Type messageType, IEnumerable<string>? groups = null)
+    {
+        var key = (messageType, typeof(TResult), GroupsKey(groups));
+        if (!_resultExecutors.TryGetValue(key, out var executor))
+        {
+            executor = _resultExecutors.GetOrAdd(key,
+                static (k, state) => state.Cache.CreateResultExecutor(k.MessageType, k.ResultType, state.Groups),
+                (Cache: this, Groups: MaterializeGroups(groups)));
+        }
+
+        return (IPipelineExecutor<TResult>)executor;
+    }
+
+    private static string GroupsKey(IEnumerable<string>? groups)
+        => groups is null ? string.Empty : string.Join('\x1f', groups);
+
+    private static string[] MaterializeGroups(IEnumerable<string>? groups)
+        => groups is null ? EmptyGroups : [.. groups];
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "The executor generic is closed over a live message's runtime type; the message roots its type.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Executors close over reference message types (shared generic code under Native AOT); " +
+                        "source-generated dispatch will emit these instantiations concretely.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2077", Justification = "Executor types are constructed from typeof expressions below; their constructors are rooted.")]
+    private IPipelineExecutor CreateVoidExecutor(Type messageType, string[] groups)
+    {
+        var descriptor = FindDescriptor(messageType);
+        var executorType = typeof(VoidPipelineExecutor<>).MakeGenericType(messageType);
+
+        return (IPipelineExecutor)Activator.CreateInstance(executorType, descriptor, dependenciesFactory, resultAdapterService, groups)!;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "The executor generic is closed over a live message's runtime type; the message roots its type.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Executors close over reference message types (shared generic code under Native AOT); " +
+                        "source-generated dispatch will emit these instantiations concretely.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2077", Justification = "Executor types are constructed from typeof expressions below; their constructors are rooted.")]
+    private object CreateResultExecutor(Type messageType, Type resultType, string[] groups)
+    {
+        var descriptor = FindDescriptor(messageType);
+        var executorType = typeof(ResultPipelineExecutor<,>).MakeGenericType(messageType, resultType);
+
+        return Activator.CreateInstance(executorType, descriptor, dependenciesFactory, resultAdapterService, groups)!;
+    }
+
+    private IMessageDescriptor FindDescriptor(Type messageType)
+    {
+        return messageResolveStrategy.Find(messageType)
+               ?? throw new NoHandlerFoundException(messageType);
+    }
+}

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -106,16 +106,26 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
     {
         for (var i = 0; i < handlers.Count; i++)
         {
-            // Typed seam: PublishAsync<TEvent> dispatches with the concrete event type, so
-            // the typed check hits (`in TMessage` variance also admits base-typed handlers);
-            // the interface-erased PublishAsync(IEvent) overload falls back to the bridge.
+            // Typed dispatch only — no object bridge. `in TMessage` variance admits handlers
+            // registered for base event types; erased dispatch goes through the executor.
             var handler = handlers[i].Resolve(serviceProvider);
 
-            var handleTask = handler is IHandler<TMessage, ValueTask> typed
-                ? typed.Handle(message, context)
-                : (ValueTask)handler.Handle(message, context);
-
-            await handleTask;
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage> asyncHandler:
+                    await asyncHandler.HandleAsync(message, context);
+                    break;
+                case IHandler<TMessage, ValueTask> valueTaskShaped:
+                    await valueTaskShaped.Handle(message, context);
+                    break;
+                case IHandler<TMessage, object> syncHandler:
+                    syncHandler.Handle(message, context);
+                    break;
+                default:
+                    throw new NotSupportedException(
+                        $"'{handler.GetType()}' does not implement a supported handler contract for event '{typeof(TMessage)}'. " +
+                        "Interface-erased dispatch is not supported; publish with the concrete event type.");
+            }
         }
     }
 }

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -1,0 +1,65 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Events.Abstractions;
+
+namespace Stella.Ergosfare.Events;
+
+/// <summary>
+/// Publishes an event through a pipeline closed over the event's concrete type, so broadcast
+/// handlers are always invoked through their typed members — interface-erased publishes
+/// (<c>PublishAsync((IEvent)e)</c>) resolve the invoker from the event's runtime type.
+/// Invokers are closed once per event type and cached; the per-call
+/// <see cref="EventMediationSettings"/> flows into a fresh strategy instance, as before.
+/// </summary>
+internal interface IEventBroadcastInvoker
+{
+    ValueTask Publish(object @event, EventMediationSettings settings, CancellationToken cancellationToken,
+        IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IResultAdapterService? resultAdapterService);
+}
+
+internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
+    where TEvent : notnull
+{
+    private static readonly string[] EmptyGroups = [];
+
+    public ValueTask Publish(object @event, EventMediationSettings settings, CancellationToken cancellationToken,
+        IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IResultAdapterService? resultAdapterService)
+    {
+        var options = new MediateOptions<TEvent, ValueTask>
+        {
+            MessageMediationStrategy = new AsyncBroadcastMediationStrategy<TEvent>(resultAdapterService, settings),
+            MessageResolveStrategy = resolveStrategy,
+            CancellationToken = cancellationToken,
+            Items = settings.Items,
+            Groups = settings.Filters.Groups,
+        };
+
+        return mediator.Mediate((TEvent)@event, options);
+    }
+}
+
+/// <summary>
+/// Process-wide cache of <see cref="IEventBroadcastInvoker"/> instances, one per event
+/// runtime type — one <see cref="Type.MakeGenericType"/> per event type.
+/// </summary>
+internal static class EventBroadcastInvokerCache
+{
+    private static readonly ConcurrentDictionary<Type, IEventBroadcastInvoker> Invokers = new();
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "The invoker generic is closed over a live event's runtime type; the event roots its type.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Invokers close over reference event types (shared generic code under Native AOT); " +
+                        "source-generated dispatch will emit these instantiations concretely.")]
+    public static IEventBroadcastInvoker Get(Type eventType)
+    {
+        return Invokers.TryGetValue(eventType, out var invoker)
+            ? invoker
+            : Invokers.GetOrAdd(eventType,
+                static t => (IEventBroadcastInvoker)Activator.CreateInstance(typeof(EventBroadcastInvoker<>).MakeGenericType(t))!);
+    }
+}

--- a/src/Stella.Ergosfare.Events/EventMediator.cs
+++ b/src/Stella.Ergosfare.Events/EventMediator.cs
@@ -1,4 +1,4 @@
-﻿using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Events.Abstractions;
 
@@ -6,9 +6,9 @@ namespace Stella.Ergosfare.Events;
 
 
 /// <summary>
-/// Mediates events through the framework message pipeline, supporting both generic and non-generic events.
-/// Responsible for publishing events to all registered handlers asynchronously, optionally applying
-/// result adapters and event mediation settings.
+/// Mediates events through broadcast pipelines closed over each event's runtime type, so
+/// handlers are always invoked through their typed members — including for the
+/// interface-erased <see cref="PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> overload.
 /// </summary>
 /// <inheritdoc cref="IEventMediator"/>
 public sealed class EventMediator(
@@ -16,7 +16,7 @@ public sealed class EventMediator(
     IResultAdapterService? resultAdapterService,
     IMessageMediator messageMediator) : IPublisher
 {
-    
+
     /// <summary>
     /// Publishes a non-generic event asynchronously through the mediation pipeline.
     /// </summary>
@@ -24,53 +24,29 @@ public sealed class EventMediator(
     /// <param name="eventMediationSettings">Optional settings for pipeline execution, e.g., filters, items, and exception behavior.</param>
     /// <param name="cancellationToken">Cancellation token for async execution.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous publish operation.</returns>
-    public async ValueTask PublishAsync(IEvent @event,
+    public ValueTask PublishAsync(IEvent @event,
                              EventMediationSettings? eventMediationSettings = null,
                              CancellationToken cancellationToken = default)
     {
-        // Create a broadcast strategy for sending this event to multiple handlers
-        var mediationStrategy = new AsyncBroadcastMediationStrategy<IEvent>(resultAdapterService, eventMediationSettings ??= new EventMediationSettings());
-
-        // Execute the event through the message mediator
-        await  messageMediator.Mediate(@event,
-            new MediateOptions<IEvent, ValueTask>
-            {
-                MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = messageResolveStrategy,
-                CancellationToken = cancellationToken,
-                RegisterPlainMessagesOnSpot = !eventMediationSettings.ThrowIfNoHandlerFound,
-                Items = eventMediationSettings.Items,
-                Groups = eventMediationSettings.Filters.Groups
-            });
+        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+            @event, eventMediationSettings ?? new EventMediationSettings(), cancellationToken,
+            messageMediator, messageResolveStrategy, resultAdapterService);
     }
 
-    
     /// <summary>
-    /// Publishes a strongly-typed poco generic event asynchronously through the mediation pipeline.
+    /// Publishes a strongly-typed event asynchronously through the mediation pipeline.
     /// </summary>
-    /// <typeparam name="TEvent">The concrete event type.</typeparam>
-    /// <param name="event">The strongly-typed poco event message to publish.</param>
-    /// <param name="eventMediationSettings">Optional settings for pipeline execution, e.g., filters, items, and exception behavior.</param>
+    /// <typeparam name="TEvent">The event type being published.</typeparam>
+    /// <param name="event">The event message to publish.</param>
+    /// <param name="eventMediationSettings">Optional settings for pipeline execution.</param>
     /// <param name="cancellationToken">Cancellation token for async execution.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous publish operation.</returns>
-    public async ValueTask PublishAsync<TEvent>(TEvent @event,
+    public ValueTask PublishAsync<TEvent>(TEvent @event,
                                      EventMediationSettings? eventMediationSettings = null,
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
-        // Create a broadcast strategy for this specific event type
-        var mediationStrategy = new AsyncBroadcastMediationStrategy<TEvent>(resultAdapterService, eventMediationSettings ??= new EventMediationSettings());
-        // Execute the strongly-typed event through the mediator
-        await messageMediator.Mediate(@event,
-            new MediateOptions<TEvent, ValueTask>
-            {
-                MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = messageResolveStrategy,
-                CancellationToken = cancellationToken,
-                RegisterPlainMessagesOnSpot = !eventMediationSettings.ThrowIfNoHandlerFound,
-                Items = eventMediationSettings.Items,
-                Groups = eventMediationSettings.Filters.Groups
-            });
-        // Trigger the pipeline finish event
-        //FinishPipelineSignal.Invoke(@event, null);
+        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+            @event, eventMediationSettings ?? new EventMediationSettings(), cancellationToken,
+            messageMediator, messageResolveStrategy, resultAdapterService);
     }
 }

--- a/src/Stella.Ergosfare.Queries/QueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries/QueryMediator.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using Stella.Ergosfare.Core;
+﻿using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Queries.Abstractions;
@@ -14,17 +13,8 @@ namespace Stella.Ergosfare.Queries;
 /// </summary>
 public class QueryMediator(
     ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
-    IResultAdapterService resultAdapterService,
     IMessageMediator messageMediator): IQueryMediator
 {
-    private static readonly string[] EmptyGroups = [];
-
-    /// <summary>
-    /// Mediation strategies for queries, one per result type; stateless, so shared across
-    /// calls. Created lazily so mediators in short-lived scopes that never run typed
-    /// queries pay nothing.
-    /// </summary>
-    private ConcurrentDictionary<Type, object>? _typedMediationStrategies;
 
     /// <summary>
     /// Executes a query and returns a single result of type <typeparamref name="TResult"/>.
@@ -40,26 +30,11 @@ public class QueryMediator(
     public ValueTask<TResult> QueryAsync<TResult>(IQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        // Reuse the mediation strategy for this result type
-        var typedMediationStrategies = LazyInitializer.EnsureInitialized(ref _typedMediationStrategies);
-
-        if (!typedMediationStrategies.TryGetValue(typeof(TResult), out var mediationStrategy))
-        {
-            mediationStrategy = typedMediationStrategies.GetOrAdd(typeof(TResult),
-                new SingleAsyncHandlerMediationStrategy<IQuery<TResult>, TResult>(resultAdapterService));
-        }
-
-        // Execute the query through the message mediator
-        var result = messageMediator.Mediate(query,
-            new MediateOptions<IQuery<TResult>, ValueTask<TResult>>
-            {
-                MessageMediationStrategy = (SingleAsyncHandlerMediationStrategy<IQuery<TResult>, TResult>)mediationStrategy,
-                MessageResolveStrategy = messageResolveStrategy,
-                CancellationToken = cancellationToken,
-                Items = queryMediationSettings?.Items,
-                Groups = queryMediationSettings?.Filters.Groups ?? EmptyGroups
-            });
-        return result;
+        return messageMediator.DispatchAsync<TResult>(
+            query,
+            queryMediationSettings?.Items,
+            cancellationToken,
+            queryMediationSettings?.Filters.Groups);
     }
 
     
@@ -77,18 +52,7 @@ public class QueryMediator(
     public IAsyncEnumerable<TResult> StreamAsync<TResult>(IStreamQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        // Build a mediation strategy for streaming queries (carries the per-call cancellation token)
-        var mediationStrategy = new SingleStreamHandlerMediationStrategy<IStreamQuery<TResult>, TResult>(new ResultAdapterService(), cancellationToken);
-        // Execute the streaming query through the message mediator
-        var result =  messageMediator.Mediate(query,
-            new MediateOptions<IStreamQuery<TResult>, IAsyncEnumerable<TResult>>
-            {
-                MessageMediationStrategy = mediationStrategy,
-                MessageResolveStrategy = messageResolveStrategy,
-                CancellationToken = cancellationToken,
-                Items = queryMediationSettings?.Items,
-                Groups = queryMediationSettings?.Filters.Groups ?? EmptyGroups
-            });
-        return result;
+        return QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
+            query, queryMediationSettings, cancellationToken, messageMediator, messageResolveStrategy);
     }
 }

--- a/src/Stella.Ergosfare.Queries/StreamInvoker.cs
+++ b/src/Stella.Ergosfare.Queries/StreamInvoker.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Queries;
+
+/// <summary>
+/// Streams a query through a pipeline closed over the query's concrete type, so the stream
+/// handler is always invoked through its typed member — interface-erased streaming
+/// (<c>StreamAsync(IStreamQuery&lt;T&gt;)</c>) resolves the invoker from the query's runtime
+/// type. Invokers are closed once per (query type, result type) and cached; the per-call
+/// cancellation token flows into a fresh strategy instance, as before.
+/// </summary>
+internal interface IQueryStreamInvoker<out TResult>
+{
+    IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
+        IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy);
+}
+
+internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<TResult>
+    where TQuery : notnull
+{
+    private static readonly string[] EmptyGroups = [];
+
+    public IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
+        IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        var options = new MediateOptions<TQuery, IAsyncEnumerable<TResult>>
+        {
+            MessageMediationStrategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(new ResultAdapterService(), cancellationToken),
+            MessageResolveStrategy = resolveStrategy,
+            CancellationToken = cancellationToken,
+            Items = settings?.Items,
+            Groups = settings?.Filters.Groups ?? EmptyGroups,
+        };
+
+        return mediator.Mediate((TQuery)query, options);
+    }
+}
+
+/// <summary>
+/// Process-wide cache of <see cref="IQueryStreamInvoker{TResult}"/> instances, one per
+/// (query runtime type, result type) — one <see cref="Type.MakeGenericType"/> per pair.
+/// </summary>
+internal static class QueryStreamInvokerCache
+{
+    private static readonly ConcurrentDictionary<(Type QueryType, Type ResultType), object> Invokers = new();
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "The invoker generic is closed over a live query's runtime type; the query roots its type.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Invokers close over the query's reference type; the struct result argument's instantiations are " +
+                        "rooted by source-generated dispatch on Native AOT, with this reflective path as the JIT fallback.")]
+    public static IQueryStreamInvoker<TResult> Get<TResult>(Type queryType)
+    {
+        var key = (queryType, typeof(TResult));
+        if (!Invokers.TryGetValue(key, out var invoker))
+        {
+            invoker = Invokers.GetOrAdd(key,
+                static k => Activator.CreateInstance(typeof(QueryStreamInvoker<,>).MakeGenericType(k.QueryType, k.ResultType))!);
+        }
+
+        return (IQueryStreamInvoker<TResult>)invoker;
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/CommandMediatorTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandMediatorTests.cs
@@ -27,7 +27,7 @@ public class CommandMediatorTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public void ShouldResolveCommandTCommand()
+    public async Task ShouldResolveCommandTCommand()
     {
         var serviceCollection = new ServiceCollection()
             .AddErgosfare(options =>
@@ -39,14 +39,9 @@ public class CommandMediatorTests
             }).BuildServiceProvider();
 
         var messageMediator = serviceCollection.GetService<IMessageMediator>();
-        var mediator = new CommandMediator(
-            serviceCollection.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
-            new ResultAdapterService(),
-            messageMediator!);
+        var mediator = new CommandMediator(messageMediator!);
 
-        var result = mediator.SendAsync(new StubNonGenericCommand(), null, CancellationToken.None);
-
-        Assert.NotNull(result);
+        await mediator.SendAsync(new StubNonGenericCommand(), null, CancellationToken.None);
     }
 
     /// <summary>
@@ -72,14 +67,10 @@ public class CommandMediatorTests
             }).BuildServiceProvider();
 
         var messageMediator = serviceCollection.GetRequiredService<IMessageMediator>();
-        var mediator = new CommandMediator(
-            serviceCollection.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
-            new ResultAdapterService(),
-            messageMediator!);
+        var mediator = new CommandMediator(messageMediator!);
 
         var result = mediator.SendAsync(new StubNonGenericCommandStringResult(), StubDefaultMediationSetting.CommandDefaultSetting, CancellationToken.None);
 
-        Assert.NotNull(result);
         Assert.Equal(string.Empty, await result);
     }
 }

--- a/test/Stella.Ergosfare.Command.Test/CommandModuleTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandModuleTests.cs
@@ -51,11 +51,9 @@ public class CommandModuleTests
                     )
             )).BuildServiceProvider();
         var mediator = serviceCollection.GetRequiredService<ICommandMediator>();
-        var result = mediator.SendAsync(new TestCommand());
+        await mediator.SendAsync(new TestCommand());
         var stringResult = mediator.SendAsync<string>(new TestCommandStringResult());
-        
-        Assert.NotNull(result);
-        Assert.NotNull(stringResult);
+
         Assert.Equal(string.Empty, await stringResult);
         
     }

--- a/test/Stella.Ergosfare.Core.Test/Abstractions/Handler/IAsyncHandler[TMessage,TResult]ImplemantationTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Abstractions/Handler/IAsyncHandler[TMessage,TResult]ImplemantationTests.cs
@@ -29,12 +29,11 @@ public class IAsyncHandlerTMessageTResultTests(ExecutionContextFixture execution
     public async Task IAsyncHandlersShouldImplements()
     {
         var ctx = ExecutionContextFixture.Ctx;
-        IHandler handler = new StubStringAsyncHandler();
-        
-        var result = handler.Handle(Message, ctx);
-        
+        IAsyncHandler<StubMessage, string> handler = new StubStringAsyncHandler();
+
+        var result = await handler.HandleAsync(Message, ctx);
+
         Assert.NotNull(result);
-        await Assert.IsType<ValueTask<string>>(result);
 
     }
 }

--- a/test/Stella.Ergosfare.Core.Test/Abstractions/Handler/IAsyncHandler[TMessage]ImplemantionTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Abstractions/Handler/IAsyncHandler[TMessage]ImplemantionTests.cs
@@ -23,13 +23,9 @@ public class AsyncHandlerTests(ExecutionContextFixture executionContextFixture)
     public async Task IAsyncHandlersShouldImplement()
     {      
         // arrange
-        IHandler handler1 =  new StubVoidAsyncHandler();
-       
-        // act
-        var result = handler1.Handle(Message, ExecutionContextFixture.Ctx);
-        
-        // assert
-        Assert.NotNull(result); 
-        await Assert.IsType<ValueTask>(result, exactMatch: false);
+        IAsyncHandler<StubMessage> handler1 = new StubVoidAsyncHandler();
+
+        // act & assert: the typed member completes
+        await handler1.HandleAsync(Message, ExecutionContextFixture.Ctx);
     }
 }

--- a/test/Stella.Ergosfare.Core.Test/Abstractions/Handler/IHandlerImplemantationTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Abstractions/Handler/IHandlerImplemantationTests.cs
@@ -31,11 +31,11 @@ public class IHandlerImplementationTests(ExecutionContextFixture executionContex
     {
         // arrange
         var ctx = ExecutionContextFixture.Ctx;
-   
-        IHandler handler = new StubVoidHandler();
+
+        IHandler<StubMessage, object> handler = new StubVoidHandler();
         // act
         var result = handler.Handle(Message, ctx);
         // assert
-        Assert.Null(result); 
+        Assert.Null(result);
     }
 }

--- a/test/Stella.Ergosfare.Queries.Test/QueryMediatorTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/QueryMediatorTests.cs
@@ -29,11 +29,9 @@ public class QueryMediatorTests
         var messageMediator = services.GetService<IMessageMediator>();
         var mediator = new QueryMediator(
             services.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
-            new ResultAdapterService(),
             messageMediator!);
         var result = mediator.QueryAsync(new StubNonGenericStringResultQuery(), null);
-        Assert.NotNull(result);
-        Assert.Equal(string.Empty, await result); 
+        Assert.Equal(string.Empty, await result);
     }
     
     /// <summary>
@@ -50,7 +48,6 @@ public class QueryMediatorTests
         var messageMediator = serviceCollection.GetService<IMessageMediator>();
         var mediator = new QueryMediator(
             serviceCollection.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>(),
-            new ResultAdapterService(),
             messageMediator!);
         var expected = new []  {"Foo", "Bar", "Baz"};
         var result = new List<string>();

--- a/test/Stella.Ergosfare.Queries.Test/QueryModuleTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/QueryModuleTests.cs
@@ -44,7 +44,6 @@ public class QueryModuleTests
                 ).BuildServiceProvider();
         var mediator = serviceCollection.GetRequiredService<IQueryMediator>();
         var result = mediator.QueryAsync(new StubNonGenericStringResultQuery());
-        Assert.NotNull(result);
         Assert.Equal(string.Empty, await result);
     }
 


### PR DESCRIPTION
## Description

The agreed executor architecture: dispatch goes through pipelines **closed over the message's runtime type**, built once per (message type, result type, group set) and cached process-wide.

- **Executor core** — `IPipelineExecutor` / `IPipelineExecutor<TResult>` (Core.Abstractions) + internal executors wrapping the mediation strategies; `IMessageMediator.DispatchAsync(...)` entries; facades resolve executors by dictionary lookup. No per-call `MediateOptions`, no erased strategy, no boxed `ValueTask`.
- **Independent sync/async handler contracts** — `IHandler` is an empty marker (object-typed `Handle(object, ...)` root removed); `IHandler<TMessage, TResult>` is pure sync returning `TResult` directly; `IAsyncHandler<TMessage>[,TResult]` are standalone `ValueTask` contracts. All handler DIMs deleted; strategies invoke through typed members only.
- **Events & streams** — per-type invokers (`EventBroadcastInvokerCache`, `QueryStreamInvokerCache`) carry per-call state (settings / cancellation token); even `PublishAsync((IEvent)e)` dispatches typed.
- **Breaking**: interface-erased dispatch (`Mediate` with `TMessage = ICommand<T>` against concrete handlers) now throws `NotSupportedException` with guidance; `CommandMediator`/`QueryMediator` constructors slimmed.
- The reflective executor construction (one `MakeGenericType` per message type) is the JIT fallback the source generator will emit concretely — completing the Native AOT story.

## Benchmark (100k no-op dispatches, 7800X3D / .NET 9)

| Scenario | Before | After | MediatR |
|---|---:|---:|---:|
| Public `SendAsync` | 7.89 ms / 14.5 MB | **7.19 ms / 5.34 MB** | 6.24 ms / 18.31 MB |
| Raw mediator | 6.47 ms / 5.34 MB | 6.33 ms / 5.34 MB | — |
| ScopePerDispatch | 19.25 ms / 55.7 MB | **18.42 ms / 41.96 MB** | 11.26 ms / 33.57 MB |

Facade allocation is byte-identical to the raw path; handler-side allocation is zero for sync-completing handlers.

## Type of Change
- [ ] Bug fix
- [x] New feature — executor dispatch seam (`IPipelineExecutor`, `DispatchAsync`)
- [x] Other — v2 breaking change (severed handler contracts, erased dispatch removed)

## Related Issue
Follow-up to #83; the design was agreed as the step before source-gen Phase 1.

## Testing
- [x] I have added tests that prove my changes work — existing suites now exercise the executor path end-to-end; handler-contract tests rewritten to typed members
- [x] All existing tests pass — 0 warnings / 0 errors (no-incremental, AOT analyzers on), full suite green on net9.0 + net10.0

## Checklist
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary (CHANGELOG, README benchmarks + architecture notes)

Not: Interceptor katmanının object kökleri bilinçli olarak bu PR dışında bırakıldı (sonraki temizlik: interceptor typed-invocation + `Task*InvocationStrategy` yeniden adlandırma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)