### PR TITLE
perf: single-object facades — dispatch through a scope-free engine singleton

### DIFF
--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
@@ -32,7 +32,8 @@ internal class CommandModule : IModule
         // provider that resolved it — a transient still receives the calling scope's provider,
         // so per-dispatch handler resolution binds to the right scope. Scoped registration
         // would pay the scope lock + resolved-services dictionary insert on every fresh
-        // scope (the scope-per-dispatch hot path) with nothing to amortize it.
-        configuration.Services.TryAddTransient<ICommandMediator, CommandMediator>();
+        // scope (the scope-per-dispatch hot path) with nothing to amortize it. The
+        // engine-backed shape makes the facade the only object built per resolution.
+        configuration.Services.TryAddTransient<ICommandMediator, EngineBackedCommandMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/EngineBackedCommandMediator.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/EngineBackedCommandMediator.cs
@@ -1,0 +1,13 @@
+using Stella.Ergosfare.Core;
+
+namespace Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+
+/// <summary>
+/// DI-facing shape of <see cref="CommandMediator"/> with exactly one constructor, so
+/// container activation binds the engine-backed path deterministically — no
+/// multi-constructor ambiguity, and no per-resolution service lookup a factory
+/// registration would pay. Resolving <see cref="Stella.Ergosfare.Commands.Abstractions.ICommandMediator"/>
+/// builds this single object; the engine itself is a process-wide singleton.
+/// </summary>
+internal sealed class EngineBackedCommandMediator(MessageDispatchEngine engine, IServiceProvider serviceProvider)
+    : CommandMediator(engine, serviceProvider);

--- a/src/Stella.Ergosfare.Commands/CommandMediator.cs
+++ b/src/Stella.Ergosfare.Commands/CommandMediator.cs
@@ -1,4 +1,5 @@
 using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 
 namespace Stella.Ergosfare.Commands;
@@ -8,19 +9,68 @@ namespace Stella.Ergosfare.Commands;
 /// runtime type: handlers are always invoked through their typed members, and the dispatch
 /// path carries no object-typed bridge, options object, or erased strategy.
 /// </summary>
-public class CommandMediator(IMessageMediator messageMediator) : ICommandMediator
+public class CommandMediator : ICommandMediator
 {
+    /// <summary>
+    /// The mediator backing the original construction shape; null when the facade is
+    /// engine-backed.
+    /// </summary>
+    private readonly IMessageMediator? _messageMediator;
+
+    /// <summary>
+    /// The singleton dispatch engine; null when the facade wraps an
+    /// <see cref="IMessageMediator"/>.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine;
+
+    /// <summary>
+    /// The scope provider handlers resolve against on the engine path.
+    /// </summary>
+    private readonly IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Wraps an existing <see cref="IMessageMediator"/> — the original construction shape,
+    /// kept for direct construction and foreign mediator implementations.
+    /// </summary>
+    public CommandMediator(IMessageMediator messageMediator)
+    {
+        _messageMediator = messageMediator;
+    }
+
+    /// <summary>
+    /// Engine-backed construction: dispatches go straight to the process-wide engine with
+    /// <paramref name="serviceProvider"/> as the handler-resolution scope, making the
+    /// facade the only object built per resolution.
+    /// </summary>
+    /// <param name="engine">The singleton dispatch engine.</param>
+    /// <param name="serviceProvider">The provider of the scope this facade serves.</param>
+    public CommandMediator(MessageDispatchEngine engine, IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _engine = engine;
+        _serviceProvider = serviceProvider;
+    }
+
     /// <summary>
     /// Sends a void command through the executor pipeline.
     /// </summary>
     public ValueTask SendAsync(ICommand commandConstruct, CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return messageMediator.DispatchAsync(
-            commandConstruct,
-            commandMediationSettings?.Items,
-            cancellationToken,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync(
+                commandConstruct,
+                _serviceProvider!,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync(
+                commandConstruct,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
@@ -35,11 +85,18 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
         CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            commandConstruct,
-            commandMediationSettings?.Items,
-            cancellationToken,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                commandConstruct,
+                _serviceProvider!,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                commandConstruct,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
@@ -51,10 +108,16 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
     public ValueTask SendAsync(ICommand commandConstruct, IExecutionContext context,
         CommandMediationSettings? commandMediationSettings = null)
     {
-        return messageMediator.DispatchAsync(
-            commandConstruct,
-            context,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync(
+                commandConstruct,
+                context,
+                _serviceProvider!,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync(
+                commandConstruct,
+                context,
+                commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
@@ -64,9 +127,15 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
     public ValueTask<TResult> SendAsync<TResult>(ICommand<TResult> commandConstruct, IExecutionContext context,
         CommandMediationSettings? commandMediationSettings = null)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            commandConstruct,
-            context,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                commandConstruct,
+                context,
+                _serviceProvider!,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                commandConstruct,
+                context,
+                commandMediationSettings?.Filters.Groups);
     }
 }

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -67,6 +67,12 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
         // insert that a fresh scope per dispatch would pay on every single dispatch.
         services.TryAddSingleton<IMessageDependenciesFactory, MessageDependenciesFactory>();
         services.TryAddSingleton<PipelineExecutorCache>();
+        // Factory registration because the engine's constructor is internal (the type is
+        // only meaningful wired to the executor cache); singleton, so the cost is paid once
+        // per container while every facade resolution ctor-injects it as a constant.
+        services.TryAddSingleton(static sp => new MessageDispatchEngine(
+            sp.GetRequiredService<PipelineExecutorCache>(),
+            sp.GetRequiredService<IMessageDependenciesFactory>()));
         services.TryAddTransient<IMessageMediator, MessageMediator>();
         services.TryAddSingleton<IDescriptorCacheStrategy, LruCacheStrategy>();
         services.TryAddSingleton<MessageDescriptorCache>();

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
@@ -23,58 +22,16 @@ internal sealed class MessageMediator(
     IMessageRegistry messageRegistry,
     IMessageDependenciesFactory messageDependenciesFactory,
     IServiceProvider serviceProvider,
-    PipelineExecutorCache? executorCache = null)
+    PipelineExecutorCache? executorCache = null,
+    MessageDispatchEngine? engine = null)
     : IMessageMediator
 {
-    /// <summary>
-    /// Process-wide executor cache used by the <see cref="DispatchAsync(object,IDictionary{object,object?},CancellationToken,IEnumerable{string})"/>
-    /// path. Optional so directly-constructed mediators (tests) keep working; the DI
-    /// registration always supplies it.
-    /// </summary>
-    private readonly PipelineExecutorCache? _executorCache = executorCache;
-
     /// <inheritdoc />
     public ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var executor = RequireExecutorCache().GetVoidExecutor(message.GetType(), groups);
-        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
-        ValueTask task;
-
-        try
-        {
-            task = executor.Execute(message, context, _serviceProvider);
-        }
-        catch
-        {
-            ErgosfareExecutionContextPool.Return(context);
-            throw;
-        }
-
-        // Synchronously completed dispatches (the common case) return the context inline —
-        // no async state machine on the hot path. Only a genuinely suspended pipeline pays
-        // for the awaiting helper.
-        if (task.IsCompletedSuccessfully)
-        {
-            ErgosfareExecutionContextPool.Return(context);
-            return default;
-        }
-
-        return AwaitAndReturn(task, context);
-
-        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
-        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
-        {
-            try
-            {
-                await task;
-            }
-            finally
-            {
-                ErgosfareExecutionContextPool.Return(context);
-            }
-        }
+        return RequireEngine().DispatchAsync(message, _serviceProvider, items, cancellationToken, groups);
     }
 
     /// <inheritdoc />
@@ -82,41 +39,7 @@ internal sealed class MessageMediator(
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var executor = RequireExecutorCache().GetExecutor<TResult>(message.GetType(), groups);
-        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
-        ValueTask<TResult> task;
-
-        try
-        {
-            task = executor.Execute(message, context, _serviceProvider);
-        }
-        catch
-        {
-            ErgosfareExecutionContextPool.Return(context);
-            throw;
-        }
-
-        if (task.IsCompletedSuccessfully)
-        {
-            var result = task.Result;
-            ErgosfareExecutionContextPool.Return(context);
-            return new ValueTask<TResult>(result);
-        }
-
-        return AwaitAndReturn(task, context);
-
-        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
-        static async ValueTask<TResult> AwaitAndReturn(ValueTask<TResult> task, ErgosfareExecutionContext context)
-        {
-            try
-            {
-                return await task;
-            }
-            finally
-            {
-                ErgosfareExecutionContextPool.Return(context);
-            }
-        }
+        return RequireEngine().DispatchAsync<TResult>(message, _serviceProvider, items, cancellationToken, groups);
     }
 
     /// <inheritdoc />
@@ -125,11 +48,7 @@ internal sealed class MessageMediator(
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(context);
 
-        // Caller-owned context (typically a scope's child): the caller controls its
-        // lifetime, so nothing is rented or returned here.
-        var executor = RequireExecutorCache().GetVoidExecutor(message.GetType(), groups);
-
-        return executor.Execute(message, context, _serviceProvider);
+        return RequireEngine().DispatchAsync(message, context, _serviceProvider, groups);
     }
 
     /// <inheritdoc />
@@ -138,9 +57,7 @@ internal sealed class MessageMediator(
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(context);
 
-        var executor = RequireExecutorCache().GetExecutor<TResult>(message.GetType(), groups);
-
-        return executor.Execute(message, context, _serviceProvider);
+        return RequireEngine().DispatchAsync<TResult>(message, context, _serviceProvider, groups);
     }
 
     /// <summary>
@@ -154,8 +71,8 @@ internal sealed class MessageMediator(
     /// </summary>
     internal IMessageDependenciesFactory DependenciesFactory => _messageDependenciesFactory;
 
-    private PipelineExecutorCache RequireExecutorCache()
-        => _executorCache ?? throw new InvalidOperationException(
+    private MessageDispatchEngine RequireEngine()
+        => _engine ?? throw new InvalidOperationException(
             "Executor dispatch requires the PipelineExecutorCache; register Ergosfare through AddErgosfare or use Mediate with explicit options.");
 
 
@@ -175,6 +92,16 @@ internal sealed class MessageMediator(
     /// strategy on each dispatch so handlers resolve against the calling scope.
     /// </summary>
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+    /// <summary>
+    /// The dispatch engine the executor overloads delegate to. DI injects the container's
+    /// singleton; directly-constructed mediators (tests) that supply only an executor cache
+    /// get a private engine wrapping it, preserving the original optional-cache contract.
+    /// Declared after the null-validated fields above so a null factory still fails their
+    /// argument checks first.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine =
+        engine ?? (executorCache is null ? null : new MessageDispatchEngine(executorCache, messageDependenciesFactory));
 
     
     /// <summary>

--- a/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
+++ b/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
@@ -1,0 +1,182 @@
+using System.Runtime.CompilerServices;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Factories;
+using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Core.Internal.Mediator;
+
+namespace Stella.Ergosfare.Core;
+
+/// <summary>
+/// The scope-free dispatch engine behind every mediator facade: the pipeline-executor
+/// lookup, pooled execution context, and completion handling of the
+/// <see cref="IMessageMediator"/> executor path, with the calling scope's provider supplied
+/// per call instead of being captured per instance. One process-wide singleton serves every
+/// scope, so resolving an engine-backed facade builds exactly one object per resolution.
+/// </summary>
+/// <remarks>
+/// Construction is internal: the engine only makes sense wired to the process-wide
+/// <see cref="PipelineExecutorCache"/> and dependencies factory that the DI registration
+/// supplies. Dispatch behavior matches <see cref="IMessageMediator"/>'s executor overloads
+/// exactly — the mediator delegates here, passing its own captured provider.
+/// </remarks>
+public sealed class MessageDispatchEngine
+{
+    /// <summary>
+    /// Process-wide executor cache; one closed executor per message (and result) type.
+    /// </summary>
+    private readonly PipelineExecutorCache _executorCache;
+
+    /// <summary>
+    /// The dependencies factory the executors build their pipeline plans against; exposed
+    /// internally so the broadcast fast lane (events assembly, via InternalsVisibleTo) can
+    /// key its cached plan by the same factory reference the executors use.
+    /// </summary>
+    private readonly IMessageDependenciesFactory _dependenciesFactory;
+
+    internal MessageDispatchEngine(PipelineExecutorCache executorCache, IMessageDependenciesFactory dependenciesFactory)
+    {
+        _executorCache = executorCache ?? throw new ArgumentNullException(nameof(executorCache));
+        _dependenciesFactory = dependenciesFactory ?? throw new ArgumentNullException(nameof(dependenciesFactory));
+    }
+
+    /// <inheritdoc cref="_dependenciesFactory"/>
+    internal IMessageDependenciesFactory DependenciesFactory => _dependenciesFactory;
+
+    /// <summary>
+    /// Dispatches a void message through its cached pipeline executor, resolving handlers
+    /// against <paramref name="serviceProvider"/> — the caller's scope.
+    /// </summary>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="serviceProvider">The scope provider handlers resolve against.</param>
+    /// <param name="items">Optional contextual items exposed to the pipeline.</param>
+    /// <param name="cancellationToken">Cancellation token for the dispatch.</param>
+    /// <param name="groups">Optional group filters applied to the pipeline.</param>
+    public ValueTask DispatchAsync(object message, IServiceProvider serviceProvider,
+        IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = _executorCache.GetVoidExecutor(message.GetType(), groups);
+        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
+        ValueTask task;
+
+        try
+        {
+            task = executor.Execute(message, context, serviceProvider);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        // Synchronously completed dispatches (the common case) return the context inline —
+        // no async state machine on the hot path. Only a genuinely suspended pipeline pays
+        // for the awaiting helper.
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Result-producing counterpart of
+    /// <see cref="DispatchAsync(object, IServiceProvider, IDictionary{object, object?}?, CancellationToken, IEnumerable{string}?)"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The expected result type of the message.</typeparam>
+    public ValueTask<TResult> DispatchAsync<TResult>(object message, IServiceProvider serviceProvider,
+        IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = _executorCache.GetExecutor<TResult>(message.GetType(), groups);
+        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
+        ValueTask<TResult> task;
+
+        try
+        {
+            task = executor.Execute(message, context, serviceProvider);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            var result = task.Result;
+            ErgosfareExecutionContextPool.Return(context);
+            return new ValueTask<TResult>(result);
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        static async ValueTask<TResult> AwaitAndReturn(ValueTask<TResult> task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                return await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Dispatches a void message under a caller-owned execution context (typically a
+    /// scope's child): the caller controls the context's lifetime, so nothing is rented or
+    /// returned here.
+    /// </summary>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="context">The externally owned execution context.</param>
+    /// <param name="serviceProvider">The scope provider handlers resolve against.</param>
+    /// <param name="groups">Optional group filters applied to the pipeline.</param>
+    public ValueTask DispatchAsync(object message, IExecutionContext context, IServiceProvider serviceProvider,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var executor = _executorCache.GetVoidExecutor(message.GetType(), groups);
+
+        return executor.Execute(message, context, serviceProvider);
+    }
+
+    /// <summary>
+    /// Result-producing counterpart of
+    /// <see cref="DispatchAsync(object, IExecutionContext, IServiceProvider, IEnumerable{string}?)"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The expected result type of the message.</typeparam>
+    public ValueTask<TResult> DispatchAsync<TResult>(object message, IExecutionContext context, IServiceProvider serviceProvider,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var executor = _executorCache.GetExecutor<TResult>(message.GetType(), groups);
+
+        return executor.Execute(message, context, serviceProvider);
+    }
+}

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EngineBackedEventMediator.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EngineBackedEventMediator.cs
@@ -1,0 +1,20 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+
+namespace Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+
+/// <summary>
+/// DI-facing shape of <see cref="EventMediator"/> with exactly one constructor, so
+/// container activation binds the engine-backed path deterministically — no
+/// multi-constructor ambiguity, and no per-resolution service lookup a factory
+/// registration would pay. Resolving <see cref="Stella.Ergosfare.Events.Abstractions.IEventMediator"/>
+/// or <see cref="Stella.Ergosfare.Events.Abstractions.IPublisher"/> builds this single
+/// object; the engine itself is a process-wide singleton.
+/// </summary>
+internal sealed class EngineBackedEventMediator(
+    MessageDispatchEngine engine,
+    IServiceProvider serviceProvider,
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+    IResultAdapterService? resultAdapterService)
+    : EventMediator(engine, serviceProvider, messageResolveStrategy, resultAdapterService);

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
@@ -32,8 +32,9 @@ internal class EventModule(Action<EventModuleBuilder> builder) : IModule
         // Transient, not scoped: the mediator is stateless and a transient service is handed
         // the resolving scope's provider all the same, so per-dispatch handler resolution
         // still binds to the calling scope. Scoped would add a scope lock and a
-        // resolved-services dictionary insert to every dispatch for no benefit.
-        configuration.Services.TryAddTransient<IEventMediator, EventMediator>();
-        configuration.Services.TryAddTransient<IPublisher, EventMediator>();
+        // resolved-services dictionary insert to every dispatch for no benefit. The
+        // engine-backed shape makes the facade the only object built per resolution.
+        configuration.Services.TryAddTransient<IEventMediator, EngineBackedEventMediator>();
+        configuration.Services.TryAddTransient<IPublisher, EngineBackedEventMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
@@ -22,6 +23,18 @@ internal interface IEventBroadcastInvoker
 {
     ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null);
+
+    /// <summary>
+    /// Engine-backed publish: the concrete dispatch machinery is known by construction, so
+    /// the group-less publish takes the fast lane directly against the engine's plan and
+    /// the caller's scope provider. Non-fast shapes (grouped filters, external contexts)
+    /// resolve the scope's <see cref="IMessageMediator"/> on demand and run the original
+    /// overload — semantics unchanged.
+    /// </summary>
+    ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null);
 }
 
@@ -82,7 +95,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             if ((settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 })
                 && mediator is MessageMediator concreteMediator)
             {
-                var dependencies = GetPlan(concreteMediator, resolveStrategy);
+                var dependencies = GetPlan(concreteMediator.DependenciesFactory, resolveStrategy);
 
                 // Straight-through broadcast: with no interceptor stages and no handler
                 // filtering requested, loop the handler arrays directly — synchronously
@@ -143,6 +156,89 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     }
 
     /// <summary>
+    /// Engine-backed counterpart of the mediator overload: the engine is the concrete
+    /// dispatch machinery by construction, so the group-less publish runs the fast lane
+    /// directly against its plan and the caller's scope provider. Grouped publishes and
+    /// externally owned contexts resolve the scope's <see cref="IMessageMediator"/> on
+    /// demand and take the original overload, preserving the Mediate path's semantics
+    /// exactly.
+    /// </summary>
+    public ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null)
+    {
+        if (externalContext is not null
+            || !(settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 }))
+        {
+            return Publish(@event, settings, cancellationToken,
+                ResolveMediator(serviceProvider), resolveStrategy, resultAdapterService, externalContext);
+        }
+
+        var context = ErgosfareExecutionContextPool.Rent(settings?.Items, cancellationToken);
+
+        ValueTask task;
+
+        try
+        {
+            var dependencies = GetPlan(engine.DependenciesFactory, resolveStrategy);
+
+            if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+                && (settings is null
+                    || ReferenceEquals(settings.Filters.HandlerPredicate,
+                        EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
+            {
+                task = PublishStraightThrough(
+                    (TEvent)@event, plan, context, serviceProvider,
+                    settings?.ThrowIfNoHandlerFound ?? false);
+            }
+            else
+            {
+                var strategy = settings is null
+                    ? DefaultStrategy
+                    : new AsyncBroadcastMediationStrategy<TEvent>(settings);
+
+                task = strategy.Mediate((TEvent)@event, dependencies, context, serviceProvider);
+            }
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The scope's mediator registration, needed only for the non-fast shapes of the
+    /// engine overload — they run the Mediate path a mediator instance owns.
+    /// </summary>
+    private static IMessageMediator ResolveMediator(IServiceProvider serviceProvider)
+        => (IMessageMediator?)serviceProvider.GetService(typeof(IMessageMediator))
+           ?? throw new InvalidOperationException(
+               "Grouped or externally-scoped publishes resolve IMessageMediator from the scope; register Ergosfare through AddErgosfare.");
+
+    /// <summary>
     /// The group-less pipeline plan for <typeparamref name="TEvent"/>, cached on the
     /// invoker and re-validated against the registry version — runtime registrations
     /// invalidate it exactly as they invalidate the executors' caches. Races are benign:
@@ -153,10 +249,10 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     private int _cachedVersion = int.MinValue;
 
     private IMessageDependencies GetPlan(
-        MessageMediator mediator,
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
     {
-        if (mediator.DependenciesFactory is MessageDependenciesFactory typedFactory)
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
             var cached = _cachedDependencies;
 
@@ -180,7 +276,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             return dependencies;
         }
 
-        return BuildPlan(mediator.DependenciesFactory, resolveStrategy);
+        return BuildPlan(dependenciesFactory, resolveStrategy);
     }
 
     /// <summary>

--- a/src/Stella.Ergosfare.Events/EventMediator.cs
+++ b/src/Stella.Ergosfare.Events/EventMediator.cs
@@ -1,3 +1,4 @@
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Events.Abstractions;
@@ -10,12 +11,80 @@ namespace Stella.Ergosfare.Events;
 /// handlers are always invoked through their typed members — including for the
 /// interface-erased <see cref="PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> overload.
 /// </summary>
+/// <remarks>
+/// Unsealed so the DI registration can bind the engine-backed constructor through a
+/// single-constructor derived shape; the facade carries no state a derived type could
+/// corrupt.
+/// </remarks>
 /// <inheritdoc cref="IEventMediator"/>
-public sealed class EventMediator(
-    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
-    IResultAdapterService? resultAdapterService,
-    IMessageMediator messageMediator) : IPublisher
+public class EventMediator : IPublisher
 {
+    /// <summary>
+    /// Resolve strategy handed to the broadcast invoker; identical on both construction
+    /// shapes.
+    /// </summary>
+    private readonly ActualTypeOrFirstAssignableTypeMessageResolveStrategy _messageResolveStrategy;
+
+    /// <summary>
+    /// Result adapters handed to the broadcast invoker; identical on both construction
+    /// shapes.
+    /// </summary>
+    private readonly IResultAdapterService? _resultAdapterService;
+
+    /// <summary>
+    /// The mediator backing the original construction shape; null when the facade is
+    /// engine-backed.
+    /// </summary>
+    private readonly IMessageMediator? _messageMediator;
+
+    /// <summary>
+    /// The singleton dispatch engine; null when the facade wraps an
+    /// <see cref="IMessageMediator"/>.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine;
+
+    /// <summary>
+    /// The scope provider handlers resolve against on the engine path.
+    /// </summary>
+    private readonly IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Wraps an existing <see cref="IMessageMediator"/> — the original construction shape,
+    /// kept for direct construction and foreign mediator implementations.
+    /// </summary>
+    public EventMediator(
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+        IResultAdapterService? resultAdapterService,
+        IMessageMediator messageMediator)
+    {
+        _messageResolveStrategy = messageResolveStrategy;
+        _resultAdapterService = resultAdapterService;
+        _messageMediator = messageMediator;
+    }
+
+    /// <summary>
+    /// Engine-backed construction: publishes go straight to the process-wide engine's
+    /// broadcast plan with <paramref name="serviceProvider"/> as the handler-resolution
+    /// scope, making the facade the only object built per resolution.
+    /// </summary>
+    /// <param name="engine">The singleton dispatch engine.</param>
+    /// <param name="serviceProvider">The provider of the scope this facade serves.</param>
+    /// <param name="messageResolveStrategy">Resolve strategy used to find broadcast pipelines.</param>
+    /// <param name="resultAdapterService">Result adapters applied by broadcast strategies.</param>
+    public EventMediator(
+        MessageDispatchEngine engine,
+        IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+        IResultAdapterService? resultAdapterService)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _engine = engine;
+        _serviceProvider = serviceProvider;
+        _messageResolveStrategy = messageResolveStrategy;
+        _resultAdapterService = resultAdapterService;
+    }
 
     /// <summary>
     /// Publishes a non-generic event asynchronously through the mediation pipeline.
@@ -28,9 +97,13 @@ public sealed class EventMediator(
                              EventMediationSettings? eventMediationSettings = null,
                              CancellationToken cancellationToken = default)
     {
-        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings, cancellationToken,
-            messageMediator, messageResolveStrategy, resultAdapterService);
+        return _engine is not null
+            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService)
+            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _messageMediator!, _messageResolveStrategy, _resultAdapterService);
     }
 
     /// <summary>
@@ -45,9 +118,13 @@ public sealed class EventMediator(
                                      EventMediationSettings? eventMediationSettings = null,
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
-        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings, cancellationToken,
-            messageMediator, messageResolveStrategy, resultAdapterService);
+        return _engine is not null
+            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService)
+            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _messageMediator!, _messageResolveStrategy, _resultAdapterService);
     }
 
     /// <summary>
@@ -62,8 +139,12 @@ public sealed class EventMediator(
     public ValueTask PublishAsync(IEvent @event, IExecutionContext context,
                              EventMediationSettings? eventMediationSettings = null)
     {
-        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings, context.CancellationToken,
-            messageMediator, messageResolveStrategy, resultAdapterService, context);
+        return _engine is not null
+            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, context.CancellationToken,
+                _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService, context)
+            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, context.CancellationToken,
+                _messageMediator!, _messageResolveStrategy, _resultAdapterService, context);
     }
 }

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/EngineBackedQueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/EngineBackedQueryMediator.cs
@@ -1,0 +1,18 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Queries;
+
+namespace Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+/// <summary>
+/// DI-facing shape of <see cref="QueryMediator"/> with exactly one constructor, so
+/// container activation binds the engine-backed path deterministically — no
+/// multi-constructor ambiguity, and no per-resolution service lookup a factory
+/// registration would pay. Resolving <see cref="Stella.Ergosfare.Queries.Abstractions.IQueryMediator"/>
+/// builds this single object; the engine itself is a process-wide singleton.
+/// </summary>
+internal sealed class EngineBackedQueryMediator(
+    MessageDispatchEngine engine,
+    IServiceProvider serviceProvider,
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy)
+    : QueryMediator(engine, serviceProvider, messageResolveStrategy);

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
@@ -26,7 +26,8 @@ internal class QueryModule(
         // Transient, not scoped: the mediator is stateless and a transient service is handed
         // the resolving scope's provider all the same, so per-dispatch handler resolution
         // still binds to the calling scope. Scoped would add a scope lock and a
-        // resolved-services dictionary insert to every dispatch for no benefit.
-        configuration.Services.TryAddTransient<IQueryMediator, QueryMediator>();
+        // resolved-services dictionary insert to every dispatch for no benefit. The
+        // engine-backed shape makes the facade the only object built per resolution.
+        configuration.Services.TryAddTransient<IQueryMediator, EngineBackedQueryMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Queries/QueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries/QueryMediator.cs
@@ -1,4 +1,4 @@
-﻿using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Queries.Abstractions;
@@ -11,10 +11,64 @@ namespace Stella.Ergosfare.Queries;
 /// Handles both standard queries and streaming queries using the internal message mediation pipeline,
 /// supporting pre/post/final interceptors and result adapters.
 /// </summary>
-public class QueryMediator(
-    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
-    IMessageMediator messageMediator): IQueryMediator
+public class QueryMediator : IQueryMediator
 {
+    /// <summary>
+    /// Resolve strategy handed to the streaming invoker; identical on both construction
+    /// shapes.
+    /// </summary>
+    private readonly ActualTypeOrFirstAssignableTypeMessageResolveStrategy _messageResolveStrategy;
+
+    /// <summary>
+    /// The mediator backing the original construction shape; null when the facade is
+    /// engine-backed.
+    /// </summary>
+    private readonly IMessageMediator? _messageMediator;
+
+    /// <summary>
+    /// The singleton dispatch engine; null when the facade wraps an
+    /// <see cref="IMessageMediator"/>.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine;
+
+    /// <summary>
+    /// The scope provider handlers resolve against on the engine path; the streaming path
+    /// also resolves its <see cref="IMessageMediator"/> from it on demand.
+    /// </summary>
+    private readonly IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Wraps an existing <see cref="IMessageMediator"/> — the original construction shape,
+    /// kept for direct construction and foreign mediator implementations.
+    /// </summary>
+    public QueryMediator(
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+        IMessageMediator messageMediator)
+    {
+        _messageResolveStrategy = messageResolveStrategy;
+        _messageMediator = messageMediator;
+    }
+
+    /// <summary>
+    /// Engine-backed construction: queries go straight to the process-wide engine with
+    /// <paramref name="serviceProvider"/> as the handler-resolution scope, making the
+    /// facade the only object built per resolution.
+    /// </summary>
+    /// <param name="engine">The singleton dispatch engine.</param>
+    /// <param name="serviceProvider">The provider of the scope this facade serves.</param>
+    /// <param name="messageResolveStrategy">Resolve strategy used by the streaming path.</param>
+    public QueryMediator(
+        MessageDispatchEngine engine,
+        IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _engine = engine;
+        _serviceProvider = serviceProvider;
+        _messageResolveStrategy = messageResolveStrategy;
+    }
 
     /// <summary>
     /// Executes a query and returns a single result of type <typeparamref name="TResult"/>.
@@ -30,14 +84,21 @@ public class QueryMediator(
     public ValueTask<TResult> QueryAsync<TResult>(IQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            query,
-            queryMediationSettings?.Items,
-            cancellationToken,
-            queryMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                query,
+                _serviceProvider!,
+                queryMediationSettings?.Items,
+                cancellationToken,
+                queryMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                query,
+                queryMediationSettings?.Items,
+                cancellationToken,
+                queryMediationSettings?.Filters.Groups);
     }
 
-    
+
     /// <summary>
     /// Executes a streaming query and returns an asynchronous enumerable of results.
     /// The query is processed through the streaming pipeline, supporting interceptors and result adapters.
@@ -53,7 +114,7 @@ public class QueryMediator(
         CancellationToken cancellationToken = default)
     {
         return QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
-            query, queryMediationSettings, cancellationToken, messageMediator, messageResolveStrategy);
+            query, queryMediationSettings, cancellationToken, RequireMessageMediator(), _messageResolveStrategy);
     }
 
     /// <summary>
@@ -64,9 +125,26 @@ public class QueryMediator(
     public ValueTask<TResult> QueryAsync<TResult>(IQuery<TResult> query, IExecutionContext context,
         QueryMediationSettings? queryMediationSettings = null)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            query,
-            context,
-            queryMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                query,
+                context,
+                _serviceProvider!,
+                queryMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                query,
+                context,
+                queryMediationSettings?.Filters.Groups);
     }
+
+    /// <summary>
+    /// The mediator the streaming path (untouched by the engine: it mediates through
+    /// <c>Mediate(options)</c>) runs against — the wrapped instance, or on the engine
+    /// shape the scope's own registration, resolved on demand.
+    /// </summary>
+    private IMessageMediator RequireMessageMediator()
+        => _messageMediator
+           ?? (IMessageMediator?)_serviceProvider!.GetService(typeof(IMessageMediator))
+           ?? throw new InvalidOperationException(
+               "Streaming dispatch resolves IMessageMediator from the scope; register Ergosfare through AddErgosfare.");
 }

--- a/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
@@ -1,6 +1,7 @@
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,6 +80,12 @@ public class DispatchItemsAndInvalidationTests
             => ValueTask.CompletedTask;
     }
 
+    /// <summary>
+    /// Excluded from discovery: the fact below registers this type at runtime to observe
+    /// the version bump — another test's assembly scan (the registry is process-wide)
+    /// must not slip it into the pipeline before the warm dispatches run.
+    /// </summary>
+    [ExcludeFromDiscovery]
     public sealed class LateRegisteredInterceptor : ICommandPreInterceptor<LateInterceptedCommand>
     {
         public ValueTask<LateInterceptedCommand> HandleAsync(LateInterceptedCommand command, IExecutionContext context)

--- a/test/Stella.Ergosfare.Command.Test/EngineBackedFacadeTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/EngineBackedFacadeTests.cs
@@ -1,0 +1,133 @@
+using Stella.Ergosfare.Commands;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Covers the engine-backed facade shape: DI resolves a single-object facade bound to the
+/// process-wide <see cref="MessageDispatchEngine"/>, handler resolution still binds to the
+/// calling scope (verified under <c>ValidateScopes</c>), and the facade's two public
+/// constructors dispatch identically.
+/// </summary>
+public class EngineBackedFacadeTests
+{
+    public sealed class ScopedProbe
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    public sealed class ProbeCommand : ICommand { }
+
+    public sealed class ProbeCommandHandler(ScopedProbe probe) : ICommandHandler<ProbeCommand>
+    {
+        public ValueTask HandleAsync(ProbeCommand command, IExecutionContext context)
+        {
+            context.Set("probeId", probe.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class EchoCommand : ICommand<string>
+    {
+        public string Payload { get; init; } = string.Empty;
+    }
+
+    public sealed class EchoCommandHandler : ICommandHandler<EchoCommand, string>
+    {
+        public ValueTask<string> HandleAsync(EchoCommand command, IExecutionContext context)
+        {
+            context.Set("sawPayload", command.Payload);
+            return ValueTask.FromResult(command.Payload + "!");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_IsTheEngineBackedShape()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<EchoCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The DI shape derives from the public facade (compat for callers typed to it) but
+        // is not the bare facade — it must be the single-constructor engine-backed type.
+        Assert.IsAssignableFrom<CommandMediator>(mediator);
+        Assert.NotEqual(typeof(CommandMediator), mediator.GetType());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_WithValidateScopes_BindsHandlerResolutionToTheCallingScope()
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<ScopedProbe>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ProbeCommandHandler>()))
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        await using var _ = provider;
+
+        Guid first, second, third;
+
+        using (var scope = provider.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<ICommandMediator>();
+
+            var firstSettings = new CommandMediationSettings();
+            await mediator.SendAsync(new ProbeCommand(), firstSettings);
+            first = Assert.IsType<Guid>(firstSettings.Items["probeId"]);
+
+            var secondSettings = new CommandMediationSettings();
+            await mediator.SendAsync(new ProbeCommand(), secondSettings);
+            second = Assert.IsType<Guid>(secondSettings.Items["probeId"]);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<ICommandMediator>();
+
+            var thirdSettings = new CommandMediationSettings();
+            await mediator.SendAsync(new ProbeCommand(), thirdSettings);
+            third = Assert.IsType<Guid>(thirdSettings.Items["probeId"]);
+        }
+
+        // Within one scope the scoped dependency is one instance; a fresh scope gets its own.
+        Assert.Equal(first, second);
+        Assert.NotEqual(first, third);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task BothConstructors_DispatchIdentically()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<EchoCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var engineBacked = new CommandMediator(
+            provider.GetRequiredService<MessageDispatchEngine>(), provider);
+        var mediatorBacked = new CommandMediator(
+            provider.GetRequiredService<IMessageMediator>());
+
+        foreach (var mediator in new[] { engineBacked, mediatorBacked })
+        {
+            var settings = new CommandMediationSettings();
+
+            var result = await mediator.SendAsync<string>(
+                new EchoCommand { Payload = "hi" }, settings);
+
+            Assert.Equal("hi!", result);
+            Assert.Equal("hi", settings.Items["sawPayload"]);
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -1,4 +1,5 @@
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
@@ -264,6 +265,12 @@ public class BroadcastFastLaneTests
 
     public sealed class LateEvent : IEvent { }
 
+    /// <summary>
+    /// Excluded from discovery: the fact below registers this type at runtime to observe
+    /// the version bump — another test's assembly scan (the registry is process-wide)
+    /// must not slip it into the pipeline before the warm publishes run.
+    /// </summary>
+    [ExcludeFromDiscovery]
     public sealed class LateEventHandler : IEventHandler<LateEvent>
     {
         public ValueTask HandleAsync(LateEvent @event, IExecutionContext context)

--- a/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
@@ -1,0 +1,122 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Covers the engine-backed facade shape for events: DI resolves a single-object facade
+/// bound to the process-wide <see cref="MessageDispatchEngine"/>, both public constructors
+/// publish identically, and grouped publishes leave the fast lane for the original
+/// Mediate path with its handler-group filtering intact.
+/// </summary>
+public class EngineBackedEventFacadeTests
+{
+    public sealed class GroupedEvent : IEvent { }
+
+    /// <summary>
+    /// Excluded from discovery so another test's assembly scan (the registry is
+    /// process-wide) cannot register it into a group set this class does not control.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    [Group("audit")]
+    public sealed class AuditGroupHandler : IEventHandler<GroupedEvent>
+    {
+        public ValueTask HandleAsync(GroupedEvent @event, IExecutionContext context)
+        {
+            context.Set("auditRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class DefaultGroupHandler : IEventHandler<GroupedEvent>
+    {
+        public ValueTask HandleAsync(GroupedEvent @event, IExecutionContext context)
+        {
+            context.Set("defaultRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider Build()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<AuditGroupHandler>();
+                e.Register<DefaultGroupHandler>();
+            }))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_IsTheEngineBackedShape_AndPublishes()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        Assert.IsAssignableFrom<EventMediator>(mediator);
+        Assert.NotEqual(typeof(EventMediator), mediator.GetType());
+
+        var settings = new EventMediationSettings();
+        await mediator.PublishAsync(new GroupedEvent(), settings);
+
+        // A group-less publish serves the default group only.
+        Assert.Equal(true, settings.Items["defaultRan"]);
+        Assert.False(settings.Items.ContainsKey("auditRan"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithGroups_TakesTheMediateFallback_AndFiltersHandlers()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = ["audit"];
+
+        await mediator.PublishAsync(new GroupedEvent(), settings);
+
+        // The grouped publish leaves the fast lane; only the requested group's handler runs.
+        Assert.Equal(true, settings.Items["auditRan"]);
+        Assert.False(settings.Items.ContainsKey("defaultRan"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task BothConstructors_PublishIdentically()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var strategy = provider.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>();
+        var adapters = provider.GetRequiredService<IResultAdapterService>();
+
+        var engineBacked = new EventMediator(
+            provider.GetRequiredService<MessageDispatchEngine>(), provider, strategy, adapters);
+        var mediatorBacked = new EventMediator(
+            strategy, adapters, provider.GetRequiredService<IMessageMediator>());
+
+        foreach (var mediator in new EventMediator[] { engineBacked, mediatorBacked })
+        {
+            var settings = new EventMediationSettings();
+
+            await mediator.PublishAsync(new GroupedEvent(), settings);
+
+            Assert.Equal(true, settings.Items["defaultRan"]);
+            Assert.False(settings.Items.ContainsKey("auditRan"));
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
@@ -1,0 +1,82 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Test.__stubs__;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Queries.Test;
+
+/// <summary>
+/// Covers the engine-backed facade shape for queries: DI resolves a single-object facade
+/// bound to the process-wide <see cref="MessageDispatchEngine"/>, both public constructors
+/// query identically, and the streaming path — which stays on the mediator's
+/// <c>Mediate(options)</c> machinery — resolves the scope's mediator on demand.
+/// </summary>
+public class EngineBackedQueryFacadeTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_IsTheEngineBackedShape_AndQueries()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStringResultQueryHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        Assert.IsAssignableFrom<QueryMediator>(mediator);
+        Assert.NotEqual(typeof(QueryMediator), mediator.GetType());
+        Assert.Equal(string.Empty, await mediator.QueryAsync(new StubNonGenericStringResultQuery()));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_Streams_ResolvingTheScopesMediatorOnDemand()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStreamStringResultQueryHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IQueryMediator>();
+
+        var result = new List<string>();
+
+        await foreach (var item in mediator.StreamAsync(new StubNonGenericStreamStringResultQuery()))
+        {
+            result.Add(item);
+        }
+
+        Assert.Equal(["Foo", "Bar", "Baz"], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task BothConstructors_QueryIdentically()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStringResultQueryHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var strategy = provider.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>();
+
+        var engineBacked = new QueryMediator(
+            provider.GetRequiredService<MessageDispatchEngine>(), provider, strategy);
+        var mediatorBacked = new QueryMediator(
+            strategy, provider.GetRequiredService<IMessageMediator>());
+
+        foreach (var mediator in new[] { engineBacked, mediatorBacked })
+        {
+            Assert.Equal(string.Empty, await mediator.QueryAsync(new StubNonGenericStringResultQuery()));
+        }
+    }
+}


### PR DESCRIPTION
Resolving a facade used to build two transients per scope (facade + `IMessageMediator`); MediatR pays one. The executor dispatch bodies move into **`MessageDispatchEngine`**, a process-wide singleton taking the calling scope's provider per call:

- `IMessageMediator`'s executor overloads delegate to the engine unchanged; the options/`Mediate` and stream paths are untouched.
- The facades gain a public engine constructor and DI binds single-constructor `EngineBacked*` shapes — constructor injection compiles the engine into a constant callsite (no ambiguous-ctor rejection, no per-resolution service lookup). `EventMediator` is unsealed for its DI shape; the `IMessageMediator` constructors remain.
- The broadcast invoker gains an engine overload: group-less publishes run the existing fast lane against the engine's factory-keyed plan cache; grouped or externally-scoped publishes resolve the scope's `IMessageMediator` on demand and keep the original Mediate path exactly.

Measured (7800X3D, net9): Command_Void_Scoped 91.4→84.0 ns (224→192 B), Query_Result_Scoped 109.7→103.7 (232→200 B), Event_Publish_Scoped 117.7→108.7 (264→232 B); no row regresses. 9 new facts: scope binding under `ValidateScopes`, two-constructor equality per facade, grouped-publish fallback, DI shape assertions.

Also carries a test-only isolation fix: two runtime-registration facts are shielded from assembly-scan pollution with `[ExcludeFromDiscovery]` (the registry is process-wide; the failure reproduced on the unmodified base).

Part 2/6 of the v2.3.0-preview stack — depends on #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)