### PR TITLE
perf: broadcast fast lane — pooled publishes, invoker plan cache, straight-through broadcast

### DIFF
--- a/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
@@ -22,6 +22,15 @@ internal sealed class ErgosfareExecutionContext(
     private IDictionary<object, object?>? _items = items;
 
     /// <summary>
+    /// Whether <see cref="_items"/> was created lazily by this context (owned) as opposed
+    /// to adopted from the caller (a settings object's dictionary). Owned dictionaries are
+    /// cleared and kept across pool reuses for their capacity; adopted ones are detached
+    /// untouched on <see cref="Clear"/> — the caller keeps whatever handlers wrote, and the
+    /// pool can never hand one dispatch's dictionary to the next.
+    /// </summary>
+    private bool _ownsItems;
+
+    /// <summary>
     /// Gets the <see cref="CancellationToken"/> associated with the current execution context.
     /// This token can be used to observe cancellation requests and propagate them to handlers or interceptors.
     /// </summary>
@@ -33,7 +42,19 @@ internal sealed class ErgosfareExecutionContext(
     /// The backing dictionary is created lazily on first access so dispatches that never
     /// touch shared items pay no allocation for it.
     /// </summary>
-    public IDictionary<object, object?> Items => _items ??= new Dictionary<object, object?>();
+    public IDictionary<object, object?> Items
+    {
+        get
+        {
+            if (_items is null)
+            {
+                _items = new Dictionary<object, object?>();
+                _ownsItems = true;
+            }
+
+            return _items;
+        }
+    }
 
     /// <summary>Re-initializes a pooled instance for a new dispatch.</summary>
     public void Reset(IDictionary<object, object?>? items, CancellationToken cancellationToken)
@@ -41,6 +62,7 @@ internal sealed class ErgosfareExecutionContext(
         if (items is not null)
         {
             _items = items;
+            _ownsItems = false;
         }
 
         CancellationToken = cancellationToken;
@@ -53,7 +75,23 @@ internal sealed class ErgosfareExecutionContext(
     /// </summary>
     public void Clear()
     {
-        _items?.Clear();
+        if (_items is not null)
+        {
+            if (_ownsItems)
+            {
+                // Lazily created here: clear and keep, so the capacity is reused.
+                _items.Clear();
+            }
+            else
+            {
+                // Adopted from the caller: detach without touching its contents — the
+                // caller reads results from it, and clearing it here would silently wipe
+                // their settings object (and retaining it would leak it into the next
+                // dispatch that rents this context).
+                _items = null;
+            }
+        }
+
         CancellationToken = default;
     }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
@@ -64,8 +64,10 @@ internal sealed class MessageDependencies : IMessageDependencies
     /// </param>
     public MessageDependencies(MessagePipelineShape shape, IServiceProvider? memoizedProvider)
     {
-        Handlers = Materialize<IHandler, IMainHandlerDescriptor>(shape.Handlers, memoizedProvider);
-        IndirectHandlers = Materialize<IHandler, IMainHandlerDescriptor>(shape.IndirectHandlers, memoizedProvider);
+        HandlerArray = Materialize<IHandler, IMainHandlerDescriptor>(shape.Handlers, memoizedProvider);
+        IndirectHandlerArray = Materialize<IHandler, IMainHandlerDescriptor>(shape.IndirectHandlers, memoizedProvider);
+        Handlers = HandlerArray;
+        IndirectHandlers = IndirectHandlerArray;
         PreInterceptors = Materialize<IPreInterceptor, IPreInterceptorDescriptor>(shape.PreInterceptors, memoizedProvider);
         PostInterceptors = Materialize<IPostInterceptor, IPostInterceptorDescriptor>(shape.PostInterceptors, memoizedProvider);
         ExceptionInterceptors = Materialize<IExceptionInterceptor, IExceptionInterceptorDescriptor>(shape.ExceptionInterceptors, memoizedProvider);
@@ -74,15 +76,28 @@ internal sealed class MessageDependencies : IMessageDependencies
         // Precomputed once per (message type, groups): the exact condition the single-handler
         // strategies use for their zero-interceptor fast path. Executors read this to invoke
         // the handler directly, without entering the strategy's async machinery.
-        FastSingleHandler =
-            Handlers.Count == 1
-            && PreInterceptors.Count == 0
+        HasNoInterceptors =
+            PreInterceptors.Count == 0
             && PostInterceptors.Count == 0
             && ExceptionInterceptors.Count == 0
-            && FinalInterceptors.Count == 0
-                ? Handlers[0]
-                : null;
+            && FinalInterceptors.Count == 0;
+
+        FastSingleHandler = HasNoInterceptors && Handlers.Count == 1 ? Handlers[0] : null;
     }
+
+    /// <summary>
+    /// The main-handler stages as concrete arrays, so hot loops index without interface
+    /// dispatch. Same instances the <see cref="Handlers"/>/<see cref="IndirectHandlers"/>
+    /// properties expose.
+    /// </summary>
+    internal IHandlerReference<IHandler, IMainHandlerDescriptor>[] HandlerArray { get; }
+    internal IHandlerReference<IHandler, IMainHandlerDescriptor>[] IndirectHandlerArray { get; }
+
+    /// <summary>
+    /// Whether all four interceptor stages are empty — the broadcast fast path's
+    /// eligibility condition, computed once at construction.
+    /// </summary>
+    internal bool HasNoInterceptors { get; }
 
     /// <summary>
     /// The sole main handler when the pipeline has exactly one handler and no interceptor

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -143,6 +143,17 @@ internal sealed class MessageMediator(
         return executor.Execute(message, context, _serviceProvider);
     }
 
+    /// <summary>
+    /// The provider of the scope this mediator was resolved from — the broadcast fast lane
+    /// (events assembly, via InternalsVisibleTo) dispatches strategies against it directly.
+    /// </summary>
+    internal IServiceProvider ScopeProvider => _serviceProvider;
+
+    /// <summary>
+    /// The dependencies factory backing this mediator; see <see cref="ScopeProvider"/>.
+    /// </summary>
+    internal IMessageDependenciesFactory DependenciesFactory => _messageDependenciesFactory;
+
     private PipelineExecutorCache RequireExecutorCache()
         => _executorCache ?? throw new InvalidOperationException(
             "Executor dispatch requires the PipelineExecutorCache; register Ergosfare through AddErgosfare or use Mediate with explicit options.");

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
@@ -212,7 +213,10 @@ internal sealed class PipelineExecutorCache(
         {
             if (_resultExecutorsByType.TryGetValue((messageType, typeof(TResult)), out var fast))
             {
-                return (IPipelineExecutor<TResult>)fast;
+                // Entries are only ever created as IPipelineExecutor<TResult> for their
+                // (message, result) key, so the interface cast can skip the runtime
+                // covariance check — a measurable cost on the hot path.
+                return Unsafe.As<IPipelineExecutor<TResult>>(fast);
             }
 
             return (IPipelineExecutor<TResult>)_resultExecutorsByType.GetOrAdd((messageType, typeof(TResult)),

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -17,6 +17,7 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 /// strategy's typed seam always hits — the handler is invoked through its typed member and
 /// its <see cref="ValueTask{TResult}"/> never crosses an object-typed bridge.
 /// </summary>
+#pragma warning disable CS8714 // TResult is used as a pattern type argument; handler contracts declare notnull results
 internal sealed class ResultPipelineExecutor<TMessage, TResult>(
     IMessageDescriptor descriptor,
     IMessageDependenciesFactory dependenciesFactory,
@@ -92,6 +93,8 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
         return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }
+
+#pragma warning restore CS8714
 
 /// <summary>
 /// Void pipeline closed over the concrete <typeparamref name="TMessage"/>; see

--- a/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
+++ b/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
@@ -14,5 +14,7 @@
      
     <ItemGroup>
         <InternalsVisibleTo Include="Ergosfare.Core.Extensions.MicrosoftDependencyInjection" />
+        <!-- The event broadcast invoker rents/returns pooled execution contexts directly. -->
+        <InternalsVisibleTo Include="Stella.Ergosfare.Events" />
     </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
@@ -33,6 +33,13 @@ public sealed class EventMediationSettings
     {
    
         /// <summary>
+        /// The canonical accept-everything predicate. Publish paths compare against this
+        /// instance by reference to recognize "no filtering requested" and skip the
+        /// per-handler predicate loop entirely.
+        /// </summary>
+        internal static readonly Func<Type, bool> AcceptAllHandlers = static _ => true;
+
+        /// <summary>
         /// Gets or sets the collection of group names used to filter event handlers.
         /// Only handlers belonging to these groups will receive the event.
         /// </summary>
@@ -43,6 +50,6 @@ public sealed class EventMediationSettings
         /// Gets or sets a predicate function to filter handlers by their type.
         /// By default, all handler types are included.
         /// </summary>
-        public Func<Type, bool> HandlerPredicate { get; set; } = _ => true;
+        public Func<Type, bool> HandlerPredicate { get; set; } = AcceptAllHandlers;
     }
 }

--- a/src/Stella.Ergosfare.Events.Abstractions/Stella.Ergosfare.Events.Abstractions.csproj
+++ b/src/Stella.Ergosfare.Events.Abstractions/Stella.Ergosfare.Events.Abstractions.csproj
@@ -8,4 +8,8 @@
       <ProjectReference Include="..\Stella.Ergosfare.Core.Abstractions\Stella.Ergosfare.Core.Abstractions.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- The broadcast fast lane reads the canonical accept-all predicate by reference. -->
+        <InternalsVisibleTo Include="Stella.Ergosfare.Events" />
+    </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -138,6 +138,14 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         IReadOnlyList<IHandlerReference<IHandler, IMainHandlerDescriptor>> handlers)
     {
         var predicate = settings.Filters.HandlerPredicate;
+
+        // The canonical accept-all predicate can be recognized by reference — no filtering
+        // requested, so skip the per-handler predicate loop entirely.
+        if (ReferenceEquals(predicate, EventMediationSettings.EventMediationFilters.AcceptAllHandlers))
+        {
+            return handlers;
+        }
+
         List<IHandlerReference<IHandler, IMainHandlerDescriptor>>? filtered = null;
 
         for (var i = 0; i < handlers.Count; i++)

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -70,20 +70,45 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         Exception? exception = null;
         try
         {
-            // events doesn't need result adapter, since events intended to not return a result
-            var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-            await preInvoker.Invoke(message, context);
-            await PublishSequentially(message, handlers, context, serviceProvider);
-            await PublishSequentially(message, indirectHandlers, context, serviceProvider);
+            // Empty stages are skipped before any invoker object exists — an invoker over an
+            // empty stage is a no-op, so the guards change allocations, not behavior.
+            if (messageDependencies.PreInterceptors.Count > 0)
+            {
+                // events doesn't need result adapter, since events intended to not return a result
+                var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
+                await preInvoker.Invoke(message, context);
+            }
 
-            // A ValueTask may be awaited only once — the completed ValueTask stands in as the
-            // (meaningless for events) result object flowing through the interceptor stages.
-            var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, null, serviceProvider);
-            await postInvoker.Invoke(message, CompletedResultBox.Instance, context);
+            if (handlers.Count > 0)
+            {
+                await PublishSequentially(message, handlers, context, serviceProvider);
+            }
+
+            if (indirectHandlers.Count > 0)
+            {
+                await PublishSequentially(message, indirectHandlers, context, serviceProvider);
+            }
+
+            if (messageDependencies.PostInterceptors.Count > 0)
+            {
+                // A ValueTask may be awaited only once — the completed ValueTask stands in as the
+                // (meaningless for events) result object flowing through the interceptor stages.
+                var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, null, serviceProvider);
+                await postInvoker.Invoke(message, CompletedResultBox.Instance, context);
+            }
         }
         catch (Exception e)
         {
             exception = e;
+
+            // Zero exception interceptors: rethrow directly — identical to the invoker's own
+            // empty-stage behavior (it rethrows via ExceptionDispatchInfo), minus the
+            // allocations. Final interceptors still run from the finally block.
+            if (messageDependencies.ExceptionInterceptors.Count == 0)
+            {
+                throw;
+            }
+
             var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
             await exceptionInvoker.Invoke(message, CompletedResultBox.Instance,
                 ExceptionDispatchInfo.Capture(e), context);
@@ -92,8 +117,11 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
 
         finally
         {
-            var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-            await finalInvoker.Invoke(message, CompletedResultBox.Instance, exception, context);
+            if (messageDependencies.FinalInterceptors.Count > 0)
+            {
+                var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
+                await finalInvoker.Invoke(message, CompletedResultBox.Instance, exception, context);
+            }
         }
     }
 

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -76,7 +76,11 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
             {
                 // events doesn't need result adapter, since events intended to not return a result
                 var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-                await preInvoker.Invoke(message, context);
+
+                // Pre-interceptors may transform the event — including returning a brand new
+                // instance — so the broadcast continues with the returned message, exactly as
+                // the single-handler strategies do.
+                message = (TMessage) await preInvoker.Invoke(message, context);
             }
 
             if (handlers.Count > 0)

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -149,6 +149,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     /// concurrent writers publish equivalent, idempotent state.
     /// </summary>
     private IMessageDependencies? _cachedDependencies;
+    private MessageDependenciesFactory? _cachedFactory;
     private int _cachedVersion = int.MinValue;
 
     private IMessageDependencies GetPlan(
@@ -159,13 +160,22 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         {
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            // The invoker is process-wide (one per event type) while factories are
+            // per-container — the factory reference is part of the cache key, so one
+            // container's plan (which may pin that container's root provider for
+            // memoized, all-singleton pipelines) is never served to another container.
+            // Multiple containers ping-ponging simply rebuild the single slot; the
+            // factory's own per-container cache keeps that cheap.
+            if (cached is not null
+                && ReferenceEquals(_cachedFactory, typedFactory)
+                && _cachedVersion == typedFactory.CurrentRegistryVersion)
             {
                 return cached;
             }
 
             var dependencies = BuildPlan(typedFactory, resolveStrategy);
             _cachedDependencies = dependencies;
+            _cachedFactory = typedFactory;
             _cachedVersion = typedFactory.CurrentRegistryVersion;
             return dependencies;
         }

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -83,7 +83,24 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 && mediator is MessageMediator concreteMediator)
             {
                 var dependencies = GetPlan(concreteMediator, resolveStrategy);
-                task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
+
+                // Straight-through broadcast: with no interceptor stages and no handler
+                // filtering requested, loop the handler arrays directly — synchronously
+                // while handlers complete synchronously, bailing to an awaiting helper on
+                // the first suspension. No strategy or per-stage async frames.
+                if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+                    && (settings is null
+                        || ReferenceEquals(settings.Filters.HandlerPredicate,
+                            EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
+                {
+                    task = PublishStraightThrough(
+                        (TEvent)@event, plan, context, concreteMediator.ScopeProvider,
+                        settings?.ThrowIfNoHandlerFound ?? false);
+                }
+                else
+                {
+                    task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
+                }
             }
             else
             {
@@ -154,6 +171,108 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         }
 
         return BuildPlan(mediator.DependenciesFactory, resolveStrategy);
+    }
+
+    /// <summary>
+    /// Broadcasts sequentially over the direct then indirect handler arrays without any
+    /// async machinery while handlers complete synchronously; the first suspension hands
+    /// the remainder to an awaiting helper, preserving strict sequential order. Semantics
+    /// match <see cref="AsyncBroadcastMediationStrategy{TMessage}"/> for the
+    /// zero-interceptor, unfiltered case: exceptions propagate raw, and an empty pipeline
+    /// throws only when <paramref name="throwIfNoHandlerFound"/> asks for it.
+    /// </summary>
+    private static ValueTask PublishStraightThrough(
+        TEvent @event,
+        MessageDependencies plan,
+        IExecutionContext context,
+        IServiceProvider serviceProvider,
+        bool throwIfNoHandlerFound)
+    {
+        var direct = plan.HandlerArray;
+        var indirect = plan.IndirectHandlerArray;
+
+        if (direct.Length == 0 && indirect.Length == 0)
+        {
+            return throwIfNoHandlerFound
+                ? ValueTask.FromException(new NoHandlerFoundException(typeof(TEvent)))
+                : default;
+        }
+
+        for (var i = 0; i < direct.Length; i++)
+        {
+            var pending = Invoke(direct[i], @event, context, serviceProvider);
+
+            if (!pending.IsCompletedSuccessfully)
+            {
+                return AwaitRemaining(pending, @event, plan, context, serviceProvider, i + 1, inIndirect: false);
+            }
+        }
+
+        for (var i = 0; i < indirect.Length; i++)
+        {
+            var pending = Invoke(indirect[i], @event, context, serviceProvider);
+
+            if (!pending.IsCompletedSuccessfully)
+            {
+                return AwaitRemaining(pending, @event, plan, context, serviceProvider, i + 1, inIndirect: true);
+            }
+        }
+
+        return default;
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitRemaining(
+            ValueTask pending, TEvent @event, MessageDependencies plan, IExecutionContext context,
+            IServiceProvider serviceProvider, int next, bool inIndirect)
+        {
+            await pending;
+
+            var direct = plan.HandlerArray;
+            var indirect = plan.IndirectHandlerArray;
+
+            if (!inIndirect)
+            {
+                for (var i = next; i < direct.Length; i++)
+                {
+                    await Invoke(direct[i], @event, context, serviceProvider);
+                }
+
+                next = 0;
+            }
+
+            for (var i = next; i < indirect.Length; i++)
+            {
+                await Invoke(indirect[i], @event, context, serviceProvider);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Invokes one handler through its typed contract — the same dispatch rules the
+    /// broadcast strategy applies.
+    /// </summary>
+    private static ValueTask Invoke(
+        Core.Abstractions.IHandlerReference<Core.Abstractions.Handlers.IHandler, Core.Abstractions.Registry.Descriptors.IMainHandlerDescriptor> reference,
+        TEvent @event,
+        IExecutionContext context,
+        IServiceProvider serviceProvider)
+    {
+        var handler = reference.Resolve(serviceProvider);
+
+        switch (handler)
+        {
+            case Core.Abstractions.Handlers.IAsyncHandler<TEvent> asyncHandler:
+                return asyncHandler.HandleAsync(@event, context);
+            case Core.Abstractions.Handlers.IHandler<TEvent, ValueTask> valueTaskShaped:
+                return valueTaskShaped.Handle(@event, context);
+            case Core.Abstractions.Handlers.IHandler<TEvent, object> syncHandler:
+                syncHandler.Handle(@event, context);
+                return ValueTask.CompletedTask;
+            default:
+                throw new NotSupportedException(
+                    $"'{handler.GetType()}' does not implement a supported handler contract for event '{typeof(TEvent)}'. " +
+                    "Interface-erased dispatch is not supported; publish with the concrete event type.");
+        }
     }
 
     private static IMessageDependencies BuildPlan(

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Internal.Contexts;
 using Stella.Ergosfare.Events.Abstractions;
 
 namespace Stella.Ergosfare.Events;
@@ -15,7 +17,7 @@ namespace Stella.Ergosfare.Events;
 /// </summary>
 internal interface IEventBroadcastInvoker
 {
-    ValueTask Publish(object @event, EventMediationSettings settings, CancellationToken cancellationToken,
+    ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null);
 }
@@ -25,21 +27,88 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 {
     private static readonly string[] EmptyGroups = [];
 
-    public ValueTask Publish(object @event, EventMediationSettings settings, CancellationToken cancellationToken,
+    /// <summary>
+    /// Shared strategy for publishes without caller-supplied settings. Safe to share: the
+    /// settings instance is private and never mutated, and the strategy keeps all
+    /// per-publish state in locals — one instance serves concurrent publishes.
+    /// </summary>
+    private static readonly EventMediationSettings DefaultSettings = new();
+    private static readonly AsyncBroadcastMediationStrategy<TEvent> DefaultStrategy = new(DefaultSettings);
+
+    public ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null)
     {
+        // Null settings (the common publish) reuse the cached default strategy — no
+        // EventMediationSettings, no Filters/List/Dictionary, no strategy allocation.
+        var strategy = settings is null
+            ? DefaultStrategy
+            : new AsyncBroadcastMediationStrategy<TEvent>(settings);
+
+        if (externalContext is not null)
+        {
+            // Caller-owned context (nested publish): the caller controls its lifetime —
+            // nothing is rented here, so nothing may be returned here.
+            return mediator.Mediate((TEvent)@event, new MediateOptions<TEvent, ValueTask>
+            {
+                MessageMediationStrategy = strategy,
+                MessageResolveStrategy = resolveStrategy,
+                CancellationToken = cancellationToken,
+                Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
+                ExternalContext = externalContext,
+            });
+        }
+
+        // Root publish: rent a pooled context and hand it to Mediate as an external
+        // context. This invoker is the completion observer — the broadcast strategy is a
+        // plain async ValueTask that awaits every handler and interceptor sequentially, so
+        // the returned task's completion really is the end of all context use.
+        // Adopting the settings' items dictionary keeps handler writes visible to the
+        // caller exactly as the unpooled path did; on return the context detaches the
+        // dictionary instead of wiping it.
+        var context = ErgosfareExecutionContextPool.Rent(settings?.Items, cancellationToken);
+
         var options = new MediateOptions<TEvent, ValueTask>
         {
-            MessageMediationStrategy = new AsyncBroadcastMediationStrategy<TEvent>(settings),
+            MessageMediationStrategy = strategy,
             MessageResolveStrategy = resolveStrategy,
             CancellationToken = cancellationToken,
-            Items = settings.Items,
-            Groups = settings.Filters.Groups,
-            ExternalContext = externalContext,
+            Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
+            ExternalContext = context,
         };
 
-        return mediator.Mediate((TEvent)@event, options);
+        ValueTask task;
+
+        try
+        {
+            task = mediator.Mediate((TEvent)@event, options);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
     }
 }
 

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -2,8 +2,11 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Core.Internal.Factories;
+using Stella.Ergosfare.Core.Internal.Mediator;
 using Stella.Ergosfare.Events.Abstractions;
 
 namespace Stella.Ergosfare.Events;
@@ -59,29 +62,40 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             });
         }
 
-        // Root publish: rent a pooled context and hand it to Mediate as an external
-        // context. This invoker is the completion observer — the broadcast strategy is a
-        // plain async ValueTask that awaits every handler and interceptor sequentially, so
-        // the returned task's completion really is the end of all context use.
-        // Adopting the settings' items dictionary keeps handler writes visible to the
-        // caller exactly as the unpooled path did; on return the context detaches the
-        // dictionary instead of wiping it.
+        // Root publish: rent a pooled context; this invoker is the completion observer —
+        // the broadcast strategy is a plain async ValueTask that awaits every handler and
+        // interceptor sequentially, so the returned task's completion really is the end of
+        // all context use. Adopting the settings' items dictionary keeps handler writes
+        // visible to the caller exactly as the unpooled path did; on return the context
+        // detaches the dictionary instead of wiping it.
         var context = ErgosfareExecutionContextPool.Rent(settings?.Items, cancellationToken);
-
-        var options = new MediateOptions<TEvent, ValueTask>
-        {
-            MessageMediationStrategy = strategy,
-            MessageResolveStrategy = resolveStrategy,
-            CancellationToken = cancellationToken,
-            Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
-            ExternalContext = context,
-        };
 
         ValueTask task;
 
         try
         {
-            task = mediator.Mediate((TEvent)@event, options);
+            // Fast lane: for the group-less publish against the concrete mediator, run the
+            // broadcast strategy directly against the invoker-cached pipeline plan (the
+            // executors' registry-version-guarded pattern) — no MediateOptions, no
+            // per-publish descriptor lookup, no Mediate wrapper. Grouped publishes and
+            // foreign mediator implementations keep the original Mediate path.
+            if ((settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 })
+                && mediator is MessageMediator concreteMediator)
+            {
+                var dependencies = GetPlan(concreteMediator, resolveStrategy);
+                task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
+            }
+            else
+            {
+                task = mediator.Mediate((TEvent)@event, new MediateOptions<TEvent, ValueTask>
+                {
+                    MessageMediationStrategy = strategy,
+                    MessageResolveStrategy = resolveStrategy,
+                    CancellationToken = cancellationToken,
+                    Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
+                    ExternalContext = context,
+                });
+            }
         }
         catch
         {
@@ -109,6 +123,50 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 ErgosfareExecutionContextPool.Return(context);
             }
         }
+    }
+
+    /// <summary>
+    /// The group-less pipeline plan for <typeparamref name="TEvent"/>, cached on the
+    /// invoker and re-validated against the registry version — runtime registrations
+    /// invalidate it exactly as they invalidate the executors' caches. Races are benign:
+    /// concurrent writers publish equivalent, idempotent state.
+    /// </summary>
+    private IMessageDependencies? _cachedDependencies;
+    private int _cachedVersion = int.MinValue;
+
+    private IMessageDependencies GetPlan(
+        MessageMediator mediator,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        if (mediator.DependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = BuildPlan(typedFactory, resolveStrategy);
+            _cachedDependencies = dependencies;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return BuildPlan(mediator.DependenciesFactory, resolveStrategy);
+    }
+
+    private static IMessageDependencies BuildPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory factory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        // Mirrors MessageMediator.Mediate's descriptor handling for the options the old
+        // path used: RegisterPlainMessagesOnSpot was never set for events, so an
+        // unregistered event type throws NoHandlerFoundException here as it did there.
+        var descriptor = resolveStrategy.Find(typeof(TEvent))
+                         ?? throw new NoHandlerFoundException(typeof(TEvent));
+
+        return factory.Create(typeof(TEvent), descriptor, EmptyGroups);
     }
 }
 

--- a/src/Stella.Ergosfare.Events/EventMediator.cs
+++ b/src/Stella.Ergosfare.Events/EventMediator.cs
@@ -29,7 +29,7 @@ public sealed class EventMediator(
                              CancellationToken cancellationToken = default)
     {
         return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings ?? new EventMediationSettings(), cancellationToken,
+            @event, eventMediationSettings, cancellationToken,
             messageMediator, messageResolveStrategy, resultAdapterService);
     }
 
@@ -46,7 +46,7 @@ public sealed class EventMediator(
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
         return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings ?? new EventMediationSettings(), cancellationToken,
+            @event, eventMediationSettings, cancellationToken,
             messageMediator, messageResolveStrategy, resultAdapterService);
     }
 
@@ -63,7 +63,7 @@ public sealed class EventMediator(
                              EventMediationSettings? eventMediationSettings = null)
     {
         return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings ?? new EventMediationSettings(), context.CancellationToken,
+            @event, eventMediationSettings, context.CancellationToken,
             messageMediator, messageResolveStrategy, resultAdapterService, context);
     }
 }

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -1,19 +1,16 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Microsoft.Extensions.DependencyInjection;
-using Stella.Ergosfare;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.Handlers;
-using Stella.Ergosfare.Core.Abstractions.Registry;
-using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 using MediatR;
-using LiteBus.Commands;
-using LiteBus.Extensions.Microsoft.DependencyInjection;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace Stella.Ergosfare.Benchmarks;
 
@@ -25,146 +22,209 @@ public class Program
     }
 }
 
-public class StellaMessage : IMessage { }
-public class StellaHandler : IAsyncHandler<StellaMessage>
+// ---------------------------------------------------------------------------
+// Ergosfare messages & handlers
+// ---------------------------------------------------------------------------
+
+public sealed class VoidCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+
+public sealed class VoidCommandHandler : ICommandHandler<VoidCommand>
 {
-    public ValueTask HandleAsync(StellaMessage message, IExecutionContext context) => ValueTask.CompletedTask;
+    public ValueTask HandleAsync(VoidCommand command, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
-public class StellaCommand : ICommand { }
-public class StellaCommandHandler : ICommandHandler<StellaCommand>
+public sealed class IntQuery : IQuery<int> { }
+
+public sealed class IntQueryHandler : IQueryHandler<IntQuery, int>
 {
-    public ValueTask HandleAsync(StellaCommand message, IExecutionContext context) => ValueTask.CompletedTask;
+    public ValueTask<int> HandleAsync(IntQuery query, IExecutionContext context) => ValueTask.FromResult(7);
 }
 
-public class LiteBusCommand : LiteBus.Commands.Abstractions.ICommand { }
-public class LiteBusCommandHandler : LiteBus.Commands.Abstractions.ICommandHandler<LiteBusCommand>
+public sealed class PingEvent : IEvent { }
+
+public sealed class FirstPingEventHandler : IEventHandler<PingEvent>
 {
-    public Task HandleAsync(LiteBusCommand message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public ValueTask HandleAsync(PingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
-public class MediatrRequest : IRequest { }
-public class MediatrHandler : IRequestHandler<MediatrRequest>
+public sealed class SecondPingEventHandler : IEventHandler<PingEvent>
 {
-    public Task Handle(MediatrRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
+    public ValueTask HandleAsync(PingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
+// ---------------------------------------------------------------------------
+// MediatR requests & handlers
+// ---------------------------------------------------------------------------
+
+public sealed class MediatrVoidRequest : IRequest { }
+
+public sealed class MediatrVoidRequestHandler : IRequestHandler<MediatrVoidRequest>
+{
+    public Task Handle(MediatrVoidRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+public sealed class MediatrIntRequest : IRequest<int> { }
+
+public sealed class MediatrIntRequestHandler : IRequestHandler<MediatrIntRequest, int>
+{
+    public Task<int> Handle(MediatrIntRequest request, CancellationToken cancellationToken) => Task.FromResult(7);
+}
+
+public sealed class MediatrPingNotification : INotification { }
+
+public sealed class FirstMediatrPingHandler : INotificationHandler<MediatrPingNotification>
+{
+    public Task Handle(MediatrPingNotification notification, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+public sealed class SecondMediatrPingHandler : INotificationHandler<MediatrPingNotification>
+{
+    public Task Handle(MediatrPingNotification notification, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Two scenarios, grouped as table categories:
+/// <para><b>Root</b> — mediators resolved once from the root provider (singleton-style
+/// usage: background workers, message-pump loops).</para>
+/// <para><b>Scoped</b> — a fresh DI scope per dispatch (the web-request shape; includes
+/// scope creation and mediator resolution in every measurement).</para>
+/// Each category carries the raw <see cref="IMessageMediator"/> engine dispatch as its
+/// baseline — that is the floor the public facades add their convenience on top of, and
+/// the Ratio column reads as "what does the facade (or MediatR) cost relative to it".
+/// Within each category: a void dispatch, a result-returning dispatch, and a two-handler
+/// event publish, for Ergosfare and MediatR alike.
+/// </summary>
 [MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
 public class MediationBenchmark
 {
-    private IServiceProvider _stellaProvider = null!;
-    private IMessageMediator _stellaMediator = null!;
-    private ICommandMediator _stellaCommandMediator = null!;
-    private StellaMessage _stellaMessage = null!;
-    private StellaCommand _stellaCommand = null!;
-    private MediateOptions<StellaMessage, ValueTask> _stellaOptions = null!;
+    private ServiceProvider _ergosfare = null!;
+    private ServiceProvider _mediatr = null!;
 
-    private IServiceProvider _mediatrProvider = null!;
-    private IMediator _mediatrMediator = null!;
-    private MediatrRequest _mediatrRequest = null!;
+    private IMessageMediator _engine = null!;
+    private ICommandMediator _commands = null!;
+    private IQueryMediator _queries = null!;
+    private IEventMediator _events = null!;
+    private IMediator _mediator = null!;
 
-    private IServiceProvider _liteBusProvider = null!;
-    private LiteBus.Commands.Abstractions.ICommandMediator _liteBusCommandMediator = null!;
-    private LiteBusCommand _liteBusCommand = null!;
+    private readonly VoidCommand _voidCommand = new();
+    private readonly IntQuery _intQuery = new();
+    private readonly PingEvent _pingEvent = new();
+    private readonly MediatrVoidRequest _mediatrVoid = new();
+    private readonly MediatrIntRequest _mediatrInt = new();
+    private readonly MediatrPingNotification _mediatrPing = new();
 
     [GlobalSetup]
     public void Setup()
     {
-        // Stella Setup
-        var stellaServices = new ServiceCollection();
-        stellaServices.AddErgosfare(options => {
-            options.AddCoreModule(module => {
-                module.Register<StellaHandler>();
-            });
-            options.AddCommandModule(module => {
-                module.Register<StellaCommandHandler>();
-            });
-        });
-        _stellaProvider = stellaServices.BuildServiceProvider();
-        _stellaMediator = _stellaProvider.GetRequiredService<IMessageMediator>();
-        _stellaCommandMediator = _stellaProvider.GetRequiredService<ICommandMediator>();
-        _stellaMessage = new StellaMessage();
-        _stellaCommand = new StellaCommand();
+        _ergosfare = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+                options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
+                options.AddEventModule(events =>
+                {
+                    events.Register<FirstPingEventHandler>();
+                    events.Register<SecondPingEventHandler>();
+                });
+            })
+            .BuildServiceProvider();
 
-        _stellaOptions = new MediateOptions<StellaMessage, ValueTask>
-        {
-            CancellationToken = CancellationToken.None,
-            Groups = [],
-            MessageMediationStrategy = new SingleAsyncHandlerMediationStrategy<StellaMessage>(null),
-            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(_stellaProvider.GetRequiredService<IMessageRegistry>())
-        };
+        _engine = _ergosfare.GetRequiredService<IMessageMediator>();
+        _commands = _ergosfare.GetRequiredService<ICommandMediator>();
+        _queries = _ergosfare.GetRequiredService<IQueryMediator>();
+        _events = _ergosfare.GetRequiredService<IEventMediator>();
 
-        // MediatR Setup
-        var mediatrServices = new ServiceCollection();
-        mediatrServices.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(MediationBenchmark).Assembly));
-        _mediatrProvider = mediatrServices.BuildServiceProvider();
-        _mediatrMediator = _mediatrProvider.GetRequiredService<IMediator>();
-        _mediatrRequest = new MediatrRequest();
+        _mediatr = new ServiceCollection()
+            .AddMediatR(configuration => configuration.RegisterServicesFromAssembly(typeof(MediationBenchmark).Assembly))
+            .BuildServiceProvider();
 
-        // LiteBus Setup
-        var liteBusServices = new ServiceCollection();
-        liteBusServices.AddLiteBus(builder => {
-            builder.AddCommandModule(module => {
-                module.Register<LiteBusCommandHandler>();
-            });
-        });
-        _liteBusProvider = liteBusServices.BuildServiceProvider();
-        _liteBusCommandMediator = _liteBusProvider.GetRequiredService<LiteBus.Commands.Abstractions.ICommandMediator>();
-        _liteBusCommand = new LiteBusCommand();
+        _mediator = _mediatr.GetRequiredService<IMediator>();
     }
 
-    [Benchmark]
-    public async Task StellaErgosfare()
+    [GlobalCleanup]
+    public void Cleanup()
     {
-
-        for (var i = 0; i < 100000; i++)
-            await _stellaMediator.Mediate(_stellaMessage, _stellaOptions);
+        _ergosfare.Dispose();
+        _mediatr.Dispose();
     }
 
-    // Full public API path (settings/options/strategy handling included),
-    // symmetric with the MediatR benchmark which also uses its public Send.
-    [Benchmark]
-    public async Task StellaErgosfare_PublicApi()
+    // ------------------------------------------------------------------
+    // Root — mediators resolved once, no per-dispatch scope
+    // ------------------------------------------------------------------
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Root")]
+    public ValueTask Engine_Void() => _engine.DispatchAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Event_Publish() => _events.PublishAsync(_pingEvent);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public Task MediatR_Send_Void() => _mediator.Send(_mediatrVoid);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public Task<int> MediatR_Send_Result() => _mediator.Send(_mediatrInt);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public Task MediatR_Publish() => _mediator.Publish(_mediatrPing);
+
+    // ------------------------------------------------------------------
+    // Scoped — a fresh DI scope and mediator resolution per dispatch
+    // ------------------------------------------------------------------
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Scoped")]
+    public async Task Engine_Void_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-            await _stellaCommandMediator.SendAsync(_stellaCommand);
+        using var scope = _ergosfare.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMessageMediator>().DispatchAsync(_voidCommand);
     }
 
-    [Benchmark]
-    public async Task MediatR()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task Command_Void_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-            await _mediatrMediator.Send(_mediatrRequest);
+        using var scope = _ergosfare.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<ICommandMediator>().SendAsync(_voidCommand);
     }
 
-    // Ergosfare is an independent implementation whose design (API surface, naming) was
-    // heavily inspired by LiteBus, so LiteBus is included as a reference point.
-    [Benchmark]
-    public async Task LiteBus_PublicApi()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task<int> Query_Result_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-            await _liteBusCommandMediator.SendAsync(_liteBusCommand);
+        using var scope = _ergosfare.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<IQueryMediator>().QueryAsync(_intQuery);
     }
 
-    // Fresh DI scope per dispatch — the realistic per-request shape where
-    // lifetime-aware (scoped) handler resolution actually pays its cost.
-    [Benchmark]
-    public async Task StellaErgosfare_PublicApi_ScopePerDispatch()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task Event_Publish_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-        {
-            using var scope = _stellaProvider.CreateScope();
-            await scope.ServiceProvider.GetRequiredService<ICommandMediator>().SendAsync(_stellaCommand);
-        }
+        using var scope = _ergosfare.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IEventMediator>().PublishAsync(_pingEvent);
     }
 
-    [Benchmark]
-    public async Task MediatR_ScopePerDispatch()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatR_Send_Void_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-        {
-            using var scope = _mediatrProvider.CreateScope();
-            await scope.ServiceProvider.GetRequiredService<IMediator>().Send(_mediatrRequest);
-        }
+        using var scope = _mediatr.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMediator>().Send(_mediatrVoid);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task<int> MediatR_Send_Result_Scoped()
+    {
+        using var scope = _mediatr.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<IMediator>().Send(_mediatrInt);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatR_Publish_Scoped()
+    {
+        using var scope = _mediatr.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMediator>().Publish(_mediatrPing);
     }
 }

--- a/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
+++ b/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
@@ -6,7 +6,6 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageReference Include="MediatR" Version="12.4.1" />
-        <PackageReference Include="LiteBus.Commands.Extensions.Microsoft.DependencyInjection" Version="4.3.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     </ItemGroup>
     <PropertyGroup>

--- a/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
@@ -1,0 +1,147 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Covers the dispatch fast path's interaction with caller-supplied settings items —
+/// the pooled context adopts the caller's dictionary for the dispatch and detaches it
+/// untouched on return — and the executor-level plan cache's registry-version
+/// invalidation for runtime registrations.
+/// </summary>
+public class DispatchItemsAndInvalidationTests
+{
+    public sealed class ItemsCommand : ICommand { }
+
+    public sealed class ItemsCommandHandler : ICommandHandler<ItemsCommand>
+    {
+        public ValueTask HandleAsync(ItemsCommand command, IExecutionContext context)
+        {
+            context.Set("writtenByHandler", "yes");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ShouldNotWipeCallerSettingsItems_AndShouldExposeHandlerWrites()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ItemsCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        settings.Items["keep"] = "me";
+
+        await mediator.SendAsync(new ItemsCommand(), settings);
+
+        Assert.Equal("me", settings.Items["keep"]);
+        Assert.Equal("yes", settings.Items["writtenByHandler"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ShouldNotLeakOneDispatchesItems_IntoTheNext()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ItemsCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new CommandMediationSettings();
+        first.Items["secret"] = "data";
+        await mediator.SendAsync(new ItemsCommand(), first);
+
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new ItemsCommand(), second);
+
+        // The second dispatch's pooled context must not surface the first caller's items,
+        // and writing during the second dispatch must not reach the first caller.
+        Assert.False(second.Items.ContainsKey("secret"));
+        Assert.Equal("data", first.Items["secret"]);
+    }
+
+    public sealed class LateInterceptedCommand : ICommand { }
+
+    public sealed class LateInterceptedCommandHandler : ICommandHandler<LateInterceptedCommand>
+    {
+        public ValueTask HandleAsync(LateInterceptedCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    public sealed class LateRegisteredInterceptor : ICommandPreInterceptor<LateInterceptedCommand>
+    {
+        public ValueTask<LateInterceptedCommand> HandleAsync(LateInterceptedCommand command, IExecutionContext context)
+        {
+            context.Set("lateInterceptorRan", true);
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ShouldPickUpRuntimeRegistrations_AfterWarmingTheExecutorCache()
+    {
+        var provider = new ServiceCollection()
+            .AddTransient<LateRegisteredInterceptor>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<LateInterceptedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // Warm the executor's cached plan on the zero-interceptor fast path.
+        var warm = new CommandMediationSettings();
+        await mediator.SendAsync(new LateInterceptedCommand(), warm);
+        await mediator.SendAsync(new LateInterceptedCommand(), warm);
+        Assert.False(warm.Items.ContainsKey("lateInterceptorRan"));
+
+        // A runtime registration bumps the registry version; the cached plan must rebuild
+        // and the dispatch must leave the fast path for the full pipeline.
+        registry.Register(typeof(LateRegisteredInterceptor));
+
+        var probe = new CommandMediationSettings();
+        await mediator.SendAsync(new LateInterceptedCommand(), probe);
+
+        Assert.Equal(true, probe.Items["lateInterceptorRan"]);
+    }
+
+    public sealed class ResultCommand : ICommand<int> { }
+
+    public sealed class ResultCommandHandler : ICommandHandler<ResultCommand, int>
+    {
+        public ValueTask<int> HandleAsync(ResultCommand command, IExecutionContext context)
+            => ValueTask.FromResult(42);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ResultCommand_ShouldFlowThroughTheResultFastPath()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ResultCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Repeated sends exercise the cached result-executor lookup.
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(42, await mediator.SendAsync(new ResultCommand()));
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Core.Test/ExecutionContextItemsOwnershipTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/ExecutionContextItemsOwnershipTests.cs
@@ -1,0 +1,91 @@
+using Stella.Ergosfare.Core.Internal.Contexts;
+
+namespace Stella.Ergosfare.Core.Test;
+
+/// <summary>
+/// Unit tests for the items-dictionary ownership rules of
+/// <see cref="ErgosfareExecutionContext"/>: a dictionary adopted from the caller (a
+/// settings object) must survive the context's return to the pool untouched, while the
+/// lazily created (owned) dictionary is cleared and kept for capacity reuse — and one
+/// dispatch's items must never leak into the next dispatch that rents the same context.
+/// </summary>
+public class ExecutionContextItemsOwnershipTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Return_ShouldDetachAdoptedDictionary_WithoutClearingIt()
+    {
+        var callerItems = new Dictionary<object, object?> { ["seed"] = "value" };
+
+        var context = ErgosfareExecutionContextPool.Rent(callerItems, CancellationToken.None);
+        context.Set("writtenByHandler", 42);
+
+        ErgosfareExecutionContextPool.Return(context);
+
+        // The caller keeps both its own seed and what handlers wrote during the dispatch.
+        Assert.Equal("value", callerItems["seed"]);
+        Assert.Equal(42, callerItems["writtenByHandler"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Rent_AfterAdoptedDispatch_ShouldNotExposePreviousCallersItems()
+    {
+        var callerItems = new Dictionary<object, object?> { ["secret"] = "data" };
+
+        var first = ErgosfareExecutionContextPool.Rent(callerItems, CancellationToken.None);
+        ErgosfareExecutionContextPool.Return(first);
+
+        // The same pooled instance comes back on this thread; it must not carry the
+        // previous caller's dictionary.
+        var second = ErgosfareExecutionContextPool.Rent(items: null, CancellationToken.None);
+
+        Assert.False(second.Has("secret"));
+
+        ErgosfareExecutionContextPool.Return(second);
+
+        // And writing through the second context must never reach the first caller.
+        Assert.False(callerItems.ContainsKey("lateWrite"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Return_ShouldClearOwnedDictionary_AndReuseItAcrossRents()
+    {
+        var first = ErgosfareExecutionContextPool.Rent(items: null, CancellationToken.None);
+        first.Set("transient", "state");
+        ErgosfareExecutionContextPool.Return(first);
+
+        var second = ErgosfareExecutionContextPool.Rent(items: null, CancellationToken.None);
+
+        Assert.False(second.Has("transient"));
+
+        ErgosfareExecutionContextPool.Return(second);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Reset_WithNewAdoptedDictionary_ShouldReplaceDetachedOne()
+    {
+        var firstCaller = new Dictionary<object, object?> { ["a"] = 1 };
+        var secondCaller = new Dictionary<object, object?> { ["b"] = 2 };
+
+        var context = ErgosfareExecutionContextPool.Rent(firstCaller, CancellationToken.None);
+        ErgosfareExecutionContextPool.Return(context);
+
+        var reused = ErgosfareExecutionContextPool.Rent(secondCaller, CancellationToken.None);
+
+        Assert.False(reused.Has("a"));
+        Assert.True(reused.Has("b"));
+
+        reused.Set("c", 3);
+        ErgosfareExecutionContextPool.Return(reused);
+
+        Assert.False(firstCaller.ContainsKey("c"));
+        Assert.Equal(3, secondCaller["c"]);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -343,6 +343,51 @@ public class BroadcastFastLaneTests
         }
     }
 
+    public sealed class IsolatedEvent : IEvent { }
+
+    public sealed class IsolatedEventHandler : IEventHandler<IsolatedEvent>
+    {
+        public ValueTask HandleAsync(IsolatedEvent @event, IExecutionContext context)
+        {
+            context.Set("handlerInstance", this);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithMemoizedPipeline_ShouldNeverServeAnotherContainersPlan()
+    {
+        // Singleton-registered handler => memoized pipeline, whose plan pins the creating
+        // container's root provider. The process-wide invoker must key its cached plan by
+        // factory, so two containers publishing the same event type each hit their own
+        // handler instance.
+        static ServiceProvider BuildContainer() => new ServiceCollection()
+            .AddSingleton<IsolatedEventHandler>()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<IsolatedEventHandler>()))
+            .BuildServiceProvider();
+
+        await using var first = BuildContainer();
+        await using var second = BuildContainer();
+
+        var firstInstance = first.GetRequiredService<IsolatedEventHandler>();
+        var secondInstance = second.GetRequiredService<IsolatedEventHandler>();
+        Assert.NotSame(firstInstance, secondInstance);
+
+        var settings = new EventMediationSettings();
+        await first.GetRequiredService<IEventMediator>().PublishAsync(new IsolatedEvent(), settings);
+        Assert.Same(firstInstance, settings.Items["handlerInstance"]);
+
+        settings = new EventMediationSettings();
+        await second.GetRequiredService<IEventMediator>().PublishAsync(new IsolatedEvent(), settings);
+        Assert.Same(secondInstance, settings.Items["handlerInstance"]);
+
+        settings = new EventMediationSettings();
+        await first.GetRequiredService<IEventMediator>().PublishAsync(new IsolatedEvent(), settings);
+        Assert.Same(firstInstance, settings.Items["handlerInstance"]);
+    }
+
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -1,0 +1,366 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Covers the broadcast fast lane: pooled execution contexts with caller-owned items
+/// semantics, the cached default-settings strategy, the invoker-cached pipeline plan and
+/// its registry-version invalidation, and the pre-interceptor message transformation.
+/// </summary>
+public class BroadcastFastLaneTests
+{
+    private static ServiceProvider Build(Action<EventModuleBuilder>? extra = null)
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<FastLaneEventHandler>();
+                e.Register<FastLaneSecondHandler>();
+                extra?.Invoke(e);
+            }))
+            .BuildServiceProvider();
+
+    public sealed class FastLaneEvent : IEvent { public string? Tag { get; init; } }
+
+    public sealed class FastLaneEventHandler : IEventHandler<FastLaneEvent>
+    {
+        public ValueTask HandleAsync(FastLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("writtenByHandler", @event.Tag ?? "-");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class FastLaneSecondHandler : IEventHandler<FastLaneEvent>
+    {
+        public ValueTask HandleAsync(FastLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("secondHandlerRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldMakeHandlerWrites_VisibleInCallerSettingsItems()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new FastLaneEvent { Tag = "t1" }, settings);
+
+        Assert.Equal("t1", settings.Items["writtenByHandler"]);
+        Assert.Equal(true, settings.Items["secondHandlerRan"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldKeepCallerSeededItems_AndSurviveTheDispatch()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+        settings.Items["seed"] = "hello";
+
+        await mediator.PublishAsync(new FastLaneEvent(), settings);
+
+        // The dictionary is adopted for the dispatch and detached on return — never wiped.
+        Assert.Equal("hello", settings.Items["seed"]);
+        Assert.True(settings.Items.ContainsKey("writtenByHandler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithDefaultSettings_ShouldStartFromACleanPooledContext()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // First publish seeds a caller dictionary through the pooled context.
+        var settings = new EventMediationSettings();
+        settings.Items["seed"] = "hello";
+        await mediator.PublishAsync(new FastLaneEvent(), settings);
+
+        // A default-settings publish right after must not observe any of it, and must not
+        // pollute the earlier caller's dictionary either.
+        var probe = new EventMediationSettings();
+        await mediator.PublishAsync(new FastLaneEvent { Tag = "probe" }, probe);
+
+        Assert.False(probe.Items.ContainsKey("seed"));
+        Assert.Equal("probe", probe.Items["writtenByHandler"]);
+        Assert.Equal("hello", settings.Items["seed"]);
+        Assert.NotEqual("probe", settings.Items["writtenByHandler"]);
+    }
+
+    public sealed class RewrittenEvent : IEvent { public string Payload { get; init; } = "original"; }
+
+    public sealed class RewritingPreInterceptor : IEventPreInterceptor<RewrittenEvent>
+    {
+        public ValueTask<RewrittenEvent> HandleAsync(RewrittenEvent @event, IExecutionContext context)
+            => ValueTask.FromResult(new RewrittenEvent { Payload = @event.Payload + "+rewritten" });
+    }
+
+    public sealed class RewrittenEventHandler : IEventHandler<RewrittenEvent>
+    {
+        public ValueTask HandleAsync(RewrittenEvent @event, IExecutionContext context)
+        {
+            context.Set("observedPayload", @event.Payload);
+            context.Set("observedInstance", @event);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldContinueWithThePreInterceptorsReturnedEvent()
+    {
+        await using var provider = Build(e =>
+        {
+            e.Register<RewritingPreInterceptor>();
+            e.Register<RewrittenEventHandler>();
+        });
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+        var original = new RewrittenEvent();
+
+        await mediator.PublishAsync(original, settings);
+
+        // The handler received the brand-new instance the pre-interceptor returned.
+        Assert.Equal("original+rewritten", settings.Items["observedPayload"]);
+        Assert.NotSame(original, settings.Items["observedInstance"]);
+    }
+
+    public sealed class ThrowingEvent : IEvent { }
+
+    public sealed class ThrowingEventHandler : IEventHandler<ThrowingEvent>
+    {
+        public ValueTask HandleAsync(ThrowingEvent @event, IExecutionContext context)
+            => throw new InvalidOperationException("evt-boom");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldPropagateHandlerException_WhenNoExceptionInterceptorsExist()
+    {
+        await using var provider = Build(e => e.Register<ThrowingEventHandler>());
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.PublishAsync(new ThrowingEvent()));
+
+        Assert.Equal("evt-boom", exception.Message);
+    }
+
+    public sealed class HandlerlessEvent : IEvent { }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldHonorThrowIfNoHandlerFound()
+    {
+        await using var provider = Build(e => e.Register<HandlerlessEvent>());
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // Default: silent.
+        await mediator.PublishAsync(new HandlerlessEvent());
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(async () =>
+            await mediator.PublishAsync(
+                new HandlerlessEvent(),
+                new EventMediationSettings { ThrowIfNoHandlerFound = true }));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldApplyHandlerPredicateFilter()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+        settings.Filters.HandlerPredicate = type => type != typeof(FastLaneSecondHandler);
+
+        await mediator.PublishAsync(new FastLaneEvent { Tag = "filtered" }, settings);
+
+        Assert.Equal("filtered", settings.Items["writtenByHandler"]);
+        Assert.False(settings.Items.ContainsKey("secondHandlerRan"));
+    }
+
+    public sealed class SlowEvent : IEvent { }
+
+    public sealed class SlowEventHandler : IEventHandler<SlowEvent>
+    {
+        public async ValueTask HandleAsync(SlowEvent @event, IExecutionContext context)
+        {
+            await Task.Delay(10);
+            context.Set("afterAwait", 42);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithGenuinelyAsyncHandler_ShouldCompleteAndExposeItems()
+    {
+        await using var provider = Build(e => e.Register<SlowEventHandler>());
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new SlowEvent(), settings);
+
+        Assert.Equal(42, settings.Items["afterAwait"]);
+    }
+
+    public sealed class OuterEvent : IEvent { }
+    public sealed class InnerEvent : IEvent { }
+
+    public sealed class InnerEventHandler : IEventHandler<InnerEvent>
+    {
+        public ValueTask HandleAsync(InnerEvent @event, IExecutionContext context)
+        {
+            context.Set("innerRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class OuterEventHandler(IEventMediator events) : IEventHandler<OuterEvent>
+    {
+        public async ValueTask HandleAsync(OuterEvent @event, IExecutionContext context)
+        {
+            using var scope = context.CreateScope();
+            await events.PublishAsync(new InnerEvent(), scope.Context);
+            context.Set("outerSawInner", scope.Context.Has("innerRan"));
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_Nested_ShouldRunUnderTheCallerOwnedChildContext()
+    {
+        await using var provider = Build(e =>
+        {
+            e.Register<OuterEventHandler>();
+            e.Register<InnerEventHandler>();
+        });
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new OuterEvent(), settings);
+
+        Assert.Equal(true, settings.Items["outerSawInner"]);
+    }
+
+    public sealed class LateEvent : IEvent { }
+
+    public sealed class LateEventHandler : IEventHandler<LateEvent>
+    {
+        public ValueTask HandleAsync(LateEvent @event, IExecutionContext context)
+        {
+            context.Set("lateHandlerRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldPickUpRuntimeRegistrations_AfterWarmingTheInvokerPlan()
+    {
+        var provider = new ServiceCollection()
+            .AddTransient<LateEventHandler>()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<LateEvent>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // Warm the invoker-cached plan with zero handlers (silent publishes).
+        var warm = new EventMediationSettings();
+        await mediator.PublishAsync(new LateEvent(), warm);
+        await mediator.PublishAsync(new LateEvent(), warm);
+        Assert.False(warm.Items.ContainsKey("lateHandlerRan"));
+
+        // A runtime registration bumps the registry version; the cached plan must rebuild.
+        registry.Register(typeof(LateEventHandler));
+
+        var probe = new EventMediationSettings();
+        await mediator.PublishAsync(new LateEvent(), probe);
+
+        Assert.Equal(true, probe.Items["lateHandlerRan"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_InParallel_ShouldNeverMixPerPublishItems()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var mismatches = 0;
+
+        await Task.WhenAll(Enumerable.Range(0, 4).Select(lane => Task.Run(async () =>
+        {
+            for (var i = 0; i < 2_000; i++)
+            {
+                var settings = new EventMediationSettings();
+                var tag = $"{lane}:{i}";
+
+                await mediator.PublishAsync(new FastLaneEvent { Tag = tag }, settings);
+
+                if (!Equals(settings.Items["writtenByHandler"], tag))
+                {
+                    Interlocked.Increment(ref mismatches);
+                }
+            }
+        })));
+
+        Assert.Equal(0, mismatches);
+    }
+
+    public sealed class ScopedProbe { }
+
+    public sealed class ScopedEvent : IEvent { }
+
+    public sealed class ScopedEventHandler(ScopedProbe probe) : IEventHandler<ScopedEvent>
+    {
+        public ValueTask HandleAsync(ScopedEvent @event, IExecutionContext context)
+        {
+            context.Set("probe", probe);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_FromAScope_ShouldResolveHandlersAgainstThatScope()
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<ScopedProbe>()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<ScopedEventHandler>()))
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        await using var _ = provider;
+
+        using var scope = provider.CreateScope();
+        var expected = scope.ServiceProvider.GetRequiredService<ScopedProbe>();
+        var settings = new EventMediationSettings();
+
+        await scope.ServiceProvider.GetRequiredService<IEventMediator>()
+            .PublishAsync(new ScopedEvent(), settings);
+
+        Assert.Same(expected, settings.Items["probe"]);
+    }
+}


### PR DESCRIPTION
Event publishing joins the executor-style fast path:

- Group-less publishes rent a pooled execution context and reuse a cached default strategy — no settings object, no filter list, no strategy allocation. Caller-supplied items are adopted for the dispatch and detached untouched.
- The broadcast invoker caches the event's resolved pipeline, re-validated against the registry version and keyed by the dependencies-factory reference so one container's plan is never served to another.
- Unfiltered publishes over interceptor-free pipelines loop the handler arrays straight through, synchronously while handlers complete synchronously, bailing to an awaiting helper on the first suspension — order preserved.
- Fix: a broadcast now continues with the event instance a pre-interceptor returns.
- Grouped publishes, predicate filters, external contexts and foreign mediator implementations keep the original Mediate path unchanged.

Covered by the 12-fact `BroadcastFastLaneTests` suite plus items-ownership and invalidation facts. Benchmark tables are embedded in the individual commit messages.

Part 1/6 of the v2.3.0-preview stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)