### PR TITLE
perf: compile-time void pipeline plans — generated dispatch devirtualizes the handler call

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 
@@ -18,6 +19,7 @@ public static class GeneratedDispatchRoots
     private static readonly ConcurrentDictionary<Type, MessageRoot> Messages = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Results = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Streams = new();
+    private static readonly ConcurrentDictionary<Type, VoidPlanRoot> VoidPlans = new();
 
     /// <summary>Roots the void dispatch generics of a message type. Idempotent.</summary>
     public static void AddMessage<TMessage>() where TMessage : IMessage
@@ -42,6 +44,24 @@ public static class GeneratedDispatchRoots
     /// <summary>The stream dispatch root of the (message, result) pair, or <c>null</c> when none was generated.</summary>
     public static MessageResultRoot? FindStream(Type messageType, Type resultType)
         => Streams.TryGetValue((messageType, resultType), out var root) ? root : null;
+
+    /// <summary>
+    /// Roots a compile-time pipeline plan for a void message whose entire pipeline is a
+    /// single async handler: the dispatch executor closes over both the message and the
+    /// handler type, so the handler is invoked devirtualized — no contract pattern match.
+    /// The plan is advisory: the executor re-validates the actual pipeline against the
+    /// registry on every version change and falls back to the runtime dispatch shape
+    /// whenever the pipeline no longer matches (interceptors registered at runtime, a
+    /// different handler resolved, adapters configured). Idempotent.
+    /// </summary>
+    public static void AddVoidPlan<TMessage, THandler>()
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>
+        => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>());
+
+    /// <summary>The void pipeline plan of the message type, or <c>null</c> when none was generated.</summary>
+    public static VoidPlanRoot? FindVoidPlan(Type messageType)
+        => VoidPlans.TryGetValue(messageType, out var root) ? root : null;
 }
 
 /// <summary>
@@ -94,4 +114,34 @@ public interface IMessageResultRootVisitor<out TReturn, in TState>
 {
     /// <summary>Called with the root's message and result types as the generic arguments.</summary>
     TReturn Visit<TMessage, TResult>(TState state) where TMessage : IMessage;
+}
+
+/// <summary>
+/// A compile-time pipeline plan closed over a void message and its sole async handler;
+/// see <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}"/> and
+/// <see cref="MessageRoot"/> for the visitor re-entry pattern.
+/// </summary>
+public abstract class VoidPlanRoot
+{
+    /// <summary>Invokes the visitor with this plan's message and handler types as the generic arguments.</summary>
+    public abstract TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state);
+}
+
+/// <summary>The concrete closure of <see cref="VoidPlanRoot"/>; instantiated by generated code.</summary>
+public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage>
+{
+    /// <inheritdoc />
+    public override TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state)
+        => visitor.Visit<TMessage, THandler>(state);
+}
+
+/// <summary>Generic re-entry point for consumers of <see cref="VoidPlanRoot"/>.</summary>
+public interface IVoidPlanRootVisitor<out TReturn, in TState>
+{
+    /// <summary>Called with the plan's message and handler types as the generic arguments.</summary>
+    TReturn Visit<TMessage, THandler>(TState state)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>;
 }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -164,6 +164,90 @@ internal sealed class VoidPipelineExecutor<TMessage>(
 }
 
 /// <summary>
+/// Void pipeline closed over both the message and its compile-time-known sole handler —
+/// the executor a generated void plan constructs. The fast path resolves the handler
+/// reference exactly like <see cref="VoidPipelineExecutor{TMessage}"/> but invokes it
+/// through the closed <typeparamref name="THandler"/> type, so the call devirtualizes
+/// (and inlines for sealed handlers) instead of walking the contract pattern match. The
+/// plan is advisory: the same registry-version-guarded dependency cache re-validates the
+/// pipeline, and any mismatch — interceptors registered at runtime, a differently-typed
+/// handler instance, configured adapters — falls back to the runtime dispatch shape,
+/// preserving semantics exactly.
+/// </summary>
+internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups) : IPipelineExecutor
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage>
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);
+
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependencies? _cachedFastDependencies;
+    private int _cachedVersion = int.MinValue;
+
+    public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = GetDependencies();
+
+        if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
+            && !_foreignAdapters
+            && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
+        {
+            var handler = handlerReference.Resolve(serviceProvider);
+
+            // The compile-time plan's handler type: a devirtualized call, no pattern
+            // match. A runtime re-registration can put a differently-typed handler here;
+            // the contract switch below then dispatches it exactly as the runtime
+            // executor would.
+            if (handler is THandler planned)
+            {
+                return planned.HandleAsync((TMessage)message, context);
+            }
+
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, object> syncHandler:
+                    syncHandler.Handle((TMessage)message, context);
+                    return ValueTask.CompletedTask;
+            }
+        }
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            _cachedFastDependencies = dependencies as MessageDependencies;
+            _cachedDependencies = dependencies;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+    }
+}
+
+/// <summary>
 /// Process-wide cache of pipeline executors, one per (message runtime type, result type,
 /// group set). Executor construction closes the generic executor over the message's runtime
 /// type — one <see cref="Type.MakeGenericType"/> per message type, consistent with the
@@ -294,6 +378,17 @@ internal sealed class PipelineExecutorCache(
     {
         var descriptor = FindDescriptor(messageType);
 
+        // Generated void plan: closed over (message, handler) at compile time, so the
+        // fast path calls the handler devirtualized. Group-less pipelines only — a
+        // grouped pipeline may exclude the planned handler, and the plain executor
+        // serves that shape without the plan's permanently-missing fast check.
+        if (groups.Length == 0 && GeneratedDispatchRoots.FindVoidPlan(messageType) is { } plan)
+        {
+            return plan.Accept(
+                GeneratedVoidExecutorVisitor.Instance,
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups));
+        }
+
         // Generated dispatch roots close the executor generic at compile time; the
         // reflective path below only serves types without a root.
         if (GeneratedDispatchRoots.FindMessage(messageType) is { } root)
@@ -357,6 +452,22 @@ internal sealed class PipelineExecutorCache(
 
         public object Visit<TMessage, TResult>(ExecutorState state) where TMessage : IMessage
             => new ResultPipelineExecutor<TMessage, TResult>(
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups);
+    }
+
+    /// <summary>
+    /// Re-enters a generic context with a generated void plan's (message, handler) pair
+    /// and constructs the plan-closed executor there — no reflection, and the handler
+    /// call devirtualizes inside the closed generic.
+    /// </summary>
+    private sealed class GeneratedVoidExecutorVisitor : IVoidPlanRootVisitor<IPipelineExecutor, ExecutorState>
+    {
+        public static readonly GeneratedVoidExecutorVisitor Instance = new();
+
+        public IPipelineExecutor Visit<TMessage, THandler>(ExecutorState state)
+            where TMessage : notnull, IMessage
+            where THandler : class, IAsyncHandler<TMessage>
+            => new GeneratedVoidPipelineExecutor<TMessage, THandler>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups);
     }
 

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -93,6 +93,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             var commandBuilder = compilation.GetTypeByMetadataName(CommandBuilderMetadataName);
             var queryBuilder = compilation.GetTypeByMetadataName(QueryBuilderMetadataName);
             var eventBuilder = compilation.GetTypeByMetadataName(EventBuilderMetadataName);
+            var dispatchRoots = compilation.GetTypeByMetadataName(DispatchRootsMetadataName);
 
             return new ModuleBuilderAvailability(
                 HasMessageRegistry: compilation.GetTypeByMetadataName(MessageRegistryMetadataName) is not null,
@@ -103,7 +104,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 CommandBuilderHasRegisterDescriptors: HasRegisterDescriptors(commandBuilder),
                 QueryBuilderHasRegisterDescriptors: HasRegisterDescriptors(queryBuilder),
                 EventBuilderHasRegisterDescriptors: HasRegisterDescriptors(eventBuilder),
-                HasDispatchRoots: compilation.GetTypeByMetadataName(DispatchRootsMetadataName) is not null);
+                HasDispatchRoots: dispatchRoots is not null,
+                DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty);
         });
 
         // Reference scanning is default-on; consumers opt out per project through the
@@ -622,8 +624,85 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         // Deterministic output regardless of declaration/discovery order.
         types.Sort(static (x, y) => string.CompareOrdinal(x.TypeofExpression, y.TypeofExpression));
 
-        var source = RegistrationEmitter.Emit(types, availability, GeneratorVersion);
+        var voidPlans = availability.DispatchRootsHasVoidPlans
+            ? ComputeVoidPlans(types)
+            : (IReadOnlyList<VoidPlanModel>)Array.Empty<VoidPlanModel>();
+
+        var source = RegistrationEmitter.Emit(types, availability, voidPlans, GeneratorVersion);
         context.AddSource("ErgosfareRegistrations.g.cs", SourceText.From(source, Encoding.UTF8));
+    }
+
+    /// <summary>
+    ///     Computes the compile-time void pipeline plans: a dispatchable command message
+    ///     qualifies when the whole discovered pipeline for it is exactly one main-handler
+    ///     descriptor, that descriptor is the result-less async contract
+    ///     (<c>IAsyncHandler&lt;TMessage&gt;</c>), its handler participates in default
+    ///     discovery in the default group, and no discovered interceptor targets the
+    ///     message directly. The check is deliberately conservative and only ever costs
+    ///     the speedup when wrong: the runtime executor re-validates the actual pipeline
+    ///     per registry version and falls back to the runtime dispatch shape on any
+    ///     mismatch (covariant handlers or interceptors registered for base contracts,
+    ///     keyed selections, runtime registrations).
+    /// </summary>
+    private static List<VoidPlanModel> ComputeVoidPlans(List<RegistrableTypeModel> types)
+    {
+        var handlerCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var soleHandlers = new Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)>(StringComparer.Ordinal);
+        var interceptedMessages = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var type in types)
+        {
+            foreach (var descriptor in type.Descriptors)
+            {
+                if (descriptor.Kind == DescriptorKind.MainHandler)
+                {
+                    handlerCounts.TryGetValue(descriptor.MessageTypeExpression, out var count);
+                    handlerCounts[descriptor.MessageTypeExpression] = count + 1;
+                    soleHandlers[descriptor.MessageTypeExpression] = (type, descriptor);
+                }
+                else
+                {
+                    interceptedMessages.Add(descriptor.MessageTypeExpression);
+                }
+            }
+        }
+
+        var plans = new List<VoidPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || !type.IsCommand)
+            {
+                continue;
+            }
+
+            if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
+            {
+                continue;
+            }
+
+            if (interceptedMessages.Contains(type.TypeofExpression))
+            {
+                continue;
+            }
+
+            var (handler, descriptor) = soleHandlers[type.TypeofExpression];
+
+            // The sole handler must be the async void contract, discoverable by default
+            // (an unkeyed, ungrouped registration — anything else may not be registered,
+            // or not in the default-group pipeline the plan serves).
+            if (descriptor.ResultTypeExpression != ValueTaskExpression
+                || !handler.IsAccessible
+                || !handler.DiscoveryKeys.IsEmpty
+                || handler.GroupsExpression is not null)
+            {
+                continue;
+            }
+
+            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression));
+        }
+
+        return plans;
     }
 
     private static void AddModels(

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -17,6 +17,7 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// <param name="QueryBuilderHasRegisterDescriptors">Whether the query builder exposes <c>RegisterDescriptors</c>.</param>
 /// <param name="EventBuilderHasRegisterDescriptors">Whether the event builder exposes <c>RegisterDescriptors</c>.</param>
 /// <param name="HasDispatchRoots">Whether the <c>GeneratedDispatchRoots</c> store is resolvable.</param>
+/// <param name="DispatchRootsHasVoidPlans">Whether the store exposes <c>AddVoidPlan</c> (compile-time pipeline plans).</param>
 internal readonly record struct ModuleBuilderAvailability(
     bool HasMessageRegistry,
     bool HasCommandModuleBuilder,
@@ -26,4 +27,5 @@ internal readonly record struct ModuleBuilderAvailability(
     bool CommandBuilderHasRegisterDescriptors,
     bool QueryBuilderHasRegisterDescriptors,
     bool EventBuilderHasRegisterDescriptors,
-    bool HasDispatchRoots);
+    bool HasDispatchRoots,
+    bool DispatchRootsHasVoidPlans);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
@@ -1,0 +1,15 @@
+namespace Stella.Ergosfare.SourceGenerator.Models;
+
+/// <summary>
+///     A compile-time void pipeline plan: a dispatchable command message whose entire
+///     discovered pipeline is a single default-discovery, default-group async handler.
+///     Emitted as <c>GeneratedDispatchRoots.AddVoidPlan&lt;TMessage, THandler&gt;()</c> so
+///     the runtime executor closes over both types and calls the handler devirtualized.
+///     The runtime re-validates the pipeline per registry version, so a plan that turns
+///     out not to match the actual registrations only loses the speedup, never behavior.
+/// </summary>
+/// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
+/// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>
+internal readonly record struct VoidPlanModel(
+    string MessageTypeExpression,
+    string HandlerTypeExpression);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -40,6 +40,7 @@ internal static class RegistrationEmitter
     public static string Emit(
         IReadOnlyList<RegistrableTypeModel> types,
         ModuleBuilderAvailability builders,
+        IReadOnlyList<VoidPlanModel> voidPlans,
         string generatorVersion)
     {
         var useDescriptors = builders.HasDescriptorFactory;
@@ -97,7 +98,7 @@ internal static class RegistrationEmitter
 
         if (emitDispatchRoots)
         {
-            EmitDispatchRoots(sb, ref wroteMember, types);
+            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans);
         }
 
         EmitMatchesHelper(sb, ref wroteMember);
@@ -241,7 +242,8 @@ internal static class RegistrationEmitter
     private static void EmitDispatchRoots(
         StringBuilder sb,
         ref bool wroteMember,
-        IReadOnlyList<RegistrableTypeModel> types)
+        IReadOnlyList<RegistrableTypeModel> types,
+        IReadOnlyList<VoidPlanModel> voidPlans)
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        private static void RootDispatchInstantiations()");
@@ -264,6 +266,17 @@ internal static class RegistrationEmitter
                   .Append(type.TypeofExpression).Append(", ").Append(result.ResultTypeExpression)
                   .AppendLine(">();");
             }
+        }
+
+        // Compile-time pipeline plans: the runtime re-validates each one against the
+        // registry per version, so a plan can only lose its speedup, never change
+        // behavior.
+        foreach (var plan in voidPlans)
+        {
+            sb.Append("            ").Append(DispatchRootsFullName)
+              .Append(".AddVoidPlan<").Append(plan.MessageTypeExpression)
+              .Append(", ").Append(plan.HandlerTypeExpression)
+              .AppendLine(">();");
         }
 
         sb.AppendLine("        }");

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -8,6 +8,7 @@ using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
 using Stella.Ergosfare.Queries.Abstractions;
 using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 using MediatR;
@@ -100,10 +101,12 @@ public sealed class SecondMediatrPingHandler : INotificationHandler<MediatrPingN
 public class MediationBenchmark
 {
     private ServiceProvider _ergosfare = null!;
+    private ServiceProvider _ergosfareGenerated = null!;
     private ServiceProvider _mediatr = null!;
 
     private IMessageMediator _engine = null!;
     private ICommandMediator _commands = null!;
+    private ICommandMediator _generatedCommands = null!;
     private IQueryMediator _queries = null!;
     private IEventMediator _events = null!;
     private IMediator _mediator = null!;
@@ -150,6 +153,28 @@ public class MediationBenchmark
         _mediatr.Dispose();
     }
 
+    /// <summary>
+    /// Source-generated registration variant, isolated to its own benchmark process via
+    /// targets: <c>RegisterGenerated()</c> installs the compile-time dispatch roots and
+    /// void pipeline plans process-wide, and the targeted setup keeps that installation
+    /// away from the runtime-registration rows' processes so the comparison stays honest.
+    /// </summary>
+    [GlobalSetup(Targets = [nameof(Command_Void_Generated)])]
+    public void SetupGenerated()
+    {
+        _ergosfareGenerated = new ServiceCollection()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated()))
+            .BuildServiceProvider();
+
+        _generatedCommands = _ergosfareGenerated.GetRequiredService<ICommandMediator>();
+    }
+
+    [GlobalCleanup(Targets = [nameof(Command_Void_Generated)])]
+    public void CleanupGenerated()
+    {
+        _ergosfareGenerated.Dispose();
+    }
+
     // ------------------------------------------------------------------
     // Root — mediators resolved once, no per-dispatch scope
     // ------------------------------------------------------------------
@@ -159,6 +184,9 @@ public class MediationBenchmark
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Generated() => _generatedCommands.SendAsync(_voidCommand);
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);

--- a/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
+++ b/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <ProjectReference Include="..\..\src\Stella.Ergosfare\Stella.Ergosfare.csproj" />
+        <ProjectReference Include="..\..\src\Stella.Ergosfare.SourceGenerator\Stella.Ergosfare.SourceGenerator.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
@@ -1,0 +1,150 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime behavior of generated void pipeline plans, installed here through the public
+/// <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}"/> surface exactly as
+/// generated code would: the plan-closed executor dispatches the handler, runtime
+/// registrations still invalidate the cached pipeline, and a plan whose handler type does
+/// not match the actual registration falls back to the runtime dispatch shape without any
+/// behavioral difference. Helper types are excluded from discovery so assembly scans (the
+/// registry is process-wide) cannot alter the pipelines these facts construct.
+/// </summary>
+public class GeneratedVoidPlanExecutionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class PlannedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class PlannedCommandHandler : ICommandHandler<PlannedCommand>
+    {
+        public ValueTask HandleAsync(PlannedCommand command, IExecutionContext context)
+        {
+            context.Set("plannedRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlannedDispatch_RunsTheHandler_WithCallerVisibleItems()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<PlannedCommand, PlannedCommandHandler>();
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<PlannedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        settings.Items["keep"] = "me";
+
+        await mediator.SendAsync(new PlannedCommand(), settings);
+
+        Assert.Equal("me", settings.Items["keep"]);
+        Assert.Equal(true, settings.Items["plannedRan"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class LatePlannedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class LatePlannedCommandHandler : ICommandHandler<LatePlannedCommand>
+    {
+        public ValueTask HandleAsync(LatePlannedCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class LatePlannedInterceptor : ICommandPreInterceptor<LatePlannedCommand>
+    {
+        public ValueTask<LatePlannedCommand> HandleAsync(LatePlannedCommand command, IExecutionContext context)
+        {
+            context.Set("lateInterceptorRan", true);
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlannedDispatch_StillPicksUpRuntimeRegistrations()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<LatePlannedCommand, LatePlannedCommandHandler>();
+
+        var provider = new ServiceCollection()
+            .AddTransient<LatePlannedInterceptor>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<LatePlannedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // Warm the plan-closed executor on its devirtualized fast path.
+        var warm = new CommandMediationSettings();
+        await mediator.SendAsync(new LatePlannedCommand(), warm);
+        await mediator.SendAsync(new LatePlannedCommand(), warm);
+        Assert.False(warm.Items.ContainsKey("lateInterceptorRan"));
+
+        // A runtime registration bumps the registry version; the plan's cached pipeline
+        // must rebuild and leave the fast path for the full interceptor pipeline.
+        registry.Register(typeof(LatePlannedInterceptor));
+
+        var probe = new CommandMediationSettings();
+        await mediator.SendAsync(new LatePlannedCommand(), probe);
+
+        Assert.Equal(true, probe.Items["lateInterceptorRan"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedCommand : ICommand { }
+
+    /// <summary>Registered handler — not the type the plan claims.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ActualMismatchedHandler : ICommandHandler<MismatchedCommand>
+    {
+        public ValueTask HandleAsync(MismatchedCommand command, IExecutionContext context)
+        {
+            context.Set("actualRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>The plan's claimed handler; never registered anywhere.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ClaimedMismatchedHandler : ICommandHandler<MismatchedCommand>
+    {
+        public ValueTask HandleAsync(MismatchedCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlanClaimingTheWrongHandler_StillDispatchesTheRegisteredOne()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<MismatchedCommand, ClaimedMismatchedHandler>();
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ActualMismatchedHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+
+        await mediator.SendAsync(new MismatchedCommand(), settings);
+
+        Assert.Equal(true, settings.Items["actualRan"]);
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
@@ -1,0 +1,153 @@
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+/// Compile-time void pipeline plan emission: a dispatchable command whose whole discovered
+/// pipeline is a single default-discovery, default-group async handler gets an
+/// <c>AddVoidPlan</c> root; any ambiguity — a second handler, an interceptor, a keyed or
+/// grouped handler, a result contract — keeps the type on the plain dispatch roots only.
+/// </summary>
+public class VoidPlanEmissionTests
+{
+    [Fact]
+    public void SoloAsyncHandler_EmitsTheVoidPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record SoloPing : ICommand;
+
+                public sealed class SoloPingHandler : ICommandHandler<SoloPing>
+                {
+                    public ValueTask HandleAsync(SoloPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.SoloPing, global::TestApp.SoloPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void SecondHandler_SuppressesThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record DuoPing : ICommand;
+
+                public sealed class FirstDuoPingHandler : ICommandHandler<DuoPing>
+                {
+                    public ValueTask HandleAsync(DuoPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class SecondDuoPingHandler : ICommandHandler<DuoPing>
+                {
+                    public ValueTask HandleAsync(DuoPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+        Assert.Contains("AddMessage<global::TestApp.DuoPing>", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void DiscoveredInterceptor_SuppressesThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record GuardedPing : ICommand;
+
+                public sealed class GuardedPingHandler : ICommandHandler<GuardedPing>
+                {
+                    public ValueTask HandleAsync(GuardedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class GuardedPingInterceptor : ICommandPreInterceptor<GuardedPing>
+                {
+                    public ValueTask<GuardedPing> HandleAsync(GuardedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void KeyedOrGroupedHandler_SuppressesThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record KeyedPing : ICommand;
+
+                [DiscoveryKey("plans.keyed")]
+                public sealed class KeyedPingHandler : ICommandHandler<KeyedPing>
+                {
+                    public ValueTask HandleAsync(KeyedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed record GroupedPing : ICommand;
+
+                [Group("reporting")]
+                public sealed class GroupedPingHandler : ICommandHandler<GroupedPing>
+                {
+                    public ValueTask HandleAsync(GroupedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ResultContract_DoesNotProduceAVoidPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record TypedPing : ICommand<string>;
+
+                public sealed class TypedPingHandler : ICommandHandler<TypedPing, string>
+                {
+                    public ValueTask<string> HandleAsync(TypedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(string.Empty);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+        Assert.Contains("AddResult<global::TestApp.TypedPing, string>", result.GeneratedSource);
+    }
+}


### PR DESCRIPTION
First vertical slice of source-generated pipeline plans, void commands only. When the generator proves a dispatchable command's whole discovered pipeline is a single default-discovery, default-group async handler, it emits `GeneratedDispatchRoots.AddVoidPlan<TMessage, THandler>()`; the executor cache closes an executor over both types and the fast path invokes the handler devirtualized — no contract pattern match.

Plans are advisory, never authoritative:
- the registry-version-guarded dependency cache re-validates the pipeline, so runtime registrations invalidate generated plans exactly as they invalidate runtime executors (new fact);
- a plan whose handler no longer matches falls through to the ordinary contract switch, then the strategy — behavior identical (new fact);
- grouped pipelines and `RegisterFromAssembly`/manual-registration users never see a plan.

Measured (7800X3D, net9): `Command_Void_Generated` 26.5 ns vs the hand-written fast path's 30.1 — the plan beats it by 12%. The benchmark's generated variant runs `RegisterGenerated` in its own targeted-setup process so the runtime rows stay uncontaminated. 16 new facts across generator emission and runtime plan execution.

A result-producing counterpart was implemented and measured during the cycle: it showed no gain (the contract switch's first arm already matches the async contract and PGO devirtualizes it), so it was deliberately not shipped.

Part 5/6 of the v2.3.0-preview stack — depends on #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)