### PR TITLE
docs: rework compatibility policy (correctness over bug-for-bug)

### DIFF
--- a/COMPATIBILITY.TR.md
+++ b/COMPATIBILITY.TR.md
@@ -1,68 +1,72 @@
-# Ergosfare Sürümleme ve Geriye Dönük Uyumluluk Politikası
+# Ergosfare Sürümleme ve Uyumluluk Politikası
 
+Ergosfare, bug-for-bug uyumluluk yerine **doğruluğu ve geliştirme hızını** önceler. Bu
+belge, tam olarak neye güvenebileceğinizi — ve neye güvenemeyeceğinizi — söyler.
 
-Belge, sürümlerin nasıl artırılacağını, geriye dönük uyumluluğun nasıl korunacağını ve obsolete API’lerin nasıl yönetileceğini tanımlar.
+> **SemVer sapmaları, en baştan beyan.** Ergosfare SemVer tarzı sürüm numaraları kullanır
+> ancak katı SemVer'den bilinçli olarak iki noktada sapar:
+>
+> 1. **Kusurlu API'ler herhangi bir sürümde, obsolete adımı olmadan düzeltilebilir veya
+>    kaldırılabilir.** Yalnızca bir bug sayesinde var olan davranış, sözleşmenin parçası
+>    değildir.
+> 2. **`[Obsolete]` işaretli API'ler minor bir sürümde kaldırılabilir** — en erken,
+>    işaretlendikleri sürümden sonraki minor'da (bölüm 4).
 
 ## 1. Kapsam
 
-Bu belge, tüm Ergosfare Yüzey API’leri için geçerlidir. Bunlar arasında şunlar yer alır:
+Bu politika tüm Ergosfare paketlerinin desteklenen public yüzeyini kapsar: mesaj ve
+handler kontratları, mediator facade'ları, interceptor'lar, mediation stratejileri ve
+modül kayıt API'leri.
 
-* Ergosfare modulleri ve Paketleri
-* Mesajlar ve Handler kontratları 
-* Mediation stratejileri
-* Snapshot ve önbellekleme mekanizmaları
+## 2. Yüzey katmanları
 
-## 2. Sürümleme Stratejisi
+| Katman | Ne | Vaat |
+|--------|-----|------|
+| **Stable** | Modül paketlerinin (Commands, Queries, Events, Contracts) public API'leri ve belgelenmiş kayıt/dispatch yüzeyi | Bölüm 3–4 kapsamında |
+| **İç yüzey** | `Stella.Ergosfare.Core` / `Stella.Ergosfare.Core.Abstractions` implementasyon mekanizması — yalnızca birinci parti modüller assembly sınırları arasında tüketebilsin diye public | **Vaat yok.** Herhangi bir sürümde değişebilir; üçüncü parti eklenti kontratı değildir |
+| **Deneysel** | `[Experimental]` işaretli API'ler (`ERGOEXP` önekli tanı kimlikleri) | **Vaat yok.** Herhangi bir sürümde değişebilir veya kaldırılabilir; tanı bastırılmadan tüketmek derleme hatasıdır — geçiş her zaman bilinçlidir |
 
-1. **Major sürümler (`vX.0.0`)**
+## 3. Sürümleme kuralları
 
-    * Breaking change’ler veya kaldırılabilecek obsolete API’leri içerir.
-    * Önceki stable API’ler için geriye dönük uyumluluk, yalnızca obsolete olarak işaretlendikten sonraki **3 aylık süre** için garanti edilir.
+1. **Major sürümler (`vX.0.0`)** her şeyi değiştirebilir. **Major geçişler uyumluluk
+   vaadinin tamamen dışındadır.** Major sürüm yeni bir hattır: bilinçli geçin ya da önceki
+   hatta kalın — önceki hatlar bakımda kaldıkları sürece düzeltme almaya devam eder ve
+   birinde kalmak tamamen desteklenen bir tercihtir.
+2. **Minor sürümler (`vX.Y.0`)** özellik ve iyileştirme ekler. Sağlıklı, obsolete olmayan
+   stable API'leri kırmaz — ancak (a) **kusurlu** API'leri düzeltebilir/kaldırabilir ve
+   (b) daha önceki bir minor'da `[Obsolete]` işaretlenmiş API'leri kaldırabilir.
+3. **Patch sürümleri (`vX.Y.Z`)** yalnızca düzeltme içerir — kusurlu davranışı değiştiren
+   düzeltmeler dahil. **Patch'ler asla API kaldırmaz.**
+4. **Ön sürümler (`vX.Y.Z-preview.N`)** hiçbir vaat taşımaz; ardışık iki preview arasında
+   dahi.
 
-2. **Minor sürümler (`vX.Y.Z`)**
+Sürümler takvimle değil API değişiklikleriyle sürülür: kırıcı bir değişiklik yayınlamaya
+değdiği anda major sürüm çıkar.
 
-    * Yeni özellikler veya iyileştirmeler ekler.
-    * Stable API’lerde **breaking change yapamaz**. Obsolete API’ler çalışmaya devam eder.
+## 4. API yaşam döngüsü
 
-3. **Patch sürümleri (`vX.Y.Z+`)**
+**Kusurlu API'ler.** Yanlış çalışan, güvensiz olan ya da kendi belgelenmiş sözleşmesini
+yerine getiremeyen bir API, **herhangi bir sürümde, obsolete adımı olmadan, derhal**
+düzeltilebilir veya kaldırılabilir. Doğruluk uyumluluğu döver; bug-for-bug uyumluluk asla
+korunmaz.
 
-    * Hata düzeltmeleri, performans iyileştirmeleri ve güvenlik yamaları içerir.
-    * Yeni API eklemez veya mevcut API’leri kaldırmaz.
+**Sağlıklı ama yerini yenisine bırakan API'ler** deprecation yaşam döngüsünü izler:
 
-**Not:** Ergosfare, katı bir roadmap bazlı sürüm takvimi takip etmez. Yayın türü **API değişikliklerine göre** belirlenir: breaking change varsa, bir sonraki major sürüm hemen yayınlanabilir.
+1. API `[Obsolete]` işaretlenir; attribute mesajı her zaman yeni adresi söyler.
+2. Kendi minor hattı boyunca yerinde ve çalışır kalır — **patch'ler asla API kaldırmaz**.
+3. **Kaldırılabileceği en erken nokta bir sonraki minor sürümdür**; sonraki herhangi bir
+   minor veya major da kaldırabilir. Zamana dayalı bir pencere yoktur — obsolete bir API
+   daha uzun da yaşayabilir, ama yaşamayacakmış gibi plan yapın.
 
-## 3. Geriye Dönük Uyumluluk
+Sözleşme derleyicidir: kusurlu-API istisnası dışında, **bugün uyarısız derlenen bir proje
+tüm patch güncellemelerini ve bir sonraki minor sürümü sorunsuz atlatır.**
 
-### 3.1 Tanımlar
+## 5. Deneysel (Experimental) API'ler
 
-* **Stable API’ler**: Stable bir sürüm (`vX.Y.Z`) içinde yayınlanmış public tipler, metodlar ve özellikler.
-* **Obsolete API’ler**: Stable sürümde obsolete olarak işaretlenen API’ler. Bu işaretleme ile **3 ay olacak şekilde geriye dönük uyumluluk süresi** başlar.
-* **Preview/RC API’ler**: Önizleme (preview) veya release candidate (RC) sürümlerinde yayınlanıp henüz stable sürümde yayınlanmadan önce obsolete olan API’ler için **geri uyumluluk garantisi yoktur**.
-
-### 3.2 Obsolete API Yaşam Döngüsü
-
-1. Yeni bir API tanıtıldığında veya mevcut API değiştirildiğinde, eski API stable sürümde **obsolete** olarak işaretlenebilir.
-  
-2. Stable sürümde obsolete olarak işaretlendiğinde:
-
-    * API, **geriye dönük uyumluluk süresi boyunca tamamen işlevsel** kalır.
-    * Geliştiriciler, **yeni API’ye geçmeleri** konusunda bilgilendirilir.
-    * 3 aylık süre, obsolete API’nin güncel alternatifi ile birlikte stable sürümde yayınlandığı tarihten itibaren başlar.
-3. Geriye dönük uyumluluk süresinin bitiminden sonra:
-
-    * Obsolete API **bir sonraki major sürümde** kaldırılabilir.
-    * Bu 3 aylık süre içinde birden fazla major, minor veya patch sürüm yayınlanabilir; kaldırma, sürenin dolması ile sınırlıdır.
-
-### 3.3 İstisnalar
-
-* Preview veya RC sürümünde yayınlanıp stable sürümden önce obsolete olan API’ler için **geri uyumluluk garantisi yoktur**.
-* Güvenlik yamaları, 3 aylık süre dolmadan API’nin değiştirilmesini gerektirebilir; bu durumda **yeni API’ye geçiş şiddetle önerilir**.
-
-### 3.4 Örnek
-
-* `v1.0.0` stable sürüm olarak yayınlandı.
-* `v1.4.0` sürümünde `OldMethod()` obsolete olarak işaretlendi.
-* Geriye dönük uyumluluk süresi `v1.4.0`’dan itibaren başlar.
-* Bu 3 aylık süre boyunca, v1.4.x veya v1.5.x gibi stable sürümlerde `OldMethod()` çalışmaya devam etmelidir.
-* 3 ayın sonunda, bir sonraki major sürüm (`v2.0.0` veya daha sonrası) obsolete API’yi kaldırabilir.
-
+* `[Experimental]` işaretli API'ler (`ERGOEXP` önekli tanı kimlikleri, ör. `ERGOEXP001`)
+  bu politikanın **tamamen dışındadır** — stable bir sürümde yayınlansalar bile.
+* Obsolete adımı olmaksızın **herhangi bir** sürümde değiştirilebilir veya kaldırılabilir.
+* Deneysel bir API'yi kullanmak, tüketici ilgili tanı kimliğini açıkça bastırmadıkça
+  (ör. `#pragma warning disable ERGOEXP001` veya `<NoWarn>`) **derleme hatasıdır**.
+* Deneysel bir API, attribute'un stable bir sürümde kaldırılmasıyla mezun olur; o sürümden
+  itibaren bu politika kapsamında stable bir API'dir.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,65 +1,71 @@
-# Ergosfare Versioning & Backward Compatibility Policy
+# Ergosfare Versioning & Compatibility Policy
 
+Ergosfare optimizes for **correctness and development velocity** over bug-for-bug
+compatibility. This document tells you exactly what you can rely on — and what you cannot.
+
+> **SemVer deviations, stated up front.** Ergosfare uses SemVer-style version numbers but
+> deliberately deviates from strict SemVer in two ways:
+>
+> 1. **Defective APIs may be fixed or removed in any release, without an obsolete step.**
+>    Behavior that only exists because of a bug is not part of the contract.
+> 2. **APIs marked `[Obsolete]` may be removed in a minor release** — at the earliest, the
+>    minor release after the one that marked them (section 4).
 
 ## 1. Scope
 
-This document applies to all Ergosfare APIs, including:
+This policy covers the supported public surface of all Ergosfare packages: message and
+handler contracts, mediator facades, interceptors, mediation strategies, and module
+registration APIs.
 
-- Commands, queries, and handlers
-- Mediation strategies
-- Snapshot and caching mechanisms
-- Interceptors and oficial plugins
+## 2. Surface tiers
 
-It defines how versions are incremented, backward compatibility is maintained, and obsolete APIs are handled.
+| Tier | What | Promise |
+|------|------|---------|
+| **Stable** | Public APIs of the module packages (Commands, Queries, Events, Contracts) and the documented registration/dispatch surface | Covered by sections 3–4 |
+| **Internal surface** | `Stella.Ergosfare.Core` / `Stella.Ergosfare.Core.Abstractions` implementation machinery — public only so first-party modules can consume it across assembly boundaries | **No promise.** May change in any release; not a third-party plugin contract |
+| **Experimental** | APIs marked `[Experimental]` (diagnostic IDs prefixed `ERGOEXP`) | **No promise.** May change or disappear in any release; consuming one is a compile-time error until you suppress its diagnostic — opting in is always deliberate |
 
-## 2. Versioning Strategy
+## 3. Versioning rules
 
-1. **Major releases (`vX.0.0`)**
-    - Introduce breaking changes or obsolete APIs that may be removed.
-    - Backward compatibility for previously stable APIs is guaranteed only for the 3-month period after marking them obsolete.
+1. **Major releases (`vX.0.0`)** may change anything. **Major transitions sit entirely
+   outside the compatibility promise.** A major version is a new line: migrate
+   deliberately, or stay on the previous line — previous lines keep receiving fixes for
+   as long as they are maintained, and staying on one is a fully supported choice.
+2. **Minor releases (`vX.Y.0`)** add features and improvements. They do not break healthy,
+   non-obsolete stable APIs — but they may (a) fix or remove **defective** APIs and
+   (b) remove APIs that an earlier minor marked `[Obsolete]`.
+3. **Patch releases (`vX.Y.Z`)** contain fixes only — including fixes that change
+   defective behavior. **Patches never remove APIs.**
+4. **Pre-releases (`vX.Y.Z-preview.N`)** carry no promises of any kind, including between
+   two consecutive previews.
 
-2. **Minor releases (`vX.Y.Z`)**
-    - Add new features or enhancements.
-    - Must **not introduce breaking changes** to stable APIs. Obsolete APIs remain functional.
+Releases are driven by API changes, not a calendar: a major version ships whenever a
+breaking change is worth shipping.
 
-3. **Patch releases (`vX.Y.Z+`)**
-    - Bug fixes, performance improvements, and security patches only.
-    - Do not introduce new APIs or remove existing ones.
+## 4. API lifecycle
 
-**Note:** Ergosfare does **not follow a strict roadmap-based release schedule**. Release type is determined by **API changes**: if a breaking change occurs, the next major version may be released immediately.
+**Defective APIs.** An API that works incorrectly, is unsafe, or cannot fulfil its own
+documented contract may be corrected or removed **immediately, in any release, without an
+obsolete step**. Correctness beats compatibility; bug-for-bug compatibility is never kept.
 
+**Healthy but superseded APIs** follow the deprecation lifecycle:
 
-## 3. Backward Compatibility
+1. The API is marked `[Obsolete]`; the attribute message always names the replacement.
+2. It remains present and functional for the rest of its minor line — **patches never
+   remove APIs**.
+3. **The next minor release is the earliest point it may be removed**; any later minor or
+   major release may also remove it. There is no time-based window — an obsolete API may
+   well survive longer, but plan as if it will not.
 
-### 3.1 Definitions
+The compiler is the contract: aside from the defective-API exception, **a warning-free
+build is safe through every patch update and through the next minor release.**
 
-* **Stable APIs**: Public types, methods, and properties that are published in a stable release (`vX.Y.Z`).
-* **Obsolete APIs**: Stable APIs that are marked as obsolete in a stable release. This starts a **3-month backward compatibility window**.
-* **Preview/RC APIs**: APIs released in preview or release candidate versions that are obsolete before becoming stable **do not receive backward compatibility guarantees**.
+## 5. Experimental APIs
 
-### 3.2 Obsolete API Lifecycle
-
-1. When a new API is introduced or an existing API is being replaced, the old API may be marked as **obsolete** in a stable release.
-2. Once marked obsolete in a stable release:
-
-    * It **remains fully functional** during the backward compatibility window.
-    * Developers are **advised to migrate** to the new API.
-    * The 3-month timer starts **from the stable release date** where the API is marked obsolete.
-3. After the backward compatibility window:
-
-    * The obsolete API **may be removed in the next major release**.
-    * Multiple major, minor or patch releases may occur within these 3 months; removal is only restricted by the backward compatibility duration.
-
-### 3.3 Exceptions
-
-* APIs obsolete in **preview or RC** versions **before a stable release** do **not** get any backward compatibility guarantee.
-* Security patches may require breaking the obsolete API before the 3-month period; in such cases, migration is strongly recommended.
-
-### 3.4 Example
-
-* Suppose `v1.0.0` is stable.
-* `v1.4.0` marks `OldMethod()` as obsolete.
-* Backward compatibility period starts from `v1.4.0`.
-* Any stable release (v1.4.x, v1.5.x, etc.) during the next 3 months must keep `OldMethod()` functional.
-* After 3 months, the **next major release (v2.0.0 or later)** may remove `OldMethod()`.
-
+* APIs marked `[Experimental]` (diagnostic IDs prefixed `ERGOEXP`, e.g. `ERGOEXP001`) sit
+  **entirely outside this policy** — even when they ship in a stable release.
+* They may change or be removed in **any** release without an obsolete step.
+* Consuming an experimental API is a **compile-time error** unless the consumer explicitly
+  suppresses its diagnostic ID (e.g. `#pragma warning disable ERGOEXP001` or `<NoWarn>`).
+* An experimental API graduates by having the attribute removed in a stable release; from
+  that release on, it is a stable API covered by this policy.


### PR DESCRIPTION
## Description

Main-line twin of #85 — the same policy governs the v1 line. Replaces the 3-month obsolete window with the Godot-style strategy: defective APIs removable immediately in any release; healthy obsolete APIs survive their minor line (patches never remove APIs) with the next minor as the earliest removal point; major transitions fully outside the compatibility promise. Surface tiers and both SemVer deviations are disclosed in the document itself.

## Type of Change
- [x] Documentation update

## Testing
- [x] All existing tests pass — docs-only change

## Checklist
- [x] I have updated the documentation where necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)