### PR TITLE
feat: deliver the remaining discovery-line commits to preview

### DIFF
--- a/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptor[TCommand,TResult].cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptor[TCommand,TResult].cs
@@ -12,16 +12,17 @@ namespace Stella.Ergosfare.Commands.Abstractions;
 /// The command type being intercepted. Must implement <see cref="ICommand{TResult}"/>.
 /// </typeparam>
 /// <typeparam name="TResult">
-/// The result type of the command. Also the type returned by the interceptor — for a
+/// The result type of the command. Also, the type returned by the interceptor — for a
 /// narrower return type there is no third parameter anymore; return the base result type.
 /// </typeparam>
 /// <remarks>
-/// The type parameters are deliberately invariant: the pipeline invokes interceptors
-/// through the non-generic root interfaces, so interface variance bought nothing while
-/// forcing the result-returning member onto a separate three-parameter interface.
+/// <typeparamref name="TCommand"/> is contravariant, matching the core
+/// <see cref="IAsyncExceptionInterceptor{TMessage, TResult}"/> contract the typed dispatch
+/// matches against. <typeparamref name="TResult"/> must stay invariant: the typed member
+/// returns it.
 /// </remarks>
 // ReSharper disable once UnusedType.Global
-public interface ICommandExceptionInterceptor<TCommand, TResult> : ICommand, IAsyncExceptionInterceptor<TCommand, TResult>
+public interface ICommandExceptionInterceptor<in TCommand, TResult> : ICommand, IAsyncExceptionInterceptor<TCommand, TResult>
     where TCommand : ICommand<TResult>
     where TResult : notnull
 {

--- a/src/Stella.Ergosfare.Commands.Abstractions/PostInterceptors/ICommandPostInterceptor.cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/PostInterceptors/ICommandPostInterceptor.cs
@@ -2,15 +2,17 @@ using Stella.Ergosfare.Core.Abstractions.Handlers;
 
 namespace Stella.Ergosfare.Commands.Abstractions;
 
-
 /// <summary>
 /// Represents a post-processing interceptor for commands that executes after any <see cref="ICommand"/> is handled.
 /// </summary>
 /// <remarks>
 /// This interceptor is non-generic and non-type-safe. It can be registered to run for multiple command types
-/// without specifying a particular result type. The <see cref="HandleAsync"/> method returns <see cref="object"/>,
+/// without specifying a particular result type. The <see>
+///     <cref>HandleAsync</cref>
+/// </see>
+/// method returns <see cref="object"/>,
 /// so any result modifications are handled via object references and casting.
-///
+/// 
 /// For scenarios where type safety is required, use the generic version:
 /// <see cref="ICommandPostInterceptor{TCommand,TResult}"/>.
 /// </remarks>

--- a/src/Stella.Ergosfare.Commands.Abstractions/PostInterceptors/ICommandPostInterceptor[TCommand,TResult].cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/PostInterceptors/ICommandPostInterceptor[TCommand,TResult].cs
@@ -15,11 +15,12 @@ namespace Stella.Ergosfare.Commands.Abstractions;
 /// narrower return type there is no third parameter anymore; return the base result type.
 /// </typeparam>
 /// <remarks>
-/// The type parameters are deliberately invariant: the pipeline invokes interceptors
-/// through the non-generic root interfaces, so interface variance bought nothing while
-/// forcing the result-returning member onto a separate three-parameter interface.
+/// <typeparamref name="TCommand"/> is contravariant, matching the core
+/// <see cref="IAsyncPostInterceptor{TMessage, TResult}"/> contract the typed dispatch
+/// matches against. <typeparamref name="TResult"/> must stay invariant: the typed member
+/// returns it.
 /// </remarks>
-public interface ICommandPostInterceptor<TCommand, TResult> :
+public interface ICommandPostInterceptor<in TCommand, TResult> :
     ICommand,
     IAsyncPostInterceptor<TCommand, TResult>
     where TCommand : ICommand<TResult>
@@ -28,7 +29,7 @@ public interface ICommandPostInterceptor<TCommand, TResult> :
     /// <inheritdoc />
     async ValueTask<object> IAsyncPostInterceptor<TCommand, TResult>.HandleAsync(
         TCommand command, TResult messageResult, IExecutionContext context)
-        => (await HandleAsync(command, messageResult, context))!;
+        => (await HandleAsync(command, messageResult, context));
 
     /// <summary>
     /// Handles the post-processing of a command asynchronously.

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModuleBuilder.cs
@@ -27,7 +27,7 @@ public sealed class CommandModuleBuilder
     /// <summary>
     ///     Registers a command type for the message registry.
     /// </summary>
-    /// <typeparam name="T">The type of command to register, which must implement <see cref="IRegistrableCommandConstruct" />.</typeparam>
+    /// <typeparam name="T">The type of command to register, which must implement <see cref="ICommand" />.</typeparam>
     /// <returns>The current <see cref="CommandModuleBuilder" /> instance for method chaining.</returns>
     public CommandModuleBuilder Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ICommand
     {
@@ -38,7 +38,7 @@ public sealed class CommandModuleBuilder
     /// <summary>
     ///     Registers a command type for the message registry.
     /// </summary>
-    /// <param name="type">The type of command to register, which must implement <see cref="IRegistrableCommandConstruct" />.</param>
+    /// <param name="type">The type of command to register, which must implement <see cref="ICommand" />.</param>
     /// <returns>The current <see cref="CommandModuleBuilder" /> instance for method chaining.</returns>
     public CommandModuleBuilder Register([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/DiscoveryKeyAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/DiscoveryKeyAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Attributes;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/ExcludeFromDiscoveryAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/ExcludeFromDiscoveryAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Attributes;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/ExcludeFromPipelineAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/ExcludeFromPipelineAttribute.cs
@@ -1,0 +1,24 @@
+
+namespace Stella.Ergosfare.Core.Abstractions.Attributes;
+
+/// <summary>
+/// Excludes a message from covariantly matched interceptors: interceptors registered
+/// against a base type or interface of the message (e.g. an <c>IEvent</c>-wide
+/// pre-interceptor) no longer apply to it. Interceptors registered against the message
+/// type itself always run — they were written for this message deliberately.
+/// </summary>
+/// <remarks>
+/// Without arguments every covariantly matched interceptor is excluded; with group names
+/// only the covariant interceptors carrying one of those <see cref="GroupAttribute"/>
+/// groups are. Main handlers are never affected — the attribute shapes the interceptor
+/// pipeline, not dispatch itself.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false)]
+public sealed class ExcludeFromPipelineAttribute(params string[] groups) : Attribute
+{
+    /// <summary>
+    /// The interceptor groups excluded from covariant matching; empty to exclude every
+    /// covariantly matched interceptor.
+    /// </summary>
+    public string[] Groups => groups;
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/GroupAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/GroupAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Attributes;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/WeightAttribute.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/WeightAttribute.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Attributes;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Context/Abstractions/IExecutionContext.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Context/Abstractions/IExecutionContext.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/AdaptedException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/AdaptedException.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/ExecutionAbortedException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/ExecutionAbortedException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/ExecutionRetryRequestedException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/ExecutionRetryRequestedException.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/InvalidMessageTypeException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/InvalidMessageTypeException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/MultipleHandlerFoundException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/MultipleHandlerFoundException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/NoHandlerFoundException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/NoHandlerFoundException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Factories/IMessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Factories/IMessageDependenciesFactory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+﻿using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 namespace Stella.Ergosfare.Core.Abstractions.Factories;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage,TResult].cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IAsyncExceptionHandler[TMessage].cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler.cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionHandler[TMessage,TResult].cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/FinalInterceptor/IAsyncFinalInterceptor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/FinalInterceptor/IAsyncFinalInterceptor[TMessage,TResult].cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/FinalInterceptor/IAsyncFinalInterceptor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/FinalInterceptor/IAsyncFinalInterceptor[TMessage].cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/FinalInterceptor/IFinalInterceptor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/FinalInterceptor/IFinalInterceptor[TMessage,TResult].cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage,TResult].cs
@@ -1,5 +1,4 @@
-using System.Threading.Tasks;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IAsyncHandler[TMessage].cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
@@ -8,7 +7,9 @@ namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 /// </summary>
 /// <typeparam name="TMessage">The type of the message to handle. Must be non-nullable.</typeparam>
 /// <remarks>
-/// This interface extends the generic <see cref="IHandler{TMessage, TResult}"/> with <typeparamref name="TResult"/>
+/// This interface extends the generic <see cref="IHandler{TMessage, TResult}"/> with <typeparamref>
+///     <name>TResult</name>
+/// </typeparamref>
 /// set to <see cref="ValueTask"/>, enabling asynchronous message processing.
 /// Implementations that already hold a <see cref="Task"/> can wrap it allocation-free via
 /// <c>new ValueTask(task)</c>; async method bodies work unchanged.

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IStreamHandler[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/Main/IStreamHandler[TMessage,TResult].cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage,TResult].cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IAsyncPostInterceptor[TMessage].cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor.cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PostInterceptors/IPostInterceptor[TMessage,TResult].cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IAsyncPreInterceptor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IAsyncPreInterceptor[TMessage].cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor.cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/PreInterceptors/IPreInterceptor[TMessage].cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Handlers;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/IMessageMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IMessageMediationStrategy.cs
@@ -1,4 +1,5 @@
-﻿namespace Stella.Ergosfare.Core.Abstractions;
+﻿
+namespace Stella.Ergosfare.Core.Abstractions;
 
 /// <summary>
 ///     Defines a strategy for mediating messages of a specific type and producing results of a specific type.

--- a/src/Stella.Ergosfare.Core.Abstractions/IMessageMediator.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IMessageMediator.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions;
 
 
@@ -13,23 +10,25 @@ public interface IMessageMediator
 {
     /// <summary>
     /// Dispatches <paramref name="message"/> through the cached pipeline executor closed over
-    /// its runtime type. The handler is invoked through its typed member — no object-typed
-    /// bridge. Serves default-group dispatches; group-filtered dispatches go through
-    /// <see cref="Mediate{TMessage, TMessageResult}"/>.
+    /// its runtime type and the requested group set. The handler is invoked through its typed
+    /// member — no object-typed bridge.
     /// </summary>
     /// <param name="message">The message instance to dispatch.</param>
     /// <param name="items">Optional items exposed on the execution context.</param>
     /// <param name="cancellationToken">Cancellation token exposed on the execution context.</param>
+    /// <param name="groups">Pipeline groups to dispatch under; <c>null</c> selects the default group.</param>
     ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null);
 
     /// <summary>
     /// Dispatches <paramref name="message"/> through the cached result-producing pipeline
-    /// executor closed over its runtime type; see <see cref="DispatchAsync"/>.
+    /// executor closed over its runtime type and the requested group set; see
+    /// <see cref="DispatchAsync"/>.
     /// </summary>
     /// <typeparam name="TResult">The result type produced by the pipeline.</typeparam>
     /// <param name="message">The message instance to dispatch.</param>
     /// <param name="items">Optional items exposed on the execution context.</param>
     /// <param name="cancellationToken">Cancellation token exposed on the execution context.</param>
+    /// <param name="groups">Pipeline groups to dispatch under; <c>null</c> selects the default group.</param>
     ValueTask<TResult> DispatchAsync<TResult>(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null);
 
     

--- a/src/Stella.Ergosfare.Core.Abstractions/IMessageResolveStrategies.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IMessageResolveStrategies.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+﻿using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/IPipelineExecutor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IPipelineExecutor.cs
@@ -1,11 +1,9 @@
-using System;
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 
 /// <summary>
 /// A message pipeline closed over its concrete message type, built once per message type
-/// and cached process-wide. <see cref="Execute{TResult}"/> receives the message as
+/// and cached process-wide. <see cref="Execute"/> receives the message as
 /// <see cref="object"/> and performs a single cast to the concrete type internally, so the
 /// handler is always invoked through its typed member — no object-typed bridge, no boxing
 /// of the handler's <see cref="ValueTask"/>.

--- a/src/Stella.Ergosfare.Core.Abstractions/IResultAdapter.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IResultAdapter.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/IResultAdapterService.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IResultAdapterService.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/MediateOptions.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/MediateOptions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions;
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/HandlerDescriptors.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/HandlerDescriptors.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IFinalInterceptorDescriptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IFinalInterceptorDescriptor.cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IHandlerDescriptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IHandlerDescriptor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IHasMessageType.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IHasMessageType.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IHasResultType.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IHasResultType.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IMainHandlerDescriptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IMainHandlerDescriptor.cs
@@ -1,4 +1,5 @@
-﻿namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+﻿
+namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IMessageDescriptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IMessageDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-
+﻿
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 
@@ -24,6 +23,20 @@ public interface IMessageDescriptor: IHasMessageType
     /// Gets a value indicating whether the message type is generic.
     /// </summary>
     bool IsGeneric { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the message excludes every covariantly matched
+    /// (indirect) interceptor via a parameterless <c>[ExcludeFromPipeline]</c>.
+    /// Interceptors registered against the message type itself are unaffected.
+    /// </summary>
+    bool ExcludesIndirectInterceptors { get; }
+
+    /// <summary>
+    /// Gets the interceptor groups the message excludes from covariant matching via
+    /// <c>[ExcludeFromPipeline("group")]</c>; empty when the message declares no
+    /// group-scoped exclusion.
+    /// </summary>
+    IReadOnlyCollection<string> ExcludedInterceptorGroups { get; }
 
     /// <summary>
     /// Gets the main handlers for the message type.

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IPostInterceptorDescriptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IPostInterceptorDescriptor.cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IPreInterceptorDescriptor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/Descriptors/IPreInterceptorDescriptor.cs
@@ -1,3 +1,4 @@
+
 namespace Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/Registry/IMessageRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Registry/IMessageRegistry.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 namespace Stella.Ergosfare.Core.Abstractions.Registry;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/CompletedResultBox.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/CompletedResultBox.cs
@@ -1,0 +1,12 @@
+namespace Stella.Ergosfare.Core.Abstractions.Strategies;
+
+/// <summary>
+/// A completed <see cref="ValueTask"/> boxed once for the whole process and reused as the
+/// void pipelines' (meaningless) result object. The box is deliberate: the alternative is
+/// a boxing allocation on every dispatch — or, as a static field inside a generic
+/// strategy, one copy per closed message type.
+/// </summary>
+internal static class CompletedResultBox
+{
+    internal static readonly object Instance = ValueTask.CompletedTask;
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategy.cs
@@ -33,6 +33,7 @@ internal sealed class FinalInterceptorInvocationStrategy<TMessage, TResult>(
     {
         var interceptors = messageDependencies.FinalInterceptors;
 
+        // ReSharper disable once ForCanBeConvertedToForeach
         for (var i = 0; i < interceptors.Count; i++)
         {
             var interceptor = interceptors[i].Resolve(serviceProvider);

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PostInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PostInterceptorInvocationStrategy.cs
@@ -35,6 +35,7 @@ internal sealed class PostInterceptorInvocationStrategy<TMessage, TResult>(
     {
         var interceptors = messageDependencies.PostInterceptors;
 
+        // ReSharper disable once ForCanBeConvertedToForeach
         for (var i = 0; i < interceptors.Count; i++)
         {
             var interceptor = interceptors[i].Resolve(serviceProvider);

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PreInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PreInterceptorInvocationStrategy.cs
@@ -31,6 +31,7 @@ internal sealed class PreInterceptorInvocationStrategy<TMessage>(
         var interceptors = messageDependencies.PreInterceptors;
         object current = message;
 
+        // ReSharper disable once ForCanBeConvertedToForeach
         for (var i = 0; i < interceptors.Count; i++)
         {
             var interceptor = interceptors[i].Resolve(serviceProvider);

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.ExceptionServices;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
@@ -20,36 +17,36 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
 {
     
     /// <summary>
-    /// Mediates the message by invoking the handler along with pre-, post-, exception-, and final interceptors.
-    /// Supports checkpointing to skip already executed handlers, integrates snapshot results, 
-    /// and ensures proper execution sequencing for fire-and-forget or retryable pipelines.
+    /// Mediates the message by invoking the single registered handler along with the pre-,
+    /// post-, exception- and final-interceptor stages, applying optional result adaptation.
     /// </summary>
-    /// <param name="message">The message to be handled. This may be transformed by pre-interceptors.</param>
-    /// <param name="messageDependencies">The dependencies of the message, including registered handlers and interceptors.</param>
-    /// <param name="context">The current execution context containing checkpoints, snapshots, and pipeline state.</param>
+    /// <param name="message">The message to be handled. May be transformed by pre-interceptors.</param>
+    /// <param name="messageDependencies">The dependencies of the message, including the registered handler and interceptor stages.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>
-    /// A <see cref="ValueTask{TResult}"/> representing the asynchronous operation, returning the final result 
+    /// A <see cref="ValueTask{TResult}"/> representing the asynchronous operation, returning the final result
     /// after executing the handler and all applicable interceptors.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="messageDependencies"/> is null.</exception>
     /// <exception cref="MultipleHandlerFoundException">Thrown if more than one handler is registered for the message.</exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if the handler is null or not of the expected type, or if a result is missing after 
-    /// execution when the pipeline is aborted.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if no handler is registered for the message.</exception>
     /// <remarks>
     /// <para>The mediation process follows this sequence:</para>
     /// <list type="number">
-    /// <item>Invoke pre-interceptors via <see cref="PreInterceptorInvocationStrategy{TMessage}"/>. Each pre-interceptor
-    /// can transform the message, and results are checkpointed to allow skipping on retries.</item>
-    /// <item>Invoke the main handler. The result is checkpointed, and snapshots may be used to skip execution if already available.</item>
-    /// <item>Invoke post-interceptors via <see cref="PostInterceptorInvocationStrategy{TMessage, TResult}"/>. Post-interceptors always execute
-    /// and are not checkpointed.</item>
-    /// <item>If an exception occurs, invoke <see cref="ExceptionInterceptorInvocationStrategy{TMessage, TResult}"/> to allow exception handling
-    /// or transformation of the result.</item>
-    /// <item>Finally, invoke <see cref="FinalInterceptorInvocationStrategy{TMessage, TResult}"/> for cleanup or final actions,
-    /// which always execute regardless of prior success or failure.</item>
-    /// <item>Checkpoints and snapshots ensure that retries, partial execution, or snapshot-based replay work seamlessly.</item>
+    /// <item>With no interceptors registered, the handler is invoked directly on a fast path
+    /// and exceptions propagate unchanged.</item>
+    /// <item>Pre-interceptors run via <see cref="PreInterceptorInvocationStrategy{TMessage}"/>;
+    /// each may transform the message.</item>
+    /// <item>The main handler runs through its typed contract; the result adapter may surface
+    /// a failure carried inside the result as an exception.</item>
+    /// <item>Post-interceptors run via <see cref="PostInterceptorInvocationStrategy{TMessage, TResult}"/>
+    /// and may replace the result.</item>
+    /// <item>On exception, <see cref="ExceptionInterceptorInvocationStrategy{TMessage, TResult}"/> runs —
+    /// with no exception interceptors registered the exception propagates unchanged; an
+    /// <see cref="ExecutionAbortedException"/> aborts without error.</item>
+    /// <item><see cref="FinalInterceptorInvocationStrategy{TMessage, TResult}"/> always runs last,
+    /// regardless of success or failure.</item>
     /// </list>
     /// </remarks>
     public async ValueTask<TResult> Mediate(TMessage message, IMessageDependencies messageDependencies, IExecutionContext context, IServiceProvider serviceProvider)

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.ExceptionServices;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
@@ -23,29 +20,26 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
     IResultAdapterService? resultAdapterService) : IMessageMediationStrategy<TMessage, ValueTask> where TMessage : IMessage
 {
     /// <summary>
-    /// A completed <see cref="ValueTask"/> boxed once and reused as the void pipeline's
-    /// result object — boxing per dispatch would cost an allocation on the hot path.
-    /// </summary>
-    private static readonly object CompletedResultBox = ValueTask.CompletedTask;
-
-    /// <summary>
     ///     Mediates a message by executing the appropriate handler and orchestrating the handling pipeline.
     /// </summary>
     /// <param name="message">The message to be mediated.</param>
     /// <param name="messageDependencies">
-    ///     The dependencies required for message handling, including handlers, pre-handlers,
-    ///     post-handlers, and error handlers.
+    ///     The dependencies required for message handling, including the handler and the
+    ///     pre-, post-, exception- and final-interceptor stages.
     /// </param>
     /// <param name="context">
     ///     The context in which the mediation is executed, providing access to cancellation tokens,
     ///     shared data, and other execution-related information.
     /// </param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>A task representing the asynchronous mediation operation.</returns>
     /// <exception cref="MultipleHandlerFoundException">Thrown when more than one handler is found for the message type.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no handler is registered for the message type.</exception>
     /// <remarks>
-    ///     The mediation process includes executing pre-handlers, the main handler, and post-handlers in sequence.
-    ///     If an exception occurs during any stage, the appropriate error handlers are executed.
-    ///     If a <see cref="ExecutionAbortedException" /> is caught, the mediation process is aborted without error.
+    ///     Pre-interceptors, the main handler and post-interceptors run in sequence; with no
+    ///     interceptors registered the handler is invoked directly on a fast path. If an
+    ///     exception occurs, the exception interceptors run; final interceptors always run.
+    ///     An <see cref="ExecutionAbortedException" /> aborts the mediation without error.
     /// </remarks>
     public async ValueTask Mediate(TMessage message, IMessageDependencies messageDependencies, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -81,7 +75,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
 
             await InvokeHandler(fastHandler, message, context);
 
-            var fastEx = resultAdapterService?.LookupException(CompletedResultBox);
+            var fastEx = resultAdapterService?.LookupException(CompletedResultBox.Instance);
 
             if (fastEx != null)
             {
@@ -109,7 +103,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
             await InvokeHandler(handler, message, context);
             result = ValueTask.CompletedTask;
 
-            var ex = resultAdapterService?.LookupException(CompletedResultBox);
+            var ex = resultAdapterService?.LookupException(CompletedResultBox.Instance);
 
             if (ex != null)
             {

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.ExceptionServices;
-using System.Threading;
+﻿using System.Runtime.ExceptionServices;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
@@ -39,11 +35,13 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
     /// </summary>
     /// <param name="message">The message to be handled.</param>
     /// <param name="messageDependencies">The dependencies of the message, including the registered handlers and interceptors.</param>
-    /// <param name="executionContext">The current execution context.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>
     /// An <see cref="IAsyncEnumerable{TResult}"/> representing the asynchronous stream of results produced by the handler.
     /// </returns>
     /// <exception cref="MultipleHandlerFoundException">Thrown if more than one handler is registered for the message.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if no handler is registered for the message.</exception>
     public async IAsyncEnumerable<TResult> Mediate(TMessage message, IMessageDependencies messageDependencies,
         IExecutionContext context, IServiceProvider serviceProvider)
     {

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategy.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Threading;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ServiceCollectionExtensions.cs
@@ -35,7 +35,6 @@ public static class ServiceCollectionExtensions
     ///   <item><description>A singleton <see cref="IResultAdapterService"/> for result adaptation.</description></item>
     ///   <item><description>Transient factories and descriptor builders for message handling.</description></item>
     ///   <item><description>A singleton <see cref="IMessageRegistry"/> for message type discovery.</description></item>
-    ///   <item><description>A singleton event hub for publishing and subscribing to signals.</description></item>
     ///   <item><description>All module-defined handlers, interceptors, and services discovered at initialization.</description></item>
     /// </list>
     /// </para>
@@ -51,11 +50,8 @@ public static class ServiceCollectionExtensions
         var resultAdapterService = new ResultAdapterService();
         services.TryAddSingleton<IResultAdapterService>(resultAdapterService);
         services.TryAddTransient<HandlerDescriptorBuilderFactory>();
-        // Get the singleton registry instance
+        // The process-wide registry singleton, also registered into DI for direct resolution.
         var messageRegistry = MessageRegistryAccessor.Instance;
-
-        // Get the singleton event-hub instance
-        // Register it as a singleton in DI
         services.TryAddSingleton(messageRegistry);
 
         // Create module registry with the shared message registry

--- a/src/Stella.Ergosfare.Core/Internal/Builders/ExceptionInterceptorBuilder.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Builders/ExceptionInterceptorBuilder.cs
@@ -1,4 +1,3 @@
-
 using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;

--- a/src/Stella.Ergosfare.Core/Internal/Caching/MessageDescriptorCache.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Caching/MessageDescriptorCache.cs
@@ -9,9 +9,9 @@ namespace Stella.Ergosfare.Core.Internal.Caching;
 /// <summary>
 /// Cache for MessageDescriptor and MessageDependencies instances.
 /// </summary>
-internal sealed class MessageDescriptorCache
+internal sealed class MessageDescriptorCache(IDescriptorCacheStrategy strategy)
 {
-    private readonly IDescriptorCacheStrategy _strategy;
+    private readonly IDescriptorCacheStrategy _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
 
     /// <summary>
     /// Hot-path cache for resolved dependencies keyed by message type (no groups —
@@ -32,11 +32,6 @@ internal sealed class MessageDescriptorCache
     private readonly ConcurrentDictionary<GroupedDependenciesKey, MessagePipelineShape> _shapesByTypeAndGroups = new();
 
     private int _registryVersion = -1;
-
-    public MessageDescriptorCache(IDescriptorCacheStrategy strategy)
-    {
-        _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
-    }
 
     public bool TryGet<T>(string key, out T? value) where T : class
     {

--- a/src/Stella.Ergosfare.Core/Internal/Caching/MessageDescriptorLruCache.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Caching/MessageDescriptorLruCache.cs
@@ -6,16 +6,10 @@ namespace Stella.Ergosfare.Core.Internal.Caching;
 /// <summary>
 /// LRU (Least Recently Used) cache strategy.
 /// </summary>
-public sealed class LruCacheStrategy : IDescriptorCacheStrategy
+public sealed class LruCacheStrategy(uint maxSize = 100) : IDescriptorCacheStrategy
 {
     private readonly ConcurrentDictionary<string, LruCacheEntry> _cache = new();
-    private readonly uint _maxSize;
-    private readonly object _cleanupLock = new();
-
-    public LruCacheStrategy(uint maxSize = 100)
-    {
-        _maxSize = maxSize;
-    }
+    private readonly Lock _cleanupLock = new();
 
     public bool TryGet(string key, out object? value)
     {
@@ -32,7 +26,7 @@ public sealed class LruCacheStrategy : IDescriptorCacheStrategy
 
     public void Add(string key, object value)
     {
-        if ((uint)_cache.Count >= _maxSize)
+        if ((uint)_cache.Count >= maxSize)
         {
             EvictLeastRecentlyUsed();
         }
@@ -54,11 +48,11 @@ public sealed class LruCacheStrategy : IDescriptorCacheStrategy
             // added: evicting down to maxSize - 1 keeps the post-add count within
             // maxSize. The previous <= guard returned early at exactly maxSize, letting
             // the cache grow to maxSize + 1 before eviction kicked in.
-            if ((uint)_cache.Count < _maxSize) return;
+            if ((uint)_cache.Count < maxSize) return;
 
             var toRemove = _cache
                 .OrderBy(x => x.Value.LastAccessed)
-                .Take((int)(_cache.Count - _maxSize + 1))
+                .Take((int)(_cache.Count - maxSize + 1))
                 .Select(x => x.Key)
                 .ToList();
 
@@ -74,16 +68,10 @@ public sealed class LruCacheStrategy : IDescriptorCacheStrategy
         Clear();
     }
 
-    private sealed class LruCacheEntry
+    private sealed class LruCacheEntry(object value)
     {
-        public object Value { get; }
-        public DateTime LastAccessed { get; private set; }
-
-        public LruCacheEntry(object value)
-        {
-            Value = value;
-            LastAccessed = DateTime.UtcNow;
-        }
+        public object Value { get; } = value;
+        public DateTime LastAccessed { get; private set; } = DateTime.UtcNow;
 
         public void Touch() => LastAccessed = DateTime.UtcNow;
     }

--- a/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
@@ -18,9 +18,7 @@ internal sealed class ErgosfareExecutionContext(
     /// This token can be used to observe cancellation requests and propagate them to handlers or interceptors.
     /// </summary>
     public CancellationToken CancellationToken { get; } = cancellationToken;
-    
-    
-    private IDictionary<object, object?>? _items = items;
+
 
     /// <summary>
     /// Gets a dictionary of arbitrary key-value pairs stored in the execution context.
@@ -28,7 +26,10 @@ internal sealed class ErgosfareExecutionContext(
     /// The backing dictionary is created lazily on first access so dispatches that never
     /// touch shared items pay no allocation for it.
     /// </summary>
-    public IDictionary<object, object?> Items => _items ??= new Dictionary<object, object?>();
+    public IDictionary<object, object?> Items
+    {
+        get => field ??= new Dictionary<object, object?>();
+    } = items;
 
     /// <summary>
     /// Stores an item in the execution context under the specified key.
@@ -58,15 +59,12 @@ internal sealed class ErgosfareExecutionContext(
     /// </summary>
     /// <typeparam name="TType">The type of the item expected.</typeparam>
     /// <param name="key">The key associated with the item.</param>
-    /// <param name="item">
-    /// When this method returns, contains the retrieved item if found and of the correct type; otherwise, the default value for <typeparamref name="TType"/>.
-    /// </param>
     /// <returns><c>true</c> if an item with the given key exists and is of the correct type; otherwise, <c>false</c>.</returns>
     public TType Get<TType>(string key) where TType : notnull
     {
-        if (!Items.TryGetValue(key, out var ıtem)) 
+        if (!Items.TryGetValue(key, out var item)) 
             throw new InvalidOperationException("Item does not exist");
-        return (TType)ıtem!;
+        return (TType)item!;
     }
 
 
@@ -93,7 +91,7 @@ internal sealed class ErgosfareExecutionContext(
 
     
     /// <summary>
-    /// Sets <see cref="MessageResult"/> and throws <exception cref="ExecutionAbortedException"></exception>
+    /// Sets <see cref="messageResult"/> and throws <exception cref="ExecutionAbortedException"></exception>
     /// </summary>
     /// <param name="messageResult"></param>
     public void Abort(object? messageResult = null)

--- a/src/Stella.Ergosfare.Core/Internal/Factories/HandlerDescriptorBuilderFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/HandlerDescriptorBuilderFactory.cs
@@ -11,7 +11,7 @@ namespace Stella.Ergosfare.Core.Internal.Factories;
 /// </summary>
 /// <remarks>
 /// The factory internally maintains a list of <see cref="IHandlerDescriptorBuilder"/>
-/// implementations, including handlers, pre/post interceptors, exception interceptors, 
+/// implementations, including handlers, pre- / post-interceptors, exception interceptors, 
 /// and final interceptors. It can build all applicable descriptors for a given type
 /// and supports both synchronous and asynchronous disposal.
 /// </remarks>

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -22,10 +22,8 @@ namespace Stella.Ergosfare.Core.Internal.Factories;
 /// The factory itself is registered as a singleton; every dispatch after the first is a
 /// cache lookup.
 /// </remarks>
-internal sealed class MessageDependenciesFactory : IMessageDependenciesFactory
+internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvider) : IMessageDependenciesFactory
 {
-    private readonly IServiceProvider _serviceProvider;
-
     private MessageDescriptorCache? _cache;
     private IMessageRegistry? _registry;
     private HandlerLifetimeRegistry? _handlerLifetimes;
@@ -33,21 +31,16 @@ internal sealed class MessageDependenciesFactory : IMessageDependenciesFactory
     private IServiceProvider? _memoizedGraphProvider;
     private bool _servicesResolved;
 
-    public MessageDependenciesFactory(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
     public IMessageDependencies Create(Type messageType, IMessageDescriptor descriptor, IEnumerable<string> groups)
     {
-        var cache = _cache ??= _serviceProvider.GetRequiredService<MessageDescriptorCache>();
+        var cache = _cache ??= serviceProvider.GetRequiredService<MessageDescriptorCache>();
 
         if (!_servicesResolved)
         {
-            _registry = _serviceProvider.GetService<IMessageRegistry>();
-            _handlerLifetimes = _serviceProvider.GetService<HandlerLifetimeRegistry>();
-            _runtimeOptions = _serviceProvider.GetService<ErgosfareRuntimeOptions>();
-            _memoizedGraphProvider = _serviceProvider.GetService<RootServiceProviderAccessor>()?.RootProvider ?? _serviceProvider;
+            _registry = serviceProvider.GetService<IMessageRegistry>();
+            _handlerLifetimes = serviceProvider.GetService<HandlerLifetimeRegistry>();
+            _runtimeOptions = serviceProvider.GetService<ErgosfareRuntimeOptions>();
+            _memoizedGraphProvider = serviceProvider.GetService<RootServiceProviderAccessor>()?.RootProvider ?? serviceProvider;
             _servicesResolved = true;
         }
 
@@ -75,7 +68,7 @@ internal sealed class MessageDependenciesFactory : IMessageDependenciesFactory
                                || (_handlerLifetimes?.AreAllHandlersSingleton(messageType, descriptor) ?? false);
 
         var dependencies = new MessageDependencies(
-            shape, memoizeInstances ? _memoizedGraphProvider ?? _serviceProvider : null);
+            shape, memoizeInstances ? _memoizedGraphProvider ?? serviceProvider : null);
 
         cache.AddDependencies(messageType, groupsArray, dependencies);
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -14,7 +14,6 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 /// </summary>
 /// <remarks>
 /// The <see cref="MessageMediator"/> uses the provided <see cref="IMessageRegistry"/> to track message types,
-/// <see cref="ISignalHub"/> to publish events (if applicable), and <see cref="IMessageDependenciesFactory"/>
 /// to lazily resolve handler dependencies. It ensures that the message mediation occurs
 /// within a controlled execution context scope.
 /// </remarks>
@@ -27,7 +26,7 @@ internal sealed class MessageMediator(
     : IMessageMediator
 {
     /// <summary>
-    /// Process-wide executor cache used by the <see cref="DispatchAsync(object, IDictionary{object, object?}?, CancellationToken)"/>
+    /// Process-wide executor cache used by the <see cref="DispatchAsync(object,IDictionary{object,object?},CancellationToken,IEnumerable{string})"/>
     /// path. Optional so directly-constructed mediators (tests) keep working; the DI
     /// registration always supplies it.
     /// </summary>

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessagePipelineShape.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessagePipelineShape.cs
@@ -33,17 +33,41 @@ internal sealed class MessagePipelineShape
             IndirectHandlers = Prepare(descriptor.IndirectHandlers, messageType, effectiveGroups),
             PreInterceptors = Merge(
                 Prepare(descriptor.PreInterceptors, messageType, effectiveGroups),
-                Prepare(descriptor.IndirectPreInterceptors, messageType, effectiveGroups)),
+                PrepareIndirect(descriptor, descriptor.IndirectPreInterceptors, messageType, effectiveGroups)),
             PostInterceptors = Merge(
                 Prepare(descriptor.PostInterceptors, messageType, effectiveGroups),
-                Prepare(descriptor.IndirectPostInterceptors, messageType, effectiveGroups)),
+                PrepareIndirect(descriptor, descriptor.IndirectPostInterceptors, messageType, effectiveGroups)),
             ExceptionInterceptors = Merge(
                 Prepare(descriptor.ExceptionInterceptors, messageType, effectiveGroups),
-                Prepare(descriptor.IndirectExceptionInterceptors, messageType, effectiveGroups)),
+                PrepareIndirect(descriptor, descriptor.IndirectExceptionInterceptors, messageType, effectiveGroups)),
             FinalInterceptors = Merge(
                 Prepare(descriptor.FinalInterceptors, messageType, effectiveGroups),
-                Prepare(descriptor.IndirectFinalInterceptors, messageType, effectiveGroups)),
+                PrepareIndirect(descriptor, descriptor.IndirectFinalInterceptors, messageType, effectiveGroups)),
         };
+    }
+
+    /// <summary>
+    /// Prepares a covariantly matched interceptor stage, honoring the message's
+    /// <c>[ExcludeFromPipeline]</c> declaration: a blanket exclusion empties the stage,
+    /// a group-scoped exclusion drops the interceptors carrying an excluded group.
+    /// Directly registered interceptors never pass through here — the attribute cannot
+    /// suppress an interceptor written for the message type itself. Indirect main
+    /// handlers are likewise unaffected: the attribute shapes the interceptor pipeline,
+    /// not dispatch.
+    /// </summary>
+    private static PlannedHandler<TDescriptor>[] PrepareIndirect<TDescriptor>(
+        IMessageDescriptor message,
+        IReadOnlyCollection<TDescriptor> descriptors,
+        Type messageType,
+        List<string> groups)
+        where TDescriptor : IHandlerDescriptor
+    {
+        if (message.ExcludesIndirectInterceptors)
+        {
+            return [];
+        }
+
+        return Prepare(descriptors, messageType, groups, message.ExcludedInterceptorGroups);
     }
 
     /// <summary>
@@ -80,7 +104,8 @@ internal sealed class MessagePipelineShape
     private static PlannedHandler<TDescriptor>[] Prepare<TDescriptor>(
         IReadOnlyCollection<TDescriptor> descriptors,
         Type messageType,
-        List<string> groups)
+        List<string> groups,
+        IReadOnlyCollection<string>? excludedGroups = null)
         where TDescriptor : IHandlerDescriptor
     {
         if (descriptors.Count == 0)
@@ -92,10 +117,17 @@ internal sealed class MessagePipelineShape
 
         foreach (var descriptor in descriptors)
         {
-            if (MatchesAnyGroup(descriptor.Groups, groups))
+            if (!MatchesAnyGroup(descriptor.Groups, groups))
             {
-                matched.Add(descriptor);
+                continue;
             }
+
+            if (excludedGroups is { Count: > 0 } && ContainsAnyGroup(descriptor.Groups, excludedGroups))
+            {
+                continue;
+            }
+
+            matched.Add(descriptor);
         }
 
         if (matched.Count == 0)
@@ -134,9 +166,31 @@ internal sealed class MessagePipelineShape
     {
         foreach (var handlerGroup in handlerGroups)
         {
+            // ReSharper disable once ForCanBeConvertedToForeach
             for (var i = 0; i < groups.Count; i++)
             {
                 if (string.Equals(handlerGroup, groups[i], StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether any of the handler's groups appears in the excluded set.
+    /// </summary>
+    private static bool ContainsAnyGroup(
+        IReadOnlyCollection<string> handlerGroups,
+        IReadOnlyCollection<string> excludedGroups)
+    {
+        foreach (var handlerGroup in handlerGroups)
+        {
+            foreach (var excluded in excludedGroups)
+            {
+                if (string.Equals(handlerGroup, excluded, StringComparison.Ordinal))
                 {
                     return true;
                 }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -72,12 +72,14 @@ internal sealed class PipelineExecutorCache(
 
     public IPipelineExecutor GetVoidExecutor(Type messageType, IEnumerable<string>? groups = null)
     {
-        var key = (messageType, GroupsKey(groups));
+        var materializedGroups = MaterializeGroups(groups);
+        var key = (messageType, GroupsKey(materializedGroups));
+
         if (!_voidExecutors.TryGetValue(key, out var executor))
         {
             executor = _voidExecutors.GetOrAdd(key,
                 static (k, state) => state.Cache.CreateVoidExecutor(k.MessageType, state.Groups),
-                (Cache: this, Groups: MaterializeGroups(groups)));
+                (Cache: this, Groups: materializedGroups));
         }
 
         return executor;
@@ -85,20 +87,27 @@ internal sealed class PipelineExecutorCache(
 
     public IPipelineExecutor<TResult> GetExecutor<TResult>(Type messageType, IEnumerable<string>? groups = null)
     {
-        var key = (messageType, typeof(TResult), GroupsKey(groups));
+        var materializedGroups = MaterializeGroups(groups);
+        var key = (messageType, typeof(TResult), GroupsKey(materializedGroups));
+
         if (!_resultExecutors.TryGetValue(key, out var executor))
         {
             executor = _resultExecutors.GetOrAdd(key,
                 static (k, state) => state.Cache.CreateResultExecutor(k.MessageType, k.ResultType, state.Groups),
-                (Cache: this, Groups: MaterializeGroups(groups)));
+                (Cache: this, Groups: materializedGroups));
         }
 
         return (IPipelineExecutor<TResult>)executor;
     }
 
-    private static string GroupsKey(IEnumerable<string>? groups)
-        => groups is null ? string.Empty : string.Join('\x1f', groups);
+    private static string GroupsKey(string[] groups)
+        => groups.Length == 0 ? string.Empty : string.Join('\x1f', groups);
 
+    /// <summary>
+    /// Snapshots the caller's group sequence exactly once: the same array both builds the
+    /// cache key and flows into the executor, so a lazy or unstable enumerable can never
+    /// produce a key that disagrees with the groups the cached executor was built with.
+    /// </summary>
     private static string[] MaterializeGroups(IEnumerable<string>? groups)
         => groups is null ? EmptyGroups : [.. groups];
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PlannedHandler.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PlannedHandler.cs
@@ -4,7 +4,7 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 
 /// <summary>
 /// A descriptor paired with the concrete handler type to resolve for it, computed once
-/// when the pipeline shape is built and reused for every dispatch afterwards.
+/// when the pipeline shape is built and reused for every dispatch afterward.
 /// </summary>
 /// <remarks>
 /// For handlers of generic messages the type is already closed over the message's generic

--- a/src/Stella.Ergosfare.Core/Internal/Registry/Descriptors/MessageDescriptor.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/Descriptors/MessageDescriptor.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 namespace Stella.Ergosfare.Core.Internal.Registry.Descriptors;
@@ -42,6 +44,14 @@ internal class MessageDescriptor(Type messageType) : IMessageDescriptor
 
 
     /// <summary>
+    /// The message type's <c>[ExcludeFromPipeline]</c> declaration, read once at
+    /// registration — startup-only reflection, shared by both the reflection-based and
+    /// source-generated registration paths.
+    /// </summary>
+    private readonly ExcludeFromPipelineAttribute? _pipelineExclusion =
+        messageType.GetCustomAttribute<ExcludeFromPipelineAttribute>(inherit: false);
+
+    /// <summary>
     /// Gets the message type associated with this descriptor.
     /// </summary>
     public Type MessageType { get; } = messageType;
@@ -50,6 +60,13 @@ internal class MessageDescriptor(Type messageType) : IMessageDescriptor
     /// Gets a value indicating whether the message type is generic.
     /// </summary>
     public bool IsGeneric { get; } = messageType.IsGenericType;
+
+    /// <inheritdoc />
+    public bool ExcludesIndirectInterceptors => _pipelineExclusion is { Groups.Length: 0 };
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> ExcludedInterceptorGroups =>
+        _pipelineExclusion is { Groups.Length: > 0 } exclusion ? exclusion.Groups : Array.Empty<string>();
 
     // pre interceptor
     public IReadOnlyCollection<IPreInterceptorDescriptor> PreInterceptors => _preInterceptors ?? Array.Empty<IPreInterceptorDescriptor>();

--- a/src/Stella.Ergosfare.Core/Internal/Registry/MessageRegistry.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/MessageRegistry.cs
@@ -76,15 +76,17 @@ internal sealed class MessageRegistry(
     /// they enumerate <see cref="_snapshot"/>, an immutable array republished after every
     /// effective registration.
     /// </summary>
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
 
     /// <summary>
     /// Immutable view of the finalized messages, republished at the end of every effective
     /// registration. The volatile write is the publication point: everything a registration
     /// mutated (descriptor stage arrays included) happens-before a reader that observes the
-    /// new snapshot or the new <see cref="Version"/>.
+    /// new snapshot or the new <see cref="Version"/>. Concrete element type on purpose —
+    /// the array is only ever reassigned wholesale, and the interface view readers get goes
+    /// through <see cref="IEnumerable{T}"/> covariance, not array covariance.
     /// </summary>
-    private volatile IMessageDescriptor[] _snapshot = [];
+    private volatile MessageDescriptor[] _snapshot = [];
 
 
     /// <summary>
@@ -196,8 +198,6 @@ internal sealed class MessageRegistry(
                     messageDescriptor.AddDescriptors(_descriptors);
                 }
             }
-            // Mark the type as processed to prevent duplicate registration
-            _processedTypes[type] = 0;
 
             // Move all newly registered messages to the main messages list and clear the newMessages list
             if (_newMessages.Count > 0)
@@ -207,6 +207,10 @@ internal sealed class MessageRegistry(
             }
 
             Publish();
+
+            // Mark processed only after publishing: a concurrent caller that observes the
+            // fast-path hit must also observe the snapshot containing this registration.
+            _processedTypes[type] = 0;
         }
     }
 
@@ -258,7 +262,6 @@ internal sealed class MessageRegistry(
             {
                 RegisterMessage(descriptor.MessageType);
                 _descriptors.Add(descriptor);
-                _processedTypes[descriptor.HandlerType] = 0;
             }
 
             // Same linking pass as Register(): attach the new descriptors to every existing
@@ -286,6 +289,13 @@ internal sealed class MessageRegistry(
             }
 
             Publish();
+
+            // Mark processed only after publishing: a concurrent Register() caller that
+            // observes the fast-path hit must also observe the published snapshot.
+            foreach (var descriptor in accepted)
+            {
+                _processedTypes[descriptor.HandlerType] = 0;
+            }
         }
     }
 

--- a/src/Stella.Ergosfare.Events.Abstractions/PreInterceptors/IEventPreInterceptor.cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/PreInterceptors/IEventPreInterceptor.cs
@@ -25,10 +25,15 @@ namespace Stella.Ergosfare.Events.Abstractions;
 public interface IEventPreInterceptor : IEvent, IAsyncPreInterceptor<IEvent>
 {
     /// <inheritdoc cref="IAsyncPreInterceptor{TEvent}.HandleAsync"/>
+    /// <remarks>
+    /// A pre-interceptor's return value is the (possibly replaced) message the rest of
+    /// the pipeline continues with — this void-flavored convenience contract passes the
+    /// event through unchanged.
+    /// </remarks>
     async ValueTask<object> IAsyncPreInterceptor<IEvent>.HandleAsync(IEvent @event, IExecutionContext executionContext)
     {
         await HandleAsync(@event, executionContext);
-        return ValueTask.CompletedTask;
+        return @event;
     }
     
     /// <summary>

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -19,7 +19,8 @@ namespace Stella.Ergosfare.Events;
 /// <para>
 /// This strategy ensures that:
 /// <list type="bullet">
-///   <item><description>All handlers for the message are invoked sequentially.</description></item>
+///   <item><description>All handlers for the message — including those registered for its
+///   base types and interfaces — are invoked sequentially, direct registrations first.</description></item>
 ///   <item><description>Pre-, post-, exception-, and final-interceptors are executed in the correct order.</description></item>
 ///   <item><description>Exceptions are captured and passed to the configured exception interceptors.</description></item>
 /// </list>
@@ -35,7 +36,9 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
     where TMessage : notnull
 {
     /// <summary>
-    ///     Mediates the given message by broadcasting it sequentially to all registered handlers.
+    ///     Mediates the given message by broadcasting it sequentially to all registered
+    ///     handlers: the event's own handlers first, then the covariantly matched ones
+    ///     (registered against a base type or interface of the event).
     /// </summary>
     /// <param name="message">The message to be processed.</param>
     /// <param name="messageDependencies">
@@ -45,12 +48,18 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
     /// <param name="context">The current execution context.</param>
     /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>A ValueTask representing the asynchronous operation of the mediation process.</returns>
+    /// <remarks>
+    ///     Opting a handler out of broad delivery is a group concern: an indirect handler
+    ///     carrying a non-default <c>[Group]</c> only runs when a publish selects its group —
+    ///     the group filter is applied while the pipeline shape is built.
+    /// </remarks>
     public async ValueTask Mediate(TMessage message, IMessageDependencies messageDependencies, IExecutionContext context, IServiceProvider serviceProvider)
     {
 
         var handlers = FilterHandlers(messageDependencies.Handlers);
+        var indirectHandlers = FilterHandlers(messageDependencies.IndirectHandlers);
 
-        if (handlers.Count == 0)
+        if (handlers.Count == 0 && indirectHandlers.Count == 0)
         {
             if (settings.ThrowIfNoHandlerFound)
             {
@@ -65,6 +74,7 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
             var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
             await preInvoker.Invoke(message, context);
             await PublishSequentially(message, handlers, context, serviceProvider);
+            await PublishSequentially(message, indirectHandlers, context, serviceProvider);
 
             // A ValueTask may be awaited only once — the completed ValueTask stands in as the
             // (meaningless for events) result object flowing through the interceptor stages.

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -3,6 +3,7 @@ using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 using Stella.Ergosfare.Events.Abstractions;
 
@@ -34,20 +35,15 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
     where TMessage : notnull
 {
     /// <summary>
-    /// A completed <see cref="ValueTask"/> boxed once and reused as the broadcast's
-    /// (meaningless for events) result object flowing through the interceptor stages.
-    /// </summary>
-    private static readonly object CompletedResultBox = ValueTask.CompletedTask;
-
-    /// <summary>
-    ///     Mediates the given message by broadcasting it to all registered handlers concurrently.
+    ///     Mediates the given message by broadcasting it sequentially to all registered handlers.
     /// </summary>
     /// <param name="message">The message to be processed.</param>
     /// <param name="messageDependencies">
-    ///     The dependencies required for message handling, including registered handlers,
-    ///     pre-handlers, post-handlers, and error handlers.
+    ///     The dependencies required for message handling, including the registered handlers
+    ///     and the pre-, post-, exception- and final-interceptor stages.
     /// </param>
-    /// <param name="context"></param>
+    /// <param name="context">The current execution context.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>A ValueTask representing the asynchronous operation of the mediation process.</returns>
     public async ValueTask Mediate(TMessage message, IMessageDependencies messageDependencies, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -73,13 +69,13 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
             // A ValueTask may be awaited only once — the completed ValueTask stands in as the
             // (meaningless for events) result object flowing through the interceptor stages.
             var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, null, serviceProvider);
-            await postInvoker.Invoke(message, CompletedResultBox, context);
+            await postInvoker.Invoke(message, CompletedResultBox.Instance, context);
         }
         catch (Exception e)
         {
             exception = e;
             var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-            await exceptionInvoker.Invoke(message, CompletedResultBox,
+            await exceptionInvoker.Invoke(message, CompletedResultBox.Instance,
                 ExceptionDispatchInfo.Capture(e), context);
 
         }
@@ -87,7 +83,7 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         finally
         {
             var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-            await finalInvoker.Invoke(message, CompletedResultBox, exception, context);
+            await finalInvoker.Invoke(message, CompletedResultBox.Instance, exception, context);
         }
     }
 

--- a/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptor[TQuery,TResult].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptor[TQuery,TResult].cs
@@ -14,12 +14,13 @@ namespace Stella.Ergosfare.Queries.Abstractions;
 /// narrower return type there is no third parameter anymore; return the base result type.
 /// </typeparam>
 /// <remarks>
-/// The type parameters are deliberately invariant: the pipeline invokes interceptors
-/// through the non-generic root interfaces, so interface variance bought nothing while
-/// forcing the result-returning member onto a separate three-parameter interface.
+/// <typeparamref name="TQuery"/> is contravariant, matching the core
+/// <see cref="IAsyncExceptionInterceptor{TMessage, TResult}"/> contract the typed dispatch
+/// matches against. <typeparamref name="TResult"/> must stay invariant: the typed member
+/// returns it.
 /// </remarks>
 // ReSharper disable once UnusedType.Global
-public interface IQueryExceptionInterceptor<TQuery, TResult>
+public interface IQueryExceptionInterceptor<in TQuery, TResult>
     : IQuery, IAsyncExceptionInterceptor<TQuery, TResult>
     where TQuery : IQuery<TResult>
     where TResult : notnull

--- a/src/Stella.Ergosfare.Queries.Abstractions/PostInterceptors/IQueryPostInterceptor[TQuery,TResult].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/PostInterceptors/IQueryPostInterceptor[TQuery,TResult].cs
@@ -15,11 +15,12 @@ namespace Stella.Ergosfare.Queries.Abstractions;
 /// narrower return type there is no third parameter anymore; return the base result type.
 /// </typeparam>
 /// <remarks>
-/// The type parameters are deliberately invariant: the pipeline invokes interceptors
-/// through the non-generic root interfaces, so interface variance bought nothing while
-/// forcing the result-returning member onto a separate three-parameter interface.
+/// <typeparamref name="TQuery"/> is contravariant, matching the core
+/// <see cref="IAsyncPostInterceptor{TMessage, TResult}"/> contract the typed dispatch
+/// matches against. <typeparamref name="TResult"/> must stay invariant: the typed member
+/// returns it.
 /// </remarks>
-public interface IQueryPostInterceptor<TQuery, TResult> : IQuery, IAsyncPostInterceptor<TQuery, TResult>
+public interface IQueryPostInterceptor<in TQuery, TResult> : IQuery, IAsyncPostInterceptor<TQuery, TResult>
     where TQuery : IQuery<TResult>
     where TResult : notnull
 {

--- a/test/Stella.Ergosfare.Core.Test/MessagePipelineShapeExclusionTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/MessagePipelineShapeExclusionTests.cs
@@ -1,0 +1,103 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Internal.Mediator;
+using Stella.Ergosfare.Core.Internal.Registry.Descriptors;
+
+namespace Stella.Ergosfare.Core.Test;
+
+/// <summary>
+/// <c>[ExcludeFromPipeline]</c> semantics in pipeline-shape building: covariantly matched
+/// (indirect) interceptors are excluded — blanket or per group — while directly registered
+/// interceptors and main handlers (direct and indirect) are never affected.
+/// </summary>
+public class MessagePipelineShapeExclusionTests
+{
+    private interface IBaseMessage;
+
+    private sealed record PlainMessage : IBaseMessage;
+
+    [ExcludeFromPipeline]
+    private sealed record BlanketExcluded : IBaseMessage;
+
+    [ExcludeFromPipeline("logging")]
+    private sealed record LoggingExcluded : IBaseMessage;
+
+    private sealed class BroadPre;
+
+    private sealed class BroadLoggingPre;
+
+    private sealed class ExactPre;
+
+    private sealed class BroadHandler;
+
+    [Fact]
+    public void MessageDescriptor_ExposesPipelineExclusionMetadata()
+    {
+        Assert.False(new MessageDescriptor(typeof(PlainMessage)).ExcludesIndirectInterceptors);
+        Assert.Empty(new MessageDescriptor(typeof(PlainMessage)).ExcludedInterceptorGroups);
+
+        Assert.True(new MessageDescriptor(typeof(BlanketExcluded)).ExcludesIndirectInterceptors);
+        Assert.Empty(new MessageDescriptor(typeof(BlanketExcluded)).ExcludedInterceptorGroups);
+
+        Assert.False(new MessageDescriptor(typeof(LoggingExcluded)).ExcludesIndirectInterceptors);
+        Assert.Equal(["logging"], new MessageDescriptor(typeof(LoggingExcluded)).ExcludedInterceptorGroups);
+    }
+
+    [Fact]
+    public void BlanketExclusion_DropsIndirectInterceptors_KeepsDirectOnesAndHandlers()
+    {
+        var descriptor = new MessageDescriptor(typeof(BlanketExcluded));
+        descriptor.AddDescriptor(HandlerDescriptors.PreInterceptor(typeof(IBaseMessage), typeof(BroadPre)));
+        descriptor.AddDescriptor(HandlerDescriptors.PreInterceptor(typeof(BlanketExcluded), typeof(ExactPre)));
+        descriptor.AddDescriptor(HandlerDescriptors.Handler(typeof(IBaseMessage), typeof(object), typeof(BroadHandler)));
+
+        var shape = MessagePipelineShape.Create(typeof(BlanketExcluded), descriptor, []);
+
+        // The covariant pre-interceptor is gone, the exact one stays.
+        var pre = Assert.Single(shape.PreInterceptors);
+        Assert.Equal(typeof(ExactPre), pre.HandlerType);
+
+        // Indirect main handlers are not the attribute's business.
+        var handler = Assert.Single(shape.IndirectHandlers);
+        Assert.Equal(typeof(BroadHandler), handler.HandlerType);
+    }
+
+    [Fact]
+    public void GroupScopedExclusion_DropsOnlyInterceptorsCarryingAnExcludedGroup()
+    {
+        var descriptor = new MessageDescriptor(typeof(LoggingExcluded));
+        descriptor.AddDescriptor(HandlerDescriptors.PreInterceptor(typeof(IBaseMessage), typeof(BroadPre)));
+        descriptor.AddDescriptor(HandlerDescriptors.PreInterceptor(
+            typeof(IBaseMessage), typeof(BroadLoggingPre), groups: [GroupAttribute.DefaultGroupName, "logging"]));
+
+        var shape = MessagePipelineShape.Create(typeof(LoggingExcluded), descriptor, []);
+
+        var pre = Assert.Single(shape.PreInterceptors);
+        Assert.Equal(typeof(BroadPre), pre.HandlerType);
+    }
+
+    [Fact]
+    public void GroupScopedExclusion_DoesNotTouchDirectInterceptorsInTheExcludedGroup()
+    {
+        var descriptor = new MessageDescriptor(typeof(LoggingExcluded));
+        descriptor.AddDescriptor(HandlerDescriptors.PreInterceptor(
+            typeof(LoggingExcluded), typeof(ExactPre), groups: [GroupAttribute.DefaultGroupName, "logging"]));
+
+        var shape = MessagePipelineShape.Create(typeof(LoggingExcluded), descriptor, []);
+
+        var pre = Assert.Single(shape.PreInterceptors);
+        Assert.Equal(typeof(ExactPre), pre.HandlerType);
+    }
+
+    [Fact]
+    public void UnattributedMessage_KeepsItsIndirectInterceptors()
+    {
+        var descriptor = new MessageDescriptor(typeof(PlainMessage));
+        descriptor.AddDescriptor(HandlerDescriptors.PreInterceptor(typeof(IBaseMessage), typeof(BroadPre)));
+
+        var shape = MessagePipelineShape.Create(typeof(PlainMessage), descriptor, []);
+
+        var pre = Assert.Single(shape.PreInterceptors);
+        Assert.Equal(typeof(BroadPre), pre.HandlerType);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/EventInterceptorDefaultImplementationTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EventInterceptorDefaultImplementationTests.cs
@@ -66,10 +66,16 @@ public class EventInterceptorDefaultImplementationTests
     public async Task PreInterceptorDefaultImplementation_ShouldForwardToTypedHandleAsync()
     {
         var interceptor = new TestPreInterceptor();
+        var @event = new TestEvent();
 
-        await ((IAsyncPreInterceptor<IEvent>) interceptor).HandleAsync(new TestEvent(), CreateContext());
+        var result = await ((IAsyncPreInterceptor<IEvent>) interceptor).HandleAsync(@event, CreateContext());
 
         Assert.True(interceptor.Called);
+
+        // Regression: the default implementation used to return ValueTask.CompletedTask,
+        // which the pipeline then cast to the message type and crashed — a pre-interceptor's
+        // return value is the message the rest of the pipeline continues with.
+        Assert.Same(@event, result);
     }
 
     [Fact]

--- a/test/Stella.Ergosfare.Events.Test/ExcludeFromPipelineTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/ExcludeFromPipelineTests.cs
@@ -1,0 +1,120 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// End-to-end <c>[ExcludeFromPipeline]</c> behavior: an event-wide (covariant)
+/// pre-interceptor is skipped for excluded events while interceptors registered against
+/// the event type itself still run.
+/// </summary>
+/// <remarks>
+/// The message registry is process-wide, so these stubs are built to be inert everywhere
+/// else: parameterless constructors, recording into the published event instance itself
+/// (other tests' events don't implement <see cref="ITracedEvent"/>), and
+/// <c>[ExcludeFromDiscovery]</c> so assembly scans in other tests never register them —
+/// this suite registers them explicitly.
+/// </remarks>
+public class ExcludeFromPipelineTests
+{
+    [ExcludeFromDiscovery]
+    public interface ITracedEvent : IEvent
+    {
+        List<string> Trace { get; }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed record ChattyEvent : ITracedEvent
+    {
+        public List<string> Trace { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    [ExcludeFromPipeline]
+    public sealed record QuietEvent : ITracedEvent
+    {
+        public List<string> Trace { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class BroadPre : IEventPreInterceptor
+    {
+        public ValueTask HandleAsync(IEvent @event, IExecutionContext context)
+        {
+            if (@event is ITracedEvent traced)
+            {
+                traced.Trace.Add("broad");
+            }
+
+            return default;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class QuietExactPre : IEventPreInterceptor<QuietEvent>
+    {
+        public ValueTask<object> HandleAsync(QuietEvent @event, IExecutionContext context)
+        {
+            @event.Trace.Add("exact");
+            return new(@event);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class ChattyHandler : IEventHandler<ChattyEvent>
+    {
+        public ValueTask HandleAsync(ChattyEvent message, IExecutionContext context)
+        {
+            message.Trace.Add("handled");
+            return default;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class QuietHandler : IEventHandler<QuietEvent>
+    {
+        public ValueTask HandleAsync(QuietEvent message, IExecutionContext context)
+        {
+            message.Trace.Add("handled");
+            return default;
+        }
+    }
+
+    private static IEventMediator BuildMediator()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e => e
+                .Register<ChattyEvent>()
+                .Register<QuietEvent>()
+                .Register(typeof(BroadPre))
+                .Register(typeof(QuietExactPre))
+                .Register(typeof(ChattyHandler))
+                .Register(typeof(QuietHandler))))
+            .BuildServiceProvider()
+            .GetRequiredService<IEventMediator>();
+
+    [Fact]
+    public async Task CovariantPreInterceptor_RunsForNormalEvents()
+    {
+        var mediator = BuildMediator();
+        var @event = new ChattyEvent();
+
+        await mediator.PublishAsync(@event, CancellationToken.None);
+
+        Assert.Equal(["broad", "handled"], @event.Trace);
+    }
+
+    [Fact]
+    public async Task ExcludedEvent_SkipsCovariantPreInterceptor_KeepsExactOne()
+    {
+        var mediator = BuildMediator();
+        var @event = new QuietEvent();
+
+        await mediator.PublishAsync(@event, CancellationToken.None);
+
+        Assert.Equal(["exact", "handled"], @event.Trace);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/IndirectHandlerBroadcastTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/IndirectHandlerBroadcastTests.cs
@@ -1,0 +1,98 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Event broadcast delivers to covariantly matched (base/interface-registered) handlers:
+/// direct registrations first, then indirect ones. Opting out of broad delivery is a group
+/// concern — an indirect handler in a non-default group only runs when a publish selects
+/// its group.
+/// </summary>
+/// <remarks>
+/// The message registry is process-wide, so the stubs are inert everywhere else:
+/// parameterless constructors, recording into the published event instance, and
+/// <c>[ExcludeFromDiscovery]</c> so other tests' assembly scans never register them.
+/// </remarks>
+public class IndirectHandlerBroadcastTests
+{
+    [ExcludeFromDiscovery]
+    public interface ITracedEvent : IEvent
+    {
+        List<string> Trace { get; }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed record OrderPlaced : ITracedEvent
+    {
+        public List<string> Trace { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class OrderPlacedHandler : IEventHandler<OrderPlaced>
+    {
+        public ValueTask HandleAsync(OrderPlaced message, IExecutionContext context)
+        {
+            message.Trace.Add("direct");
+            return default;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class TracedEventHandler : IEventHandler<ITracedEvent>
+    {
+        public ValueTask HandleAsync(ITracedEvent message, IExecutionContext context)
+        {
+            message.Trace.Add("indirect");
+            return default;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("audit")]
+    public sealed class AuditTracedEventHandler : IEventHandler<ITracedEvent>
+    {
+        public ValueTask HandleAsync(ITracedEvent message, IExecutionContext context)
+        {
+            message.Trace.Add("audit");
+            return default;
+        }
+    }
+
+    private static IEventMediator BuildMediator()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e => e
+                .Register<OrderPlaced>()
+                .Register(typeof(OrderPlacedHandler))
+                .Register(typeof(TracedEventHandler))
+                .Register(typeof(AuditTracedEventHandler))))
+            .BuildServiceProvider()
+            .GetRequiredService<IEventMediator>();
+
+    [Fact]
+    public async Task Broadcast_DeliversToIndirectHandlers_DirectFirst()
+    {
+        var mediator = BuildMediator();
+        var @event = new OrderPlaced();
+
+        await mediator.PublishAsync(@event, CancellationToken.None);
+
+        // The audit-group handler stays out of default delivery.
+        Assert.Equal(["direct", "indirect"], @event.Trace);
+    }
+
+    [Fact]
+    public async Task GroupFilteredPublish_SelectsOnlyMatchingIndirectHandlers()
+    {
+        var mediator = BuildMediator();
+        var @event = new OrderPlaced();
+
+        await mediator.PublishAsync(@event, ["audit"], CancellationToken.None);
+
+        Assert.Equal(["audit"], @event.Trace);
+    }
+}

--- a/test/Stella.Ergosfare.Test.Fixtures/MessageDependencyFixture.cs
+++ b/test/Stella.Ergosfare.Test.Fixtures/MessageDependencyFixture.cs
@@ -165,7 +165,7 @@ public class MessageDependencyFixture : IFixture<MessageDependencyFixture>
     
     
     /// <summary>
-    /// Disposes the fixture, including the underlying <see cref="ServiceProvider"/> and resets the <see cref="SignalHubAccessor"/>.
+    /// Disposes the fixture, including the underlying <see cref="ServiceProvider"/>.
     /// </summary>
     public void Dispose()
     {


### PR DESCRIPTION
## Summary

Follow-up delivery: #91 was merged before its final commits were pushed, so `preview` only received the first commit (reference scanning + discovery keys). This PR carries everything that landed on `v2/sourcegen-discovery` afterwards:

- `style:` drop redundant usings from the discovery attributes
- **#92 content** (merged into this branch, never reached `preview`):
  - `feat:` `[ExcludeFromPipeline]` — opt a message out of covariant interceptors
  - `fix:` registration and dispatch-cache correctness (registry publish-before-mark race, executor-cache group snapshot, `IEventPreInterceptor` DIM bug)
  - `refactor:` contravariant flavored interceptors + shared completed-result box
  - `style:` full review sweep (usings, SignalHub leftovers, stale doc comments, `Lock` migration)
- `feat:` broadcast events to covariantly matched handlers (pushed to #92's branch after it was merged; picked up via merge commit)

## Verification
All previously reported for #92 and re-verified on the branch head: full rebuild **0 warnings / 0 errors**, all tests green on net9.0 + net10.0 (Core 122, Events 16, SourceGenerator 27), benchmark allocations exactly at baseline (**5.34 MB** / 100k dispatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
