### PR TITLE
feat: cross-assembly discovery — reference scanning + discovery keys

### DIFF
--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModuleBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
@@ -76,16 +77,34 @@ public sealed class CommandModuleBuilder
     }
 
     /// <summary>
-    ///     Registers all command types from the specified assembly that implement <see cref="IRegistrableCommandConstruct" />.
+    ///     Registers the assembly's command types that participate in default discovery:
+    ///     types excluded via <see cref="ExcludeFromDiscoveryAttribute"/> or gated behind a
+    ///     <see cref="DiscoveryKeyAttribute"/> are skipped, mirroring source-generated
+    ///     <c>RegisterGenerated()</c>.
     /// </summary>
     /// <param name="assembly">The assembly from which to register command types.</param>
     /// <returns>The current <see cref="CommandModuleBuilder" /> instance for method chaining.</returns>
     [RequiresUnreferencedCode("Assembly scanning discovers command types via reflection; trimming may remove them. Register commands explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public CommandModuleBuilder RegisterFromAssembly(Assembly assembly)
+        => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
+
+    /// <summary>
+    ///     Registers the assembly's command types whose discovery keys match the given
+    ///     pattern — an exact key or a trailing-<c>*</c> prefix glob. See
+    ///     <see cref="DiscoveryKeyAttribute"/> for the key model.
+    /// </summary>
+    /// <param name="assembly">The assembly from which to register command types.</param>
+    /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
+    /// <returns>The current <see cref="CommandModuleBuilder" /> instance for method chaining.</returns>
+    [RequiresUnreferencedCode("Assembly scanning discovers command types via reflection; trimming may remove them. Register commands explicitly (or use source-generated registration) in trimmed or AOT applications.")]
+    public CommandModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {
-        foreach (var registrableCommandConstruct in assembly.GetTypes().Where(t => t.IsAssignableTo(typeof(ICommand))))
+        foreach (var type in assembly.GetTypes())
         {
-            _messageRegistry.Register(registrableCommandConstruct);
+            if (type.IsAssignableTo(typeof(ICommand)) && Discovery.Matches(type, discoveryKeyPattern))
+            {
+                _messageRegistry.Register(type);
+            }
         }
 
         return this;

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/Discovery.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/Discovery.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Reflection;
+
+namespace Stella.Ergosfare.Core.Abstractions.Attributes;
+
+/// <summary>
+/// Runtime evaluation of the discovery attributes — the single source of truth for how
+/// <see cref="ExcludeFromDiscoveryAttribute"/>, <see cref="DiscoveryKeyAttribute"/> and key
+/// patterns compose. The reflection-based scanning paths (<c>RegisterFromAssembly</c>) call
+/// into this so their semantics stay identical to source-generated registration, which
+/// evaluates the same rules at compile time.
+/// </summary>
+public static class Discovery
+{
+    /// <summary>
+    /// Whether discovery with the given key pattern selects the type: the type is not
+    /// excluded from discovery, and at least one of its effective discovery keys matches
+    /// the pattern.
+    /// </summary>
+    /// <param name="type">The candidate registrable type.</param>
+    /// <param name="discoveryKeyPattern">
+    /// The key pattern: an exact key, a prefix glob with a trailing <c>*</c>
+    /// (e.g. <c>"reporting.*"</c>), or the empty string for default discovery.
+    /// </param>
+    public static bool Matches(Type type, string discoveryKeyPattern)
+    {
+        if (IsExcluded(type))
+        {
+            return false;
+        }
+
+        foreach (var key in GetKeys(type))
+        {
+            if (MatchesKey(key, discoveryKeyPattern))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the type — or its assembly — opts out of discovery via
+    /// <see cref="ExcludeFromDiscoveryAttribute"/>.
+    /// </summary>
+    public static bool IsExcluded(Type type)
+        => type.IsDefined(typeof(ExcludeFromDiscoveryAttribute), inherit: false)
+           || type.Assembly.IsDefined(typeof(ExcludeFromDiscoveryAttribute));
+
+    /// <summary>
+    /// The type's effective discovery keys: its own <see cref="DiscoveryKeyAttribute"/>
+    /// keys when declared, else its assembly's, else the implicit default key.
+    /// </summary>
+    public static string[] GetKeys(Type type)
+    {
+        var declared = type.GetCustomAttribute<DiscoveryKeyAttribute>(inherit: false)?.Keys;
+
+        if (declared is not { Length: > 0 })
+        {
+            declared = type.Assembly.GetCustomAttribute<DiscoveryKeyAttribute>()?.Keys;
+        }
+
+        return declared is { Length: > 0 } ? declared : [DiscoveryKeyAttribute.DefaultKey];
+    }
+
+    /// <summary>
+    /// Whether a single discovery key matches a pattern: ordinal equality, or — when the
+    /// pattern ends with <c>*</c> — an ordinal prefix match on the part before the star.
+    /// </summary>
+    public static bool MatchesKey(string key, string discoveryKeyPattern)
+    {
+        if (discoveryKeyPattern.Length > 0 && discoveryKeyPattern[^1] == '*')
+        {
+            return key.Length >= discoveryKeyPattern.Length - 1
+                   && string.CompareOrdinal(key, 0, discoveryKeyPattern, 0, discoveryKeyPattern.Length - 1) == 0;
+        }
+
+        return string.Equals(key, discoveryKeyPattern, StringComparison.Ordinal);
+    }
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/DiscoveryKeyAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/DiscoveryKeyAttribute.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Stella.Ergosfare.Core.Abstractions.Attributes;
+
+/// <summary>
+/// Gates a registrable construct behind one or more discovery keys: a keyed type is
+/// excluded from default discovery (<c>RegisterGenerated()</c>, <c>RegisterFromAssembly(assembly)</c>)
+/// and registers only when a registration call selects one of its keys, e.g.
+/// <c>RegisterGenerated("reporting")</c> or <c>RegisterGenerated("reporting.*")</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Untagged types carry the implicit default key (the empty string), which is what the
+/// pattern-less registration calls select. Listing the empty string alongside other keys
+/// (<c>[DiscoveryKey("", "debug")]</c>) keeps a type in default discovery while also making
+/// it selectable by key.
+/// </para>
+/// <para>
+/// Applied to an assembly, the attribute sets the default keys for every registrable type
+/// in that assembly that declares no <see cref="DiscoveryKeyAttribute"/> of its own —
+/// letting a library tag its whole surface (e.g. a modular-monolith module) in one place.
+/// </para>
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Assembly,
+    Inherited = false)]
+public sealed class DiscoveryKeyAttribute(params string[] keys) : Attribute
+{
+    /// <summary>
+    /// The default discovery key carried by types that declare no
+    /// <see cref="DiscoveryKeyAttribute"/>: the empty string, selected by the pattern-less
+    /// registration calls.
+    /// </summary>
+    public const string DefaultKey = "";
+
+    /// <summary>
+    /// Gets the discovery keys assigned to the type or assembly.
+    /// </summary>
+    public string[] Keys => keys;
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/ExcludeFromDiscoveryAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/ExcludeFromDiscoveryAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Stella.Ergosfare.Core.Abstractions.Attributes;
+
+/// <summary>
+/// Excludes a registrable construct from automatic discovery entirely: both
+/// source-generated registration and reflection-based assembly scanning
+/// (<c>RegisterFromAssembly</c>) skip the type, regardless of discovery keys or patterns.
+/// Explicit registration (<c>Register&lt;T&gt;()</c>, <c>Register(Type)</c>) still works.
+/// </summary>
+/// <remarks>
+/// Applied to an assembly, the attribute removes every type in that assembly from
+/// discovery — for libraries that wire themselves up manually or are never meant to be
+/// scanned.
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Assembly,
+    Inherited = false)]
+public sealed class ExcludeFromDiscoveryAttribute : Attribute;

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/CoreModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/CoreModuleBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 
 namespace Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
@@ -39,17 +40,34 @@ public class CoreModuleBuilder(IMessageRegistry registry): IModuleBuilder
     
     
     /// <summary>
-    /// Registers all types from the given assembly into the <see cref="IMessageRegistry"/>.
+    /// Registers the assembly's types that participate in default discovery: types
+    /// excluded via <see cref="ExcludeFromDiscoveryAttribute"/> or gated behind a
+    /// <see cref="DiscoveryKeyAttribute"/> are skipped, mirroring source-generated
+    /// <c>RegisterGenerated()</c>.
     /// </summary>
     /// <param name="assembly">The assembly whose types should be registered as messages.</param>
     /// <returns>The current <see cref="IModuleBuilder"/> instance for fluent chaining.</returns>
-
     [RequiresUnreferencedCode("Assembly scanning discovers types via reflection; trimming may remove them. Register types explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public IModuleBuilder RegisterFromAssembly(Assembly assembly)
+        => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
+
+    /// <summary>
+    /// Registers the assembly's types whose discovery keys match the given pattern — an
+    /// exact key or a trailing-<c>*</c> prefix glob. See
+    /// <see cref="DiscoveryKeyAttribute"/> for the key model.
+    /// </summary>
+    /// <param name="assembly">The assembly whose types should be registered as messages.</param>
+    /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
+    /// <returns>The current <see cref="IModuleBuilder"/> instance for fluent chaining.</returns>
+    [RequiresUnreferencedCode("Assembly scanning discovers types via reflection; trimming may remove them. Register types explicitly (or use source-generated registration) in trimmed or AOT applications.")]
+    public IModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {
         foreach (var type in assembly.GetTypes())
         {
-            registry.Register(type);
+            if (Discovery.Matches(type, discoveryKeyPattern))
+            {
+                registry.Register(type);
+            }
         }
         return this;
     }

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModuleBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Events.Abstractions;
@@ -77,19 +78,36 @@ public class EventModuleBuilder(
     }
 
     /// <summary>
-    /// Registers all event types from the specified assembly.
+    /// Registers the assembly's event types that participate in default discovery: types
+    /// excluded via <see cref="ExcludeFromDiscoveryAttribute"/> or gated behind a
+    /// <see cref="DiscoveryKeyAttribute"/> are skipped, mirroring source-generated
+    /// <c>RegisterGenerated()</c>.
     /// </summary>
     /// <param name="assembly">The assembly to scan for types implementing <see cref="IEvent"/>.</param>
     /// <returns>The current <see cref="EventModuleBuilder"/> instance for fluent chaining.</returns>
     [RequiresUnreferencedCode("Assembly scanning discovers event types via reflection; trimming may remove them. Register events explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public EventModuleBuilder RegisterFromAssembly(Assembly assembly)
+        => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
+
+    /// <summary>
+    /// Registers the assembly's event types whose discovery keys match the given pattern —
+    /// an exact key or a trailing-<c>*</c> prefix glob. See
+    /// <see cref="DiscoveryKeyAttribute"/> for the key model.
+    /// </summary>
+    /// <param name="assembly">The assembly to scan for types implementing <see cref="IEvent"/>.</param>
+    /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
+    /// <returns>The current <see cref="EventModuleBuilder"/> instance for fluent chaining.</returns>
+    [RequiresUnreferencedCode("Assembly scanning discovers event types via reflection; trimming may remove them. Register events explicitly (or use source-generated registration) in trimmed or AOT applications.")]
+    public EventModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {
-        foreach (var type in assembly.GetTypes()
-                     .Where( t => t.IsAssignableTo(typeof(IEvent))))
+        foreach (var type in assembly.GetTypes())
         {
-            messageRegistry.Register(type);
+            if (type.IsAssignableTo(typeof(IEvent)) && Discovery.Matches(type, discoveryKeyPattern))
+            {
+                messageRegistry.Register(type);
+            }
         }
+
         return this;
     }
-    
 }

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModuleBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Queries.Abstractions;
@@ -68,18 +69,36 @@ public sealed class QueryModuleBuilder(IMessageRegistry messageRegistry)
     }
 
     /// <summary>
-    /// Registers all query types found in the specified assembly.
+    /// Registers the assembly's query types that participate in default discovery: types
+    /// excluded via <see cref="ExcludeFromDiscoveryAttribute"/> or gated behind a
+    /// <see cref="DiscoveryKeyAttribute"/> are skipped, mirroring source-generated
+    /// <c>RegisterGenerated()</c>.
     /// </summary>
     /// <param name="assembly">The <see cref="Assembly"/> to scan for query types.</param>
     /// <returns>The current <see cref="QueryModuleBuilder"/> instance for fluent chaining.</returns>
     [RequiresUnreferencedCode("Assembly scanning discovers query types via reflection; trimming may remove them. Register queries explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public QueryModuleBuilder RegisterFromAssembly(Assembly assembly)
+        => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
+
+    /// <summary>
+    /// Registers the assembly's query types whose discovery keys match the given pattern —
+    /// an exact key or a trailing-<c>*</c> prefix glob. See
+    /// <see cref="DiscoveryKeyAttribute"/> for the key model.
+    /// </summary>
+    /// <param name="assembly">The <see cref="Assembly"/> to scan for query types.</param>
+    /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
+    /// <returns>The current <see cref="QueryModuleBuilder"/> instance for fluent chaining.</returns>
+    [RequiresUnreferencedCode("Assembly scanning discovers query types via reflection; trimming may remove them. Register queries explicitly (or use source-generated registration) in trimmed or AOT applications.")]
+    public QueryModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {
-        foreach (var type in assembly.GetTypes().Where(t => t.IsAssignableTo(typeof(IQuery))))
+        foreach (var type in assembly.GetTypes())
         {
-            _messageRegistry.Register(type);
+            if (type.IsAssignableTo(typeof(IQuery)) && Discovery.Matches(type, discoveryKeyPattern))
+            {
+                _messageRegistry.Register(type);
+            }
         }
-        
+
         return this;
     }
 }

--- a/src/Stella.Ergosfare.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Stella.Ergosfare.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ERGOSG001 | Usage | Warning | Registrable type is not accessible from generated registration code
+ERGOSG002 | Usage | Warning | Registrable type in a referenced assembly is not visible to generated registration code

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
@@ -18,6 +19,7 @@ namespace Stella.Ergosfare.SourceGenerator;
 ///     class into the compilation.
 /// </summary>
 /// <remarks>
+///     <para>
 ///     Phase 2: for types with handler contracts, the generator pre-computes the handler
 ///     descriptors (message type, result carrier, weight, groups) that the runtime
 ///     descriptor builders would otherwise derive reflectively, and registers them through
@@ -27,6 +29,18 @@ namespace Stella.Ergosfare.SourceGenerator;
 ///     both paths are mutually idempotent in the registry. Against older Ergosfare packages
 ///     that lack the descriptor surface, emission degrades to pure <c>Register(Type)</c>
 ///     calls.
+///     </para>
+///     <para>
+///     Reference scanning: the generator also walks referenced assemblies for marker
+///     types, replacing cross-assembly <c>RegisterFromAssembly</c> calls — a library's
+///     handlers register through the consuming project's generated code. Only assemblies
+///     that themselves reference Ergosfare are inspected (nothing else can implement a
+///     marker), and Ergosfare's own assemblies are excluded because their handler contract
+///     interfaces inherit the module markers. Types the generated code cannot name —
+///     internal without <c>InternalsVisibleTo</c> covering this compilation — surface as
+///     ERGOSG002 instead of diverging silently from the runtime scan. Opt out per project
+///     with the <c>ErgosfareSourceGeneratorScanReferences=false</c> MSBuild property.
+///     </para>
 /// </remarks>
 [Generator(LanguageNames.CSharp)]
 public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
@@ -48,6 +62,9 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private const string EventBuilderMetadataName = "Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection.EventModuleBuilder";
 
     private const string ValueTaskExpression = "global::System.Threading.Tasks.ValueTask";
+
+    private const string ScanReferencesBuildProperty = "build_property.ErgosfareSourceGeneratorScanReferences";
+    private const string ErgosfareAssemblyNamePrefix = "Stella.Ergosfare";
 
     private static readonly string GeneratorVersion =
         typeof(ErgosfareRegistrationGenerator).Assembly.GetName().Version?.ToString() ?? "1.0.0";
@@ -80,9 +97,22 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 EventBuilderHasRegisterDescriptors: HasRegisterDescriptors(eventBuilder));
         });
 
+        // Reference scanning is default-on; consumers opt out per project through the
+        // ErgosfareSourceGeneratorScanReferences MSBuild property (surfaced to the
+        // generator as a build_property by the package's .props file).
+        var scanReferences = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) =>
+            !provider.GlobalOptions.TryGetValue(ScanReferencesBuildProperty, out var value)
+            || !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase));
+
+        var referencedTypes = context.CompilationProvider
+            .Combine(scanReferences)
+            .Select(static (pair, ct) => pair.Right
+                ? ScanReferencedAssemblies(pair.Left, ct)
+                : ImmutableArray<RegistrableTypeModel>.Empty);
+
         context.RegisterSourceOutput(
-            registrableTypes.Combine(availability),
-            static (spc, pair) => Execute(spc, pair.Left, pair.Right));
+            registrableTypes.Combine(availability).Combine(referencedTypes),
+            static (spc, pair) => Execute(spc, pair.Left.Left, pair.Left.Right, pair.Right));
     }
 
     private static bool HasRegisterDescriptors(INamedTypeSymbol? builder)
@@ -107,9 +137,117 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             return null;
         }
 
-        var isCommand = false;
-        var isQuery = false;
-        var isEvent = false;
+        GetMarkers(symbol, out var isCommand, out var isQuery, out var isEvent);
+
+        if (!isCommand && !isQuery && !isEvent)
+        {
+            return null;
+        }
+
+        if (IsExcludedFromDiscovery(symbol))
+        {
+            return null;
+        }
+
+        var isAccessible = IsAccessibleFromGeneratedCode(symbol);
+
+        return new RegistrableTypeModel
+        {
+            TypeofExpression = BuildTypeofExpression(symbol),
+            DisplayName = symbol.ToDisplayString(),
+            IsCommand = isCommand,
+            IsQuery = isQuery,
+            IsEvent = isEvent,
+            IsAccessible = isAccessible,
+            Location = isAccessible ? null : LocationInfo.From(symbol),
+            Weight = GetWeight(symbol),
+            GroupsExpression = GetGroupsExpression(symbol),
+            Descriptors = isAccessible ? BuildDescriptors(symbol) : ImmutableArray<DescriptorModel>.Empty,
+            ReferencedAssemblyName = null,
+            DiscoveryKeys = GetDiscoveryKeys(symbol),
+        };
+    }
+
+    /// <summary>
+    ///     Whether the type — or its containing assembly — opts out of discovery via
+    ///     <c>[ExcludeFromDiscovery]</c>. Excluded types produce no registration and no
+    ///     diagnostics: the exclusion is deliberate, unlike an inaccessible type.
+    /// </summary>
+    private static bool IsExcludedFromDiscovery(INamedTypeSymbol symbol)
+        => HasExcludeFromDiscovery(symbol.GetAttributes())
+           || HasExcludeFromDiscovery(symbol.ContainingAssembly.GetAttributes());
+
+    private static bool HasExcludeFromDiscovery(ImmutableArray<AttributeData> attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (attribute.AttributeClass is { Name: "ExcludeFromDiscoveryAttribute" } attributeClass
+                && IsInNamespace(attributeClass, AttributeNamespace))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     The type's effective discovery keys: its own <c>[DiscoveryKey]</c> keys when
+    ///     declared, else its assembly's. Empty means default discovery (the implicit
+    ///     empty-string key) — mirroring the runtime <c>Discovery</c> helper.
+    /// </summary>
+    private static ImmutableArray<string> GetDiscoveryKeys(INamedTypeSymbol symbol)
+    {
+        var keys = GetDeclaredDiscoveryKeys(symbol.GetAttributes());
+
+        return keys.IsEmpty ? GetDeclaredDiscoveryKeys(symbol.ContainingAssembly.GetAttributes()) : keys;
+    }
+
+    private static ImmutableArray<string> GetDeclaredDiscoveryKeys(ImmutableArray<AttributeData> attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (attribute.AttributeClass is not { Name: "DiscoveryKeyAttribute" } attributeClass
+                || !IsInNamespace(attributeClass, AttributeNamespace)
+                || attribute.ConstructorArguments.Length != 1)
+            {
+                continue;
+            }
+
+            var values = attribute.ConstructorArguments[0].Values;
+
+            if (values.IsDefaultOrEmpty)
+            {
+                return ImmutableArray<string>.Empty;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<string>(values.Length);
+
+            foreach (var value in values)
+            {
+                if (value.Value is string key)
+                {
+                    builder.Add(key);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        return ImmutableArray<string>.Empty;
+    }
+
+    /// <summary>
+    ///     Determines which module markers (<c>ICommand</c>, <c>IQuery</c>, <c>IEvent</c>)
+    ///     the type is assignable to. Handlers and interceptors inherit the marker through
+    ///     their contract interfaces, so a single check covers messages, handlers and
+    ///     interceptors alike.
+    /// </summary>
+    private static void GetMarkers(INamedTypeSymbol symbol, out bool isCommand, out bool isQuery, out bool isEvent)
+    {
+        isCommand = false;
+        isQuery = false;
+        isEvent = false;
 
         foreach (var iface in symbol.AllInterfaces)
         {
@@ -131,13 +269,145 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                     break;
             }
         }
+    }
+
+    /// <summary>
+    ///     Discovers registrable marker types in the compilation's referenced assemblies,
+    ///     replacing cross-assembly <c>RegisterFromAssembly</c> calls. Only assemblies that
+    ///     themselves reference an Ergosfare assembly can contain marker types, so
+    ///     everything else is skipped on a metadata-name check without realizing any of its
+    ///     types; Ergosfare's own assemblies are excluded because their handler contract
+    ///     interfaces inherit the module markers and must not be registered as user types.
+    /// </summary>
+    private static ImmutableArray<RegistrableTypeModel> ScanReferencedAssemblies(
+        Compilation compilation,
+        CancellationToken ct)
+    {
+        ImmutableArray<RegistrableTypeModel>.Builder? results = null;
+
+        foreach (var assembly in compilation.SourceModule.ReferencedAssemblySymbols)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (IsErgosfareAssemblyName(assembly.Name) || !ReferencesErgosfare(assembly))
+            {
+                continue;
+            }
+
+            // A library can opt out of discovery wholesale.
+            if (HasExcludeFromDiscovery(assembly.GetAttributes()))
+            {
+                continue;
+            }
+
+            var givesAccess = assembly.GivesAccessTo(compilation.Assembly);
+
+            CollectNamespaceTypes(assembly.GlobalNamespace, assembly.Name, givesAccess, ref results, ct);
+        }
+
+        return results?.ToImmutable() ?? ImmutableArray<RegistrableTypeModel>.Empty;
+    }
+
+    /// <summary>
+    ///     Whether the assembly name is Ergosfare's own (<c>Stella.Ergosfare</c> or a
+    ///     dotted child of it).
+    /// </summary>
+    private static bool IsErgosfareAssemblyName(string name)
+        => name.StartsWith(ErgosfareAssemblyNamePrefix, StringComparison.Ordinal)
+           && (name.Length == ErgosfareAssemblyNamePrefix.Length
+               || name[ErgosfareAssemblyNamePrefix.Length] == '.');
+
+    /// <summary>
+    ///     Whether the assembly's metadata records a reference to any Ergosfare assembly —
+    ///     a pure name check over the assembly-reference table, no symbol realization.
+    /// </summary>
+    private static bool ReferencesErgosfare(IAssemblySymbol assembly)
+    {
+        foreach (var module in assembly.Modules)
+        {
+            foreach (var reference in module.ReferencedAssemblies)
+            {
+                if (IsErgosfareAssemblyName(reference.Name))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void CollectNamespaceTypes(
+        INamespaceSymbol ns,
+        string assemblyName,
+        bool givesAccess,
+        ref ImmutableArray<RegistrableTypeModel>.Builder? results,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        foreach (var member in ns.GetMembers())
+        {
+            if (member is INamespaceSymbol nestedNamespace)
+            {
+                CollectNamespaceTypes(nestedNamespace, assemblyName, givesAccess, ref results, ct);
+            }
+            else if (member is INamedTypeSymbol type)
+            {
+                CollectTypeAndNested(type, assemblyName, givesAccess, ref results);
+            }
+        }
+    }
+
+    private static void CollectTypeAndNested(
+        INamedTypeSymbol type,
+        string assemblyName,
+        bool givesAccess,
+        ref ImmutableArray<RegistrableTypeModel>.Builder? results)
+    {
+        if (TryCreateReferencedModel(type, assemblyName, givesAccess) is { } model)
+        {
+            (results ??= ImmutableArray.CreateBuilder<RegistrableTypeModel>()).Add(model);
+        }
+
+        foreach (var nested in type.GetTypeMembers())
+        {
+            CollectTypeAndNested(nested, assemblyName, givesAccess, ref results);
+        }
+    }
+
+    /// <summary>
+    ///     Projects a metadata type from a referenced assembly to its registration model,
+    ///     or <c>null</c> when it carries no Ergosfare marker. Mirrors
+    ///     <see cref="Transform"/>; descriptor computation is shared because both operate
+    ///     on <see cref="INamedTypeSymbol"/>. Types the generated code cannot name —
+    ///     internal without an <c>InternalsVisibleTo</c> grant, protected or private
+    ///     nested, or compiler-mangled (file-local) — flow through as inaccessible and
+    ///     surface as ERGOSG002.
+    /// </summary>
+    private static RegistrableTypeModel? TryCreateReferencedModel(
+        INamedTypeSymbol symbol,
+        string assemblyName,
+        bool givesAccess)
+    {
+        if (symbol.IsStatic || symbol.IsImplicitlyDeclared)
+        {
+            return null;
+        }
+
+        GetMarkers(symbol, out var isCommand, out var isQuery, out var isEvent);
 
         if (!isCommand && !isQuery && !isEvent)
         {
             return null;
         }
 
-        var isAccessible = IsAccessibleFromGeneratedCode(symbol);
+        if (IsExcludedFromDiscovery(symbol))
+        {
+            return null;
+        }
+
+        var isAccessible = IsVisibleToCompilation(symbol, givesAccess) && HasSpellableName(symbol);
 
         return new RegistrableTypeModel
         {
@@ -147,39 +417,76 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsQuery = isQuery,
             IsEvent = isEvent,
             IsAccessible = isAccessible,
-            Location = isAccessible ? null : LocationInfo.From(symbol),
+            Location = null,
             Weight = GetWeight(symbol),
             GroupsExpression = GetGroupsExpression(symbol),
             Descriptors = isAccessible ? BuildDescriptors(symbol) : ImmutableArray<DescriptorModel>.Empty,
+            ReferencedAssemblyName = assemblyName,
+            DiscoveryKeys = GetDiscoveryKeys(symbol),
         };
+    }
+
+    /// <summary>
+    ///     Whether generated code in the current compilation can name a type declared in a
+    ///     referenced assembly: every level of the containing-type chain must be public, or
+    ///     internal with the assembly granting this compilation
+    ///     <c>InternalsVisibleTo</c> access.
+    /// </summary>
+    private static bool IsVisibleToCompilation(INamedTypeSymbol symbol, bool givesAccess)
+    {
+        for (var current = symbol; current is not null; current = current.ContainingType)
+        {
+            switch (current.DeclaredAccessibility)
+            {
+                case Accessibility.Public:
+                    break;
+                case Accessibility.Internal:
+                case Accessibility.ProtectedOrInternal:
+                    if (!givesAccess)
+                    {
+                        return false;
+                    }
+
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Whether the type's full containing chain uses names spellable in C# source.
+    ///     File-local types survive into metadata as internal types with compiler-mangled
+    ///     names (<c>&lt;File&gt;F...__Type</c>) that a <c>typeof</c> cannot express.
+    /// </summary>
+    private static bool HasSpellableName(INamedTypeSymbol symbol)
+    {
+        for (var current = symbol; current is not null; current = current.ContainingType)
+        {
+            if (!SyntaxFacts.IsValidIdentifier(current.Name))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void Execute(
         SourceProductionContext context,
-        ImmutableArray<RegistrableTypeModel> models,
-        ModuleBuilderAvailability availability)
+        ImmutableArray<RegistrableTypeModel> sourceModels,
+        ModuleBuilderAvailability availability,
+        ImmutableArray<RegistrableTypeModel> referencedModels)
     {
         var seen = new HashSet<string>();
         var types = new List<RegistrableTypeModel>();
 
-        foreach (var model in models)
-        {
-            if (!seen.Add(model.TypeofExpression))
-            {
-                continue;
-            }
-
-            if (!model.IsAccessible)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    GeneratorDiagnostics.InaccessibleRegistrableType,
-                    model.Location?.ToLocation(),
-                    model.DisplayName));
-                continue;
-            }
-
-            types.Add(model);
-        }
+        // Source-declared types first: on a (pathological) full-name collision with a
+        // referenced type, typeof in the generated file binds to the source declaration.
+        AddModels(context, sourceModels, seen, types);
+        AddModels(context, referencedModels, seen, types);
 
         if (types.Count == 0)
         {
@@ -191,6 +498,38 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
 
         var source = RegistrationEmitter.Emit(types, availability, GeneratorVersion);
         context.AddSource("ErgosfareRegistrations.g.cs", SourceText.From(source, Encoding.UTF8));
+    }
+
+    private static void AddModels(
+        SourceProductionContext context,
+        ImmutableArray<RegistrableTypeModel> models,
+        HashSet<string> seen,
+        List<RegistrableTypeModel> types)
+    {
+        foreach (var model in models)
+        {
+            if (!seen.Add(model.TypeofExpression))
+            {
+                continue;
+            }
+
+            if (!model.IsAccessible)
+            {
+                context.ReportDiagnostic(model.ReferencedAssemblyName is { } referencedAssembly
+                    ? Diagnostic.Create(
+                        GeneratorDiagnostics.InvisibleReferencedRegistrableType,
+                        location: null,
+                        model.DisplayName,
+                        referencedAssembly)
+                    : Diagnostic.Create(
+                        GeneratorDiagnostics.InaccessibleRegistrableType,
+                        model.Location?.ToLocation(),
+                        model.DisplayName));
+                continue;
+            }
+
+            types.Add(model);
+        }
     }
 
     /// <summary>

--- a/src/Stella.Ergosfare.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/GeneratorDiagnostics.cs
@@ -23,4 +23,22 @@ internal static class GeneratorDiagnostics
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    /// <summary>
+    ///     A marker type in a scanned referenced assembly cannot be named by generated
+    ///     code (internal without <c>InternalsVisibleTo</c>, protected/private nested, or
+    ///     compiler-mangled), so source-generated registration skipped it. The runtime
+    ///     scanning path (<c>RegisterFromAssembly</c>) sees such types through reflection,
+    ///     which makes the divergence worth a warning.
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvisibleReferencedRegistrableType = new(
+        id: "ERGOSG002",
+        title: "Registrable type in a referenced assembly is not visible to generated registration code",
+        messageFormat:
+            "Type '{0}' in referenced assembly '{1}' implements an Ergosfare marker interface but is not visible " +
+            "to this compilation, so source-generated registration skipped it. Grant this compilation access with " +
+            "[InternalsVisibleTo], register the type manually, or register that assembly at runtime with RegisterFromAssembly.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
 }

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -63,6 +63,20 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
     /// </summary>
     public required ImmutableArray<DescriptorModel> Descriptors { get; init; }
 
+    /// <summary>
+    ///     Name of the referenced assembly the type was discovered in, or <c>null</c> when
+    ///     the type is declared in the current compilation. Selects between the
+    ///     ERGOSG001 (source) and ERGOSG002 (reference) diagnostics for inaccessible types.
+    /// </summary>
+    public required string? ReferencedAssemblyName { get; init; }
+
+    /// <summary>
+    ///     The type's declared discovery keys (its own <c>[DiscoveryKey]</c>, else its
+    ///     assembly's). Empty means the type participates in default discovery under the
+    ///     implicit default key (the empty string).
+    /// </summary>
+    public required ImmutableArray<string> DiscoveryKeys { get; init; }
+
     public bool Equals(RegistrableTypeModel other)
     {
         if (TypeofExpression != other.TypeofExpression
@@ -74,7 +88,9 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
             || !Nullable.Equals(Location, other.Location)
             || Weight != other.Weight
             || GroupsExpression != other.GroupsExpression
-            || Descriptors.Length != other.Descriptors.Length)
+            || ReferencedAssemblyName != other.ReferencedAssemblyName
+            || Descriptors.Length != other.Descriptors.Length
+            || DiscoveryKeys.Length != other.DiscoveryKeys.Length)
         {
             return false;
         }
@@ -82,6 +98,14 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
         for (var i = 0; i < Descriptors.Length; i++)
         {
             if (!Descriptors[i].Equals(other.Descriptors[i]))
+            {
+                return false;
+            }
+        }
+
+        for (var i = 0; i < DiscoveryKeys.Length; i++)
+        {
+            if (!string.Equals(DiscoveryKeys[i], other.DiscoveryKeys[i], StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
 using Stella.Ergosfare.SourceGenerator.Models;
 
 namespace Stella.Ergosfare.SourceGenerator;
@@ -10,7 +11,12 @@ namespace Stella.Ergosfare.SourceGenerator;
 ///     inside the consumer's project under whatever language version they use.
 /// </summary>
 /// <remarks>
-///     Types with pre-computed descriptors register through
+///     Every registration surface comes in two overloads: the pattern-less form selects
+///     default discovery (types without a <c>[DiscoveryKey]</c>), while the pattern form
+///     cherry-picks keyed types (<c>RegisterGenerated("reporting.*")</c>). Types are
+///     emitted in clusters sharing the same discovery-key set, each guarded by a key-match
+///     check; the registry's idempotence makes overlapping selections across chained calls
+///     safe. Types with pre-computed descriptors register through
 ///     <c>HandlerDescriptors</c> + <c>RegisterDescriptors</c>, bypassing the reflection
 ///     based descriptor builders entirely; plain messages and open generic types fall back
 ///     to direct <c>typeof</c>-based <c>Register</c> calls, which also keep the
@@ -46,11 +52,12 @@ internal static class RegistrationEmitter
         sb.AppendLine("namespace Stella.Ergosfare.Generated");
         sb.AppendLine("{");
         sb.AppendLine("    /// <summary>");
-        sb.AppendLine("    ///     Ergosfare constructs (messages, handlers, interceptors) declared in this assembly,");
-        sb.AppendLine("    ///     discovered at compile time. Handler descriptors are pre-computed, so registration");
-        sb.AppendLine("    ///     performs no reflection over handler types; plain messages and open generic types");
-        sb.AppendLine("    ///     register through the runtime fallback. Trimmed/AOT builds stay warning-free:");
-        sb.AppendLine("    ///     every type is referenced statically via <c>typeof</c>.");
+        sb.AppendLine("    ///     Ergosfare constructs (messages, handlers, interceptors) discovered at compile");
+        sb.AppendLine("    ///     time in this compilation and its scanned references. Handler descriptors are");
+        sb.AppendLine("    ///     pre-computed, so registration performs no reflection over handler types; plain");
+        sb.AppendLine("    ///     messages and open generic types register through the runtime fallback.");
+        sb.AppendLine("    ///     Trimmed/AOT builds stay warning-free: every type is referenced statically via");
+        sb.AppendLine("    ///     <c>typeof</c>.");
         sb.AppendLine("    /// </summary>");
         sb.Append("    [global::System.CodeDom.Compiler.GeneratedCode(\"Stella.Ergosfare.SourceGenerator\", \"")
           .Append(generatorVersion)
@@ -62,46 +69,28 @@ internal static class RegistrationEmitter
 
         if (builders.HasMessageRegistry)
         {
-            EmitRegisterAll(sb, ref wroteMember, types, useDescriptors);
+            EmitRegistrySurface(sb, ref wroteMember, types, useDescriptors);
         }
 
         if (builders.HasCommandModuleBuilder)
         {
-            EmitBuilderExtension(sb, ref wroteMember, CommandBuilderFullName, "command", "CreateCommandDescriptors",
+            EmitBuilderSurface(sb, ref wroteMember, CommandBuilderFullName, "command",
                 Filter(types, static t => t.IsCommand), useDescriptors && builders.CommandBuilderHasRegisterDescriptors);
         }
 
         if (builders.HasQueryModuleBuilder)
         {
-            EmitBuilderExtension(sb, ref wroteMember, QueryBuilderFullName, "query", "CreateQueryDescriptors",
+            EmitBuilderSurface(sb, ref wroteMember, QueryBuilderFullName, "query",
                 Filter(types, static t => t.IsQuery), useDescriptors && builders.QueryBuilderHasRegisterDescriptors);
         }
 
         if (builders.HasEventModuleBuilder)
         {
-            EmitBuilderExtension(sb, ref wroteMember, EventBuilderFullName, "event", "CreateEventDescriptors",
+            EmitBuilderSurface(sb, ref wroteMember, EventBuilderFullName, "event",
                 Filter(types, static t => t.IsEvent), useDescriptors && builders.EventBuilderHasRegisterDescriptors);
         }
 
-        if (builders.HasMessageRegistry && useDescriptors && HasDescriptors(types))
-        {
-            EmitDescriptorFactory(sb, ref wroteMember, "CreateDescriptors", types);
-        }
-
-        if (builders.HasCommandModuleBuilder && useDescriptors && builders.CommandBuilderHasRegisterDescriptors)
-        {
-            EmitDescriptorFactoryIfAny(sb, ref wroteMember, "CreateCommandDescriptors", Filter(types, static t => t.IsCommand));
-        }
-
-        if (builders.HasQueryModuleBuilder && useDescriptors && builders.QueryBuilderHasRegisterDescriptors)
-        {
-            EmitDescriptorFactoryIfAny(sb, ref wroteMember, "CreateQueryDescriptors", Filter(types, static t => t.IsQuery));
-        }
-
-        if (builders.HasEventModuleBuilder && useDescriptors && builders.EventBuilderHasRegisterDescriptors)
-        {
-            EmitDescriptorFactoryIfAny(sb, ref wroteMember, "CreateEventDescriptors", Filter(types, static t => t.IsEvent));
-        }
+        EmitMatchesHelper(sb, ref wroteMember);
 
         sb.AppendLine("    }");
         sb.AppendLine("}");
@@ -139,7 +128,7 @@ internal static class RegistrationEmitter
         return false;
     }
 
-    private static void EmitRegisterAll(
+    private static void EmitRegistrySurface(
         StringBuilder sb,
         ref bool wroteMember,
         IReadOnlyList<RegistrableTypeModel> types,
@@ -147,98 +136,142 @@ internal static class RegistrationEmitter
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        /// <summary>");
-        sb.AppendLine("        ///     Registers every Ergosfare construct declared in this assembly into the given");
-        sb.AppendLine("        ///     registry, regardless of module.");
+        sb.AppendLine("        ///     Registers every discovered construct that participates in default discovery");
+        sb.AppendLine("        ///     (no <c>[DiscoveryKey]</c>) into the given registry, regardless of module.");
         sb.AppendLine("        /// </summary>");
         sb.Append("        public static void RegisterAll(").Append(RegistryFullName).AppendLine(" registry)");
         sb.AppendLine("        {");
+        sb.AppendLine("            RegisterAll(registry, \"\");");
+        sb.AppendLine("        }");
 
-        if (useDescriptors && HasDescriptors(types))
-        {
-            sb.AppendLine("            registry.RegisterDescriptors(CreateDescriptors());");
-        }
-
-        foreach (var type in types)
-        {
-            if (!useDescriptors || type.Descriptors.Length == 0)
-            {
-                sb.Append("            registry.Register(typeof(").Append(type.TypeofExpression).AppendLine("));");
-            }
-        }
-
+        StartMember(sb, ref wroteMember);
+        sb.AppendLine("        /// <summary>");
+        sb.AppendLine("        ///     Registers every discovered construct whose discovery keys match the given");
+        sb.AppendLine("        ///     pattern — an exact key or a trailing-<c>*</c> prefix glob — regardless of");
+        sb.AppendLine("        ///     module. Chained calls with overlapping patterns are safe: the registry is");
+        sb.AppendLine("        ///     idempotent per handler type.");
+        sb.AppendLine("        /// </summary>");
+        sb.Append("        public static void RegisterAll(").Append(RegistryFullName).AppendLine(" registry, string discoveryKeyPattern)");
+        sb.AppendLine("        {");
+        EmitKeyedBody(sb, types, useDescriptors, "registry");
         sb.AppendLine("        }");
     }
 
-    private static void EmitBuilderExtension(
+    private static void EmitBuilderSurface(
         StringBuilder sb,
         ref bool wroteMember,
         string builderFullName,
         string moduleName,
-        string factoryMethodName,
         List<RegistrableTypeModel> moduleTypes,
         bool useDescriptors)
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        /// <summary>");
-        sb.Append("        ///     Registers every ").Append(moduleName).AppendLine("-module construct declared in this");
-        sb.AppendLine("        ///     assembly. Drop-in replacement for <c>RegisterFromAssembly</c>.");
+        sb.Append("        ///     Registers every discovered ").Append(moduleName).AppendLine("-module construct that participates");
+        sb.AppendLine("        ///     in default discovery (no <c>[DiscoveryKey]</c>). Drop-in replacement for");
+        sb.AppendLine("        ///     <c>RegisterFromAssembly</c>.");
         sb.AppendLine("        /// </summary>");
         sb.Append("        public static ").Append(builderFullName).AppendLine(" RegisterGenerated(");
         sb.Append("            this ").Append(builderFullName).AppendLine(" builder)");
         sb.AppendLine("        {");
+        sb.AppendLine("            return RegisterGenerated(builder, \"\");");
+        sb.AppendLine("        }");
 
-        if (useDescriptors && HasDescriptors(moduleTypes))
-        {
-            sb.Append("            builder.RegisterDescriptors(").Append(factoryMethodName).AppendLine("());");
-        }
-
-        foreach (var type in moduleTypes)
-        {
-            if (!useDescriptors || type.Descriptors.Length == 0)
-            {
-                sb.Append("            builder.Register(typeof(").Append(type.TypeofExpression).AppendLine("));");
-            }
-        }
-
+        StartMember(sb, ref wroteMember);
+        sb.AppendLine("        /// <summary>");
+        sb.Append("        ///     Registers every discovered ").Append(moduleName).AppendLine("-module construct whose discovery");
+        sb.AppendLine("        ///     keys match the given pattern — an exact key or a trailing-<c>*</c> prefix");
+        sb.AppendLine("        ///     glob. Chain calls to compose selections; overlapping patterns are safe.");
+        sb.AppendLine("        /// </summary>");
+        sb.Append("        public static ").Append(builderFullName).AppendLine(" RegisterGenerated(");
+        sb.Append("            this ").Append(builderFullName).AppendLine(" builder, string discoveryKeyPattern)");
+        sb.AppendLine("        {");
+        EmitKeyedBody(sb, moduleTypes, useDescriptors, "builder");
         sb.AppendLine("            return builder;");
         sb.AppendLine("        }");
     }
 
-    private static void EmitDescriptorFactoryIfAny(
+    /// <summary>
+    ///     Emits the keyed registration body shared by the registry and builder surfaces:
+    ///     one guarded block per discovery-key cluster, adding descriptors to a local list
+    ///     (registered in one call at the end) and issuing runtime-fallback
+    ///     <c>Register(typeof)</c> calls inline.
+    /// </summary>
+    private static void EmitKeyedBody(
         StringBuilder sb,
-        ref bool wroteMember,
-        string methodName,
-        List<RegistrableTypeModel> types)
+        IReadOnlyList<RegistrableTypeModel> types,
+        bool useDescriptors,
+        string receiver)
     {
-        if (HasDescriptors(types))
+        var emitDescriptors = useDescriptors && HasDescriptors(types);
+
+        if (emitDescriptors)
         {
-            EmitDescriptorFactory(sb, ref wroteMember, methodName, types);
+            sb.Append("            var descriptors = new global::System.Collections.Generic.List<")
+              .Append(DescriptorFullName).AppendLine(">();");
+            sb.AppendLine();
         }
-    }
 
-    private static void EmitDescriptorFactory(
-        StringBuilder sb,
-        ref bool wroteMember,
-        string methodName,
-        IReadOnlyList<RegistrableTypeModel> types)
-    {
-        StartMember(sb, ref wroteMember);
-        sb.Append("        private static ").Append(DescriptorFullName).Append("[] ").Append(methodName).AppendLine("()");
-        sb.Append("            => new ").Append(DescriptorFullName).AppendLine("[]");
-        sb.AppendLine("            {");
+        var clusters = BuildClusters(types);
 
-        foreach (var type in types)
+        for (var i = 0; i < clusters.Count; i++)
         {
-            foreach (var descriptor in type.Descriptors)
+            var cluster = clusters[i];
+
+            if (i > 0)
             {
-                EmitDescriptorEntry(sb, type, descriptor);
+                sb.AppendLine();
             }
+
+            sb.Append("            if (");
+
+            for (var k = 0; k < cluster.Keys.Count; k++)
+            {
+                if (k > 0)
+                {
+                    sb.Append(" || ");
+                }
+
+                sb.Append("MatchesDiscoveryKey(")
+                  .Append(SymbolDisplay.FormatLiteral(cluster.Keys[k], quote: true))
+                  .Append(", discoveryKeyPattern)");
+            }
+
+            sb.AppendLine(")");
+            sb.AppendLine("            {");
+
+            foreach (var type in cluster.Types)
+            {
+                if (useDescriptors && type.Descriptors.Length > 0)
+                {
+                    foreach (var descriptor in type.Descriptors)
+                    {
+                        sb.Append("                descriptors.Add(");
+                        AppendDescriptorExpression(sb, type, descriptor);
+                        sb.AppendLine(");");
+                    }
+                }
+                else
+                {
+                    sb.Append("                ").Append(receiver)
+                      .Append(".Register(typeof(").Append(type.TypeofExpression).AppendLine("));");
+                }
+            }
+
+            sb.AppendLine("            }");
         }
 
-        sb.AppendLine("            };");
+        if (emitDescriptors)
+        {
+            sb.AppendLine();
+            sb.AppendLine("            if (descriptors.Count > 0)");
+            sb.AppendLine("            {");
+            sb.Append("                ").Append(receiver).AppendLine(".RegisterDescriptors(descriptors);");
+            sb.AppendLine("            }");
+        }
     }
 
-    private static void EmitDescriptorEntry(StringBuilder sb, in RegistrableTypeModel type, in DescriptorModel descriptor)
+    private static void AppendDescriptorExpression(StringBuilder sb, in RegistrableTypeModel type, in DescriptorModel descriptor)
     {
         var factoryMethod = descriptor.Kind switch
         {
@@ -250,7 +283,7 @@ internal static class RegistrationEmitter
             _ => "Handler",
         };
 
-        sb.Append("                ").Append(FactoryFullName).Append('.').Append(factoryMethod)
+        sb.Append(FactoryFullName).Append('.').Append(factoryMethod)
           .Append("(typeof(").Append(descriptor.MessageTypeExpression).Append(')');
 
         if (descriptor.ResultTypeExpression is not null)
@@ -272,7 +305,100 @@ internal static class RegistrationEmitter
             sb.Append(", ").Append(type.GroupsExpression);
         }
 
-        sb.AppendLine("),");
+        sb.Append(')');
+    }
+
+    private static void EmitMatchesHelper(StringBuilder sb, ref bool wroteMember)
+    {
+        StartMember(sb, ref wroteMember);
+        sb.AppendLine("        /// <summary>");
+        sb.AppendLine("        ///     Whether a discovery key matches a pattern: ordinal equality, or — when the");
+        sb.AppendLine("        ///     pattern ends with <c>*</c> — an ordinal prefix match on the part before the");
+        sb.AppendLine("        ///     star. Mirrors the runtime <c>Discovery</c> helper.");
+        sb.AppendLine("        /// </summary>");
+        sb.AppendLine("        private static bool MatchesDiscoveryKey(string key, string discoveryKeyPattern)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            if (discoveryKeyPattern.Length > 0 && discoveryKeyPattern[discoveryKeyPattern.Length - 1] == '*')");
+        sb.AppendLine("            {");
+        sb.AppendLine("                return key.Length >= discoveryKeyPattern.Length - 1");
+        sb.AppendLine("                    && string.CompareOrdinal(key, 0, discoveryKeyPattern, 0, discoveryKeyPattern.Length - 1) == 0;");
+        sb.AppendLine("            }");
+        sb.AppendLine();
+        sb.AppendLine("            return string.Equals(key, discoveryKeyPattern, global::System.StringComparison.Ordinal);");
+        sb.AppendLine("        }");
+    }
+
+    /// <summary>
+    ///     A group of types sharing the same effective discovery-key set, emitted under a
+    ///     single key-match guard. Untagged types form the default cluster (the implicit
+    ///     empty-string key), which sorts first.
+    /// </summary>
+    private sealed class Cluster
+    {
+        public Cluster(string signature, List<string> keys)
+        {
+            Signature = signature;
+            Keys = keys;
+        }
+
+        public string Signature { get; }
+
+        public List<string> Keys { get; }
+
+        public List<RegistrableTypeModel> Types { get; } = [];
+    }
+
+    private static List<Cluster> BuildClusters(IReadOnlyList<RegistrableTypeModel> types)
+    {
+        var bySignature = new Dictionary<string, Cluster>(System.StringComparer.Ordinal);
+        var clusters = new List<Cluster>();
+
+        foreach (var type in types)
+        {
+            var keys = EffectiveKeys(type);
+            var signature = string.Join("\u001f", keys);
+
+            if (!bySignature.TryGetValue(signature, out var cluster))
+            {
+                cluster = new Cluster(signature, keys);
+                bySignature.Add(signature, cluster);
+                clusters.Add(cluster);
+            }
+
+            cluster.Types.Add(type);
+        }
+
+        // Deterministic block order; the default cluster's empty signature sorts first.
+        clusters.Sort(static (x, y) => string.CompareOrdinal(x.Signature, y.Signature));
+
+        return clusters;
+    }
+
+    /// <summary>
+    ///     The type's effective discovery keys for emission: the implicit default key when
+    ///     it declares none, else its declared keys sorted and deduplicated so equivalent
+    ///     declarations cluster together.
+    /// </summary>
+    private static List<string> EffectiveKeys(in RegistrableTypeModel type)
+    {
+        if (type.DiscoveryKeys.IsEmpty)
+        {
+            return [""];
+        }
+
+        var keys = new List<string>(type.DiscoveryKeys.Length);
+
+        foreach (var key in type.DiscoveryKeys)
+        {
+            if (!keys.Contains(key))
+            {
+                keys.Add(key);
+            }
+        }
+
+        keys.Sort(static (x, y) => string.CompareOrdinal(x, y));
+
+        return keys;
     }
 
     private static void StartMember(StringBuilder sb, ref bool wroteMember)

--- a/src/Stella.Ergosfare.SourceGenerator/Stella.Ergosfare.SourceGenerator.csproj
+++ b/src/Stella.Ergosfare.SourceGenerator/Stella.Ergosfare.SourceGenerator.csproj
@@ -33,5 +33,10 @@
 
     <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+
+        <!-- NuGet auto-imports build/<PackageId>.props into consuming projects; it makes
+             the ErgosfareSourceGeneratorScanReferences MSBuild property visible to the
+             generator as a build_property analyzer-config key. -->
+        <None Include="build\Stella.Ergosfare.SourceGenerator.props" Pack="true" PackagePath="build" />
     </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.SourceGenerator/build/Stella.Ergosfare.SourceGenerator.props
+++ b/src/Stella.Ergosfare.SourceGenerator/build/Stella.Ergosfare.SourceGenerator.props
@@ -1,0 +1,12 @@
+<Project>
+    <!-- Surfaces the reference-scanning opt-out to the source generator. Scanning is on
+         by default (the generator treats an absent value as enabled); set
+
+             <ErgosfareSourceGeneratorScanReferences>false</ErgosfareSourceGeneratorScanReferences>
+
+         in a project to restrict source-generated registration to types declared in that
+         project. -->
+    <ItemGroup>
+        <CompilerVisibleProperty Include="ErgosfareSourceGeneratorScanReferences" />
+    </ItemGroup>
+</Project>

--- a/test/Stella.Ergosfare.Command.Test/CommandModuleBuilderDiscoveryTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandModuleBuilderDiscoveryTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using Stella.Ergosfare.Command.Test.__stubs__;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Reflection-based assembly scanning honors the discovery attributes exactly like
+/// source-generated registration: <see cref="ExcludeFromDiscoveryAttribute"/> removes a
+/// type from scanning entirely, and <see cref="DiscoveryKeyAttribute"/> gates it behind a
+/// key pattern.
+/// </summary>
+public class CommandModuleBuilderDiscoveryTests
+{
+    [ExcludeFromDiscovery]
+    public sealed record ExcludedStubCommand : ICommand;
+
+    [DiscoveryKey("discovery-tests.keyed")]
+    public sealed record KeyedStubCommand : ICommand;
+
+    private sealed class RecordingRegistry : IMessageRegistry
+    {
+        public List<Type> Registered { get; } = [];
+
+        public int Count => 0;
+
+        public IEnumerator<IMessageDescriptor> GetEnumerator()
+        {
+            yield break;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Register(Type type) => Registered.Add(type);
+
+        public void RegisterDescriptors(IEnumerable<IHandlerDescriptor> descriptors)
+        {
+        }
+    }
+
+    [Fact]
+    public void RegisterFromAssembly_SkipsExcludedAndKeyedTypes()
+    {
+        var registry = new RecordingRegistry();
+
+        new CommandModuleBuilder(registry).RegisterFromAssembly(Assembly.GetExecutingAssembly());
+
+        Assert.Contains(typeof(StubNonGenericCommand), registry.Registered);
+        Assert.DoesNotContain(typeof(ExcludedStubCommand), registry.Registered);
+        Assert.DoesNotContain(typeof(KeyedStubCommand), registry.Registered);
+    }
+
+    [Fact]
+    public void RegisterFromAssembly_WithPattern_SelectsKeyedTypesOnly()
+    {
+        var registry = new RecordingRegistry();
+
+        new CommandModuleBuilder(registry).RegisterFromAssembly(
+            Assembly.GetExecutingAssembly(), "discovery-tests.*");
+
+        Assert.Equal([typeof(KeyedStubCommand)], registry.Registered);
+    }
+
+    [Fact]
+    public void RegisterFromAssembly_ExcludedTypeIsSkippedEvenByMatchingPattern()
+    {
+        var registry = new RecordingRegistry();
+
+        new CommandModuleBuilder(registry).RegisterFromAssembly(Assembly.GetExecutingAssembly(), "*");
+
+        Assert.DoesNotContain(typeof(ExcludedStubCommand), registry.Registered);
+        Assert.Contains(typeof(KeyedStubCommand), registry.Registered);
+        Assert.Contains(typeof(StubNonGenericCommand), registry.Registered);
+    }
+}

--- a/test/Stella.Ergosfare.Core.Test/DiscoveryTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/DiscoveryTests.cs
@@ -1,0 +1,77 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Core.Test;
+
+/// <summary>
+/// Unit tests for the runtime <see cref="Discovery"/> helper — the single source of truth
+/// for how the discovery attributes and key patterns compose on the reflection paths.
+/// </summary>
+public class DiscoveryTests
+{
+    private sealed class Untagged;
+
+    [DiscoveryKey("reporting.daily", "audit")]
+    private sealed class Keyed;
+
+    [DiscoveryKey("", "debug")]
+    private sealed class KeyedWithDefault;
+
+    [ExcludeFromDiscovery]
+    private sealed class Excluded;
+
+    [Theory]
+    [InlineData("", "", true)]
+    [InlineData("a", "", false)]
+    [InlineData("", "a", false)]
+    [InlineData("a", "a", true)]
+    [InlineData("a", "A", false)]
+    [InlineData("abc", "a*", true)]
+    [InlineData("a", "a*", true)]
+    [InlineData("b", "a*", false)]
+    [InlineData("", "*", true)]
+    [InlineData("anything", "*", true)]
+    [InlineData("reporting.daily", "reporting.*", true)]
+    [InlineData("reporting", "reporting.*", false)]
+    public void MatchesKey_AppliesExactOrPrefixSemantics(string key, string pattern, bool expected)
+        => Assert.Equal(expected, Discovery.MatchesKey(key, pattern));
+
+    [Fact]
+    public void GetKeys_UntaggedTypeCarriesTheDefaultKey()
+        => Assert.Equal([DiscoveryKeyAttribute.DefaultKey], Discovery.GetKeys(typeof(Untagged)));
+
+    [Fact]
+    public void GetKeys_TaggedTypeCarriesItsDeclaredKeys()
+        => Assert.Equal(["reporting.daily", "audit"], Discovery.GetKeys(typeof(Keyed)));
+
+    [Fact]
+    public void Matches_UntaggedType_MatchesDefaultAndStarOnly()
+    {
+        Assert.True(Discovery.Matches(typeof(Untagged), ""));
+        Assert.True(Discovery.Matches(typeof(Untagged), "*"));
+        Assert.False(Discovery.Matches(typeof(Untagged), "reporting"));
+    }
+
+    [Fact]
+    public void Matches_KeyedType_IsGatedOutOfDefaultDiscovery()
+    {
+        Assert.False(Discovery.Matches(typeof(Keyed), ""));
+        Assert.True(Discovery.Matches(typeof(Keyed), "audit"));
+        Assert.True(Discovery.Matches(typeof(Keyed), "reporting.*"));
+        Assert.True(Discovery.Matches(typeof(Keyed), "*"));
+    }
+
+    [Fact]
+    public void Matches_EmptyStringKey_KeepsTypeInDefaultDiscovery()
+    {
+        Assert.True(Discovery.Matches(typeof(KeyedWithDefault), ""));
+        Assert.True(Discovery.Matches(typeof(KeyedWithDefault), "debug"));
+    }
+
+    [Fact]
+    public void Matches_ExcludedType_NeverMatches()
+    {
+        Assert.True(Discovery.IsExcluded(typeof(Excluded)));
+        Assert.False(Discovery.Matches(typeof(Excluded), ""));
+        Assert.False(Discovery.Matches(typeof(Excluded), "*"));
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/DiscoveryKeyTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/DiscoveryKeyTests.cs
@@ -1,0 +1,305 @@
+using System.Reflection;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+///     Discovery attributes in generated registration: <c>[DiscoveryKey]</c> gates types
+///     behind key patterns, <c>[ExcludeFromDiscovery]</c> removes them from discovery
+///     entirely. Semantics are asserted by executing the emitted <c>RegisterAll</c>
+///     overloads against a recording registry.
+/// </summary>
+public class DiscoveryKeyTests
+{
+    private const string RecordingRegistrySource = """
+
+        namespace TestApp
+        {
+            public sealed class RecordingRegistry : Stella.Ergosfare.Core.Abstractions.Registry.IMessageRegistry
+            {
+                public System.Collections.Generic.List<System.Type> Registered { get; } = new();
+
+                public System.Collections.Generic.List<Stella.Ergosfare.Core.Abstractions.Registry.Descriptors.IHandlerDescriptor> Descriptors { get; } = new();
+
+                public int Count => 0;
+
+                public System.Collections.Generic.IEnumerator<Stella.Ergosfare.Core.Abstractions.Registry.Descriptors.IMessageDescriptor> GetEnumerator()
+                {
+                    yield break;
+                }
+
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+                public void Register(System.Type type) => Registered.Add(type);
+
+                public void RegisterDescriptors(System.Collections.Generic.IEnumerable<Stella.Ergosfare.Core.Abstractions.Registry.Descriptors.IHandlerDescriptor> descriptors)
+                {
+                    Descriptors.AddRange(descriptors);
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    ///     Emits and loads a generator run's output once, then executes the generated
+    ///     <c>RegisterAll</c> overloads against fresh recording registries.
+    /// </summary>
+    private sealed class DiscoveryHarness
+    {
+        private readonly Assembly _assembly;
+        private readonly Type _registrations;
+        private readonly Type _recordingRegistry;
+
+        public DiscoveryHarness(GeneratorTestHost.GeneratorRunResult result)
+        {
+            Assert.Empty(result.CompilationErrors);
+
+            // Make sure the real abstractions assembly is loaded so the emitted assembly's
+            // references bind to it by name.
+            _ = typeof(IMessageRegistry);
+
+            using var stream = new MemoryStream();
+            var emitResult = result.OutputCompilation.Emit(stream);
+            Assert.True(emitResult.Success);
+
+            _assembly = Assembly.Load(stream.ToArray());
+            _registrations = _assembly.GetType("Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations", throwOnError: true)!;
+            _recordingRegistry = _assembly.GetType("TestApp.RecordingRegistry", throwOnError: true)!;
+        }
+
+        /// <summary>
+        ///     Runs <c>RegisterAll(registry)</c> (<paramref name="pattern"/> <c>null</c>) or
+        ///     <c>RegisterAll(registry, pattern)</c> and returns the simple names of the
+        ///     fallback-registered types and the descriptor handler types, combined.
+        /// </summary>
+        public IReadOnlyList<string> Run(string? pattern = null)
+        {
+            var registry = Activator.CreateInstance(_recordingRegistry)!;
+
+            if (pattern is null)
+            {
+                _registrations.GetMethod("RegisterAll", [typeof(IMessageRegistry)])!
+                    .Invoke(null, [registry]);
+            }
+            else
+            {
+                _registrations.GetMethod("RegisterAll", [typeof(IMessageRegistry), typeof(string)])!
+                    .Invoke(null, [registry, pattern]);
+            }
+
+            var names = ((List<Type>)_recordingRegistry.GetProperty("Registered")!.GetValue(registry)!)
+                .Select(type => type.Name)
+                .ToList();
+
+            names.AddRange(((List<IHandlerDescriptor>)_recordingRegistry.GetProperty("Descriptors")!.GetValue(registry)!)
+                .Select(descriptor => descriptor.HandlerType.Name));
+
+            return names;
+        }
+    }
+
+    [Fact]
+    public void KeyedTypes_AreGatedOutOfDefaultDiscovery_AndSelectedByKey()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+            namespace TestApp
+            {
+                public sealed record PlainCommand : ICommand;
+
+                [DiscoveryKey("reporting")]
+                public sealed record ReportCommand : ICommand;
+            }
+            """ + RecordingRegistrySource,
+            referenceModuleBuilders: false);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        var harness = new DiscoveryHarness(result);
+
+        Assert.Equal(["PlainCommand"], harness.Run());
+        Assert.Equal(["ReportCommand"], harness.Run("reporting"));
+        Assert.Equal(["PlainCommand", "ReportCommand"], harness.Run("*"));
+        Assert.Empty(harness.Run("other"));
+    }
+
+    [Fact]
+    public void PrefixGlob_SelectsKeysByPrefix()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+            namespace TestApp
+            {
+                [DiscoveryKey("reporting.daily")]
+                public sealed record DailyReport : ICommand;
+
+                [DiscoveryKey("reporting.monthly")]
+                public sealed record MonthlyReport : ICommand;
+
+                [DiscoveryKey("billing")]
+                public sealed record BillingRun : ICommand;
+            }
+            """ + RecordingRegistrySource,
+            referenceModuleBuilders: false);
+
+        var harness = new DiscoveryHarness(result);
+
+        Assert.Equal(["DailyReport", "MonthlyReport"], harness.Run("reporting.*"));
+        Assert.Empty(harness.Run());
+    }
+
+    [Fact]
+    public void EmptyStringKeyAlongsideOthers_KeepsTypeInDefaultDiscovery()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+            namespace TestApp
+            {
+                [DiscoveryKey("", "debug")]
+                public sealed record DebugCommand : ICommand;
+            }
+            """ + RecordingRegistrySource,
+            referenceModuleBuilders: false);
+
+        var harness = new DiscoveryHarness(result);
+
+        Assert.Equal(["DebugCommand"], harness.Run());
+        Assert.Equal(["DebugCommand"], harness.Run("debug"));
+    }
+
+    [Fact]
+    public void KeyedHandler_DescriptorsRegisterOnlyWhenSelected()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record Ping : ICommand;
+
+                [DiscoveryKey("reporting")]
+                public sealed class ReportingPingHandler : ICommandHandler<Ping>
+                {
+                    public ValueTask HandleAsync(Ping message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """ + RecordingRegistrySource,
+            referenceModuleBuilders: false);
+
+        var harness = new DiscoveryHarness(result);
+
+        // The keyed handler's pre-computed descriptor stays out of default discovery and
+        // arrives only when its key is selected.
+        Assert.Equal(["Ping"], harness.Run());
+        Assert.Equal(["ReportingPingHandler"], harness.Run("reporting"));
+    }
+
+    [Fact]
+    public void ExcludedType_ProducesNoRegistrationAndNoDiagnostics()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+            namespace TestApp
+            {
+                public sealed record PlainCommand : ICommand;
+
+                [ExcludeFromDiscovery]
+                public sealed record ManuallyWired : ICommand;
+            }
+            """ + RecordingRegistrySource,
+            referenceModuleBuilders: false);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.DoesNotContain("ManuallyWired", result.GeneratedSource);
+
+        var harness = new DiscoveryHarness(result);
+        Assert.Equal(["PlainCommand"], harness.Run("*"));
+    }
+
+    [Fact]
+    public void AssemblyLevelDiscoveryKey_GatesTheLibrarysUntaggedTypes()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+
+            namespace TestApp
+            {
+                public sealed record AppCommand : ICommand;
+            }
+            """ + RecordingRegistrySource,
+            libraries:
+            [
+                ("Ergosfare.TestLibrary.AssemblyKeyed", """
+                    using Stella.Ergosfare.Commands.Abstractions;
+                    using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+                    [assembly: DiscoveryKey("lib")]
+
+                    namespace TestLib
+                    {
+                        public sealed record LibCommand : ICommand;
+
+                        [DiscoveryKey("special")]
+                        public sealed record SpecialLibCommand : ICommand;
+                    }
+                    """),
+            ]);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        var harness = new DiscoveryHarness(result);
+
+        // The assembly-level key gates the library's untagged types; a type-level key
+        // overrides the assembly default.
+        Assert.Equal(["AppCommand"], harness.Run());
+        Assert.Equal(["LibCommand"], harness.Run("lib"));
+        Assert.Equal(["SpecialLibCommand"], harness.Run("special"));
+    }
+
+    [Fact]
+    public void ExcludedLibraryAssembly_IsNotScannedAtAll()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+
+            namespace TestApp
+            {
+                public sealed record AppCommand : ICommand;
+            }
+            """ + RecordingRegistrySource,
+            libraries:
+            [
+                ("Ergosfare.TestLibrary.Excluded", """
+                    using Stella.Ergosfare.Commands.Abstractions;
+                    using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+                    [assembly: ExcludeFromDiscovery]
+
+                    namespace TestLib
+                    {
+                        public sealed record LibCommand : ICommand;
+
+                        internal sealed record HiddenLibCommand : ICommand;
+                    }
+                    """),
+            ]);
+
+        // No registrations from the excluded assembly — and no ERGOSG002 for its
+        // internals either: the exclusion is deliberate.
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.DoesNotContain("LibCommand", result.GeneratedSource);
+
+        var harness = new DiscoveryHarness(result);
+        Assert.Equal(["AppCommand"], harness.Run("*"));
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/ErgosfareRegistrationGeneratorTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/ErgosfareRegistrationGeneratorTests.cs
@@ -343,7 +343,7 @@ public class ErgosfareRegistrationGeneratorTests
         var registrations = assembly.GetType("Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations", throwOnError: true)!;
         var registry = Activator.CreateInstance(assembly.GetType("TestApp.RecordingRegistry", throwOnError: true)!)!;
 
-        registrations.GetMethod("RegisterAll")!.Invoke(null, [registry]);
+        registrations.GetMethod("RegisterAll", [typeof(IMessageRegistry)])!.Invoke(null, [registry]);
 
         // Plain messages go through the runtime fallback...
         var registered = (List<Type>)registry.GetType().GetProperty("Registered")!.GetValue(registry)!;

--- a/test/Stella.Ergosfare.SourceGenerator.Test/GeneratorTestHost.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/GeneratorTestHost.cs
@@ -1,6 +1,10 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Stella.Ergosfare.SourceGenerator.Test;
 
@@ -16,6 +20,26 @@ internal static class GeneratorTestHost
 
     private static readonly Lazy<ImmutableArray<MetadataReference>> ReferencesWithoutModuleBuilders =
         new(() => LoadReferences(includeModuleBuilders: false));
+
+    private static readonly ConcurrentDictionary<string, byte[]> LibraryImages = new(StringComparer.Ordinal);
+
+    private static readonly ConcurrentDictionary<string, Assembly> LoadedLibraries = new(StringComparer.Ordinal);
+
+    static GeneratorTestHost()
+    {
+        // Tests that execute emitted output need the in-memory test libraries resolvable
+        // by name — the emitted app assembly references them like any project reference.
+        // Because loaded assemblies are cached by identity, a test that executes emitted
+        // code must give its library a name unique to that library's source.
+        AppDomain.CurrentDomain.AssemblyResolve += static (_, args) =>
+        {
+            var name = new AssemblyName(args.Name).Name;
+
+            return name is not null && LibraryImages.TryGetValue(name, out var image)
+                ? LoadedLibraries.GetOrAdd(name, static (_, bytes) => Assembly.Load(bytes), image)
+                : null;
+        };
+    }
 
     public sealed record GeneratorRunResult(
         Compilation OutputCompilation,
@@ -33,20 +57,96 @@ internal static class GeneratorTestHost
     /// <summary>
     ///     Runs the generator over <paramref name="source"/>. Set
     ///     <paramref name="referenceModuleBuilders"/> to <c>false</c> to simulate a project
-    ///     referencing only the abstractions packages (no DI module builders).
+    ///     referencing only the abstractions packages (no DI module builders). Each entry
+    ///     in <paramref name="libraries"/> is compiled to an in-memory metadata reference
+    ///     the app compilation references — the reference-scanning input. A non-null
+    ///     <paramref name="scanReferences"/> supplies the
+    ///     <c>ErgosfareSourceGeneratorScanReferences</c> build property.
     /// </summary>
-    public static GeneratorRunResult Run(string source, bool referenceModuleBuilders = true)
+    public static GeneratorRunResult Run(
+        string source,
+        bool referenceModuleBuilders = true,
+        IReadOnlyList<(string AssemblyName, string Source)>? libraries = null,
+        bool? scanReferences = null)
     {
+        var references = referenceModuleBuilders ? AllReferences.Value : ReferencesWithoutModuleBuilders.Value;
+
+        if (libraries is { Count: > 0 })
+        {
+            references = references.AddRange(libraries.Select(library =>
+                CompileLibrary(library.AssemblyName, library.Source, references)));
+        }
+
         var compilation = CSharpCompilation.Create(
             "Ergosfare.SourceGeneratorTestApp",
             [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest))],
-            referenceModuleBuilders ? AllReferences.Value : ReferencesWithoutModuleBuilders.Value,
+            references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ErgosfareRegistrationGenerator());
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new ErgosfareRegistrationGenerator().AsSourceGenerator()],
+            optionsProvider: scanReferences is null
+                ? null
+                : new TestAnalyzerConfigOptionsProvider(scanReferences.Value));
         driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
 
         return new GeneratorRunResult(outputCompilation, driver.GetRunResult(), diagnostics);
+    }
+
+    /// <summary>Compiles a library to an in-memory metadata reference.</summary>
+    private static MetadataReference CompileLibrary(
+        string assemblyName,
+        string source,
+        ImmutableArray<MetadataReference> references)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException(
+                $"Test library '{assemblyName}' failed to compile: " +
+                string.Join(Environment.NewLine, emitResult.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        }
+
+        var image = stream.ToArray();
+        LibraryImages[assemblyName] = image;
+
+        return MetadataReference.CreateFromImage(image);
+    }
+
+    /// <summary>
+    ///     Analyzer-config surface exposing only the reference-scanning build property, the
+    ///     way MSBuild's <c>CompilerVisibleProperty</c> plumbing would.
+    /// </summary>
+    private sealed class TestAnalyzerConfigOptionsProvider(bool scanReferences) : AnalyzerConfigOptionsProvider
+    {
+        public override AnalyzerConfigOptions GlobalOptions { get; } = new TestOptions(scanReferences);
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => GlobalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => GlobalOptions;
+
+        private sealed class TestOptions(bool scanReferences) : AnalyzerConfigOptions
+        {
+            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+            {
+                if (key == "build_property.ErgosfareSourceGeneratorScanReferences")
+                {
+                    value = scanReferences ? "true" : "false";
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+        }
     }
 
     private static ImmutableArray<MetadataReference> LoadReferences(bool includeModuleBuilders)

--- a/test/Stella.Ergosfare.SourceGenerator.Test/ReferenceScanningTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/ReferenceScanningTests.cs
@@ -1,0 +1,197 @@
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+///     Reference scanning: the consuming compilation's generator discovers marker types in
+///     referenced assemblies and registers them alongside the compilation's own — the
+///     compile-time replacement for cross-assembly <c>RegisterFromAssembly</c> calls.
+/// </summary>
+public class ReferenceScanningTests
+{
+    private const string LibrarySource = """
+        using Stella.Ergosfare.Commands.Abstractions;
+        using System.Threading.Tasks;
+
+        namespace TestLib
+        {
+            public sealed record LibPing : ICommand;
+
+            public sealed class LibPingHandler : ICommandHandler<LibPing>
+            {
+                public ValueTask HandleAsync(LibPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                    => default;
+            }
+        }
+        """;
+
+    private const string AppSource = """
+        using Stella.Ergosfare.Commands.Abstractions;
+
+        namespace TestApp
+        {
+            public sealed record AppPing : ICommand;
+        }
+        """;
+
+    [Fact]
+    public void PublicLibraryTypes_RegisterThroughTheConsumingCompilation()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries: [("Ergosfare.TestLibrary", LibrarySource)]);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+
+        var source = result.GeneratedSource;
+
+        // The library's plain message goes through the runtime fallback, its handler
+        // through a pre-computed descriptor — exactly like source-declared types.
+        Assert.Contains("registry.Register(typeof(global::TestLib.LibPing));", source);
+        Assert.Contains(
+            ".Handler(typeof(global::TestLib.LibPing), typeof(global::System.Threading.Tasks.ValueTask), typeof(global::TestLib.LibPingHandler))",
+            source);
+
+        // The compilation's own types are unaffected.
+        Assert.Contains("registry.Register(typeof(global::TestApp.AppPing));", source);
+    }
+
+    [Fact]
+    public void LibraryAttributes_FlowIntoDescriptorsFromMetadata()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries:
+            [
+                ("Ergosfare.TestLibrary", """
+                    using Stella.Ergosfare.Commands.Abstractions;
+                    using Stella.Ergosfare.Core.Abstractions.Attributes;
+                    using System.Threading.Tasks;
+
+                    namespace TestLib
+                    {
+                        public sealed record LibPing : ICommand;
+
+                        [Weight(7)]
+                        [Group("lib")]
+                        public sealed class LibAudit : ICommandPreInterceptor<LibPing>
+                        {
+                            public ValueTask<object> HandleAsync(LibPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                                => new(message);
+                        }
+                    }
+                    """),
+            ]);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            ".PreInterceptor(typeof(global::TestLib.LibPing), typeof(global::TestLib.LibAudit), 7u, new string[] { \"lib\" })",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void InternalLibraryType_WithoutIvt_IsSkippedWithErgosg002()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries:
+            [
+                ("Ergosfare.TestLibrary", """
+                    using Stella.Ergosfare.Commands.Abstractions;
+
+                    namespace TestLib
+                    {
+                        internal sealed record HiddenCommand : ICommand;
+                    }
+                    """),
+            ]);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("HiddenCommand", result.GeneratedSource);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics);
+        Assert.Equal("ERGOSG002", diagnostic.Id);
+        Assert.Contains("HiddenCommand", diagnostic.GetMessage());
+        Assert.Contains("Ergosfare.TestLibrary", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void InternalLibraryType_WithIvt_IsRegistered()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries:
+            [
+                ("Ergosfare.TestLibrary", """
+                    using Stella.Ergosfare.Commands.Abstractions;
+
+                    [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Ergosfare.SourceGeneratorTestApp")]
+
+                    namespace TestLib
+                    {
+                        internal sealed record SharedCommand : ICommand;
+                    }
+                    """),
+            ]);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains("registry.Register(typeof(global::TestLib.SharedCommand));", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ScanReferencesFalse_RestrictsRegistrationToTheCompilation()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries: [("Ergosfare.TestLibrary", LibrarySource)],
+            scanReferences: false);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("TestLib", result.GeneratedSource);
+        Assert.Contains("registry.Register(typeof(global::TestApp.AppPing));", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ScanReferencesTrue_MatchesTheDefault()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries: [("Ergosfare.TestLibrary", LibrarySource)],
+            scanReferences: true);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains("registry.Register(typeof(global::TestLib.LibPing));", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ErgosfareNamedAssemblies_AreNotScanned()
+    {
+        // Ergosfare's own assemblies are excluded by name: their handler contract
+        // interfaces inherit the module markers and must never register as user types.
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries: [("Stella.Ergosfare.FakeSatellite", LibrarySource)]);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("TestLib", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void LibraryTypes_AppearInTheirModulesBuilderExtension()
+    {
+        var result = GeneratorTestHost.Run(
+            AppSource,
+            libraries: [("Ergosfare.TestLibrary", LibrarySource)]);
+
+        var source = result.GeneratedSource;
+
+        // Once in RegisterAll, once in the command builder extension — the library's
+        // types are indistinguishable from the compilation's own in the emitted surface.
+        Assert.Contains("builder.Register(typeof(global::TestLib.LibPing));", source);
+        Assert.DoesNotContain("Register(typeof(global::TestLib.LibPingHandler))", source);
+    }
+}


### PR DESCRIPTION
## Summary

Two tightly-coupled features that together replace cross-assembly `RegisterFromAssembly` with compile-time discovery and give registration a cherry-picking model.

### Reference scanning
- The consuming project's generator now walks **referenced assemblies** for marker types and registers them through the app's generated code (descriptors included) — a library's handlers need no registration code in the library itself.
- Cheap filter: only assemblies whose metadata references an Ergosfare assembly are inspected; `Stella.Ergosfare[.*]`-named assemblies are excluded (their contract interfaces inherit the module markers).
- Visibility: public types always; internals when the library grants `InternalsVisibleTo` to the consuming assembly. Marker types the generated code cannot name surface as **ERGOSG002** instead of silently diverging from the runtime scan.
- Opt-out per project: `ErgosfareSourceGeneratorScanReferences=false` (`CompilerVisibleProperty` shipped via the package's `build/*.props`).

### Discovery keys
- `[DiscoveryKey("reporting")]` **gates** a type out of default discovery: `RegisterGenerated()` takes untagged types only; `RegisterGenerated("reporting.*")` cherry-picks by exact key or trailing-`*` prefix glob. Calls chain — registry idempotence makes overlapping selections safe.
- `[DiscoveryKey("", "debug")]` keeps a type in default discovery while also making it key-selectable; `[assembly: DiscoveryKey("lib")]` sets the default for a library's untagged types (type-level wins).
- `[ExcludeFromDiscovery]` (type or assembly) removes a type from discovery entirely — no registration, no diagnostics; explicit `Register<T>()` still works.
- **Runtime parity:** all four builders' `RegisterFromAssembly` honor both attributes via the shared `Discovery` helper and gain the same `(assembly, pattern)` overload. `RegisterFromAssembly` stays as the escape hatch for runtime-loaded plugins.
- Handlers stay non-partial: attribute metadata is read at compile time and baked into descriptor factory calls; discovery keys never reach the runtime registry — they live only in the generated key-cluster guards.

## Verification
- Full solution rebuild (`--no-incremental`): **0 warnings, 0 errors**; all tests green on net9.0 + net10.0 (SourceGenerator 27, Core 117, Command 18, remaining suites unchanged).
- New coverage: 8 reference-scanning tests, 7 discovery-key tests that **execute** the emitted `RegisterAll` overloads against a recording registry, runtime `Discovery` helper unit tests, and `RegisterFromAssembly` parity tests.
- E2E in the local Playground sandbox: nested class-lib handler registered purely via reference scanning; `[DiscoveryKey("greetings.premium")]` handler cherry-picked via chained `RegisterGenerated().RegisterGenerated("greetings.*")`; all endpoints dispatched correctly. ERGOSG002 verified in a real MSBuild build against an IVT-less internal type.
- `dotnet pack`: analyzer dll + `build/Stella.Ergosfare.SourceGenerator.props` land in the package as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
