### PR TITLE
perf: the remaining lanes join the fast path — grouped, streaming, result plans, direct construction

### DIFF
--- a/.github/workflows/aot_smoke.yml
+++ b/.github/workflows/aot_smoke.yml
@@ -1,0 +1,36 @@
+name: AotSmoke
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - main
+      - preview
+
+jobs:
+  aot-smoke:
+    # End-to-end NativeAOT gate: publishes the sample app with PublishAot=true (trim/AOT
+    # analyzer warnings are errors there) and runs the produced binary — every dispatch
+    # shape must work without the JIT's MakeGenericType fallback actually jitting.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        # Both SDKs: the referenced library projects multi-target net9.0 and net10.0, so
+        # restore needs to evaluate both even though the smoke app publishes net9.0.
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Publish NativeAOT Smoke App
+        run: dotnet publish examples/AotSmoke/AotSmoke.csproj -c Release -r linux-x64
+
+      - name: Run NativeAOT Smoke App
+        run: ./examples/AotSmoke/bin/Release/net9.0/linux-x64/publish/Ergosfare.AotSmoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,143 @@
+## v2.4.0-preview – '2026-08-07'
+
+Preview release. The theme: **the remaining lanes join the fast path.** v2.3.0-preview left three
+entry points on the original `Mediate` machinery — grouped publishes, grouped dispatches paying
+per-call key materialization, and streaming queries — and resolved every planned handler through
+the container even when the container had nothing to add. This release moves all of them onto the
+executors' cached-plan pattern, teaches generated plans to construct their handlers directly, and
+puts the benchmark up against the fastest widely-used alternative instead of only MediatR. CI
+gains an end-to-end NativeAOT gate. Behavior is preserved on every path (see Notes for the two
+deliberate edges).
+
+### Compile-time result plans and direct handler construction
+
+* The generator now emits `GeneratedDispatchRoots.AddResultPlan<TMessage, TResult, THandler>()`
+  for a dispatchable command/query with exactly one closed, non-stream result contract whose
+  whole discovered pipeline is a single async result handler — the void plan's eligibility rules,
+  applied to the result shape. The executor closes over all three types and invokes the handler
+  devirtualized.
+* Both plan shapes can additionally carry a **direct-construction factory**
+  (`static () => new THandler()`). The compile-time gate is deliberately strict: the handler's
+  *only* instance constructor must be public and parameterless (the container's greedy
+  constructor selection would pick any richer one), no `required` members (an emitted `new()`
+  would not compile), and no `IDisposable`/`IAsyncDisposable` (the container tracks transient
+  disposables; direct construction would not).
+* The factory is as advisory as the plan itself. At runtime it is used only while the handler's
+  *effective* DI registration is the module's own plain transient self-registration — no user
+  factory, no lifetime override, no forced memoization — re-validated with the same
+  registry-version guard as the dependency cache. Any customization routes the dispatch back
+  through the container.
+* The lifetime capture behind that verdict (and behind the existing memoized fast path) now runs
+  **at first resolution instead of inside `AddErgosfare`**, so registrations added between
+  `AddErgosfare` and `BuildServiceProvider` are honored by both features.
+* This reverses v2.3.0-preview's note that a result plan "showed no gain": devirtualization alone
+  did not pay, but together with direct construction the planned query path drops from ~44 ns to
+  ~25 ns per dispatch (see Benchmark).
+
+### Grouped dispatch fast lane
+
+* Grouped command/query dispatch used to materialize the caller's group sequence and build a
+  joined string key on every call. A per-message-type **last-used group-set slot** (void and
+  result alike) now answers the common shape — one message type, one stable group set — with an
+  ordinal element-wise compare: no materialization, no key, no per-dispatch allocation. Misses
+  fall back to the composite stores, which stay authoritative, so executor identity and its
+  version-guarded dependency cache are preserved when group sets alternate. The slot snapshots
+  the group contents, so mutating a reused settings instance reads as a new group set, never a
+  stale hit.
+* **Grouped publishes leave the `Mediate` fallback.** The broadcast invoker resolves the same
+  group-filtered dependencies the old path built — same factory call, same descriptor semantics —
+  from a last-used (factory, group set) plan slot, then runs the same strategy, including the
+  straight-through loop for interceptor-free, unfiltered pipelines. A grouped publish now costs
+  what a group-less one does (see Benchmark).
+
+### Streaming joins the executor path
+
+* Engine-backed facades no longer stream through `Mediate(options)`: no per-call
+  `MediateOptions`, no per-call descriptor lookup, no resolving the scope's `IMessageMediator`.
+  The stream invoker holds the query's pipeline plan (group-less and grouped slots, factory-keyed
+  and version-guarded) and runs the same streaming strategy against it. Context construction is
+  unchanged — one fresh, unpooled context per `StreamAsync` call, shared across re-enumerations
+  exactly as before — and an unregistered query still throws at call time, not at enumeration.
+
+### Typed void dispatch on the engine
+
+* `MessageDispatchEngine.DispatchVoidAsync<TMessage>` resolves its executor from a
+  static-generic holder — a field read and a cache-identity check instead of the type-keyed
+  dictionary lookup — guarded by `message.GetType() == typeof(TMessage)`, so base-typed generic
+  calls keep resolving by runtime type. It is deliberately **not** a `DispatchAsync` overload: a
+  same-name generic would join the candidate set of every explicit `DispatchAsync<T>(msg, …)`
+  call, and for echo-typed shapes (`ICommand<TResult> : ICommand : IMessage` makes them legal)
+  the identity conversion would out-rank the result overload — silently rerouting result
+  dispatches through the void pipeline or breaking compilation. The facade-level counterpart is
+  blocked by the same C# overload-resolution fact and was not shipped.
+
+### Benchmark: a real competitor
+
+* [martinothamar/Mediator](https://github.com/martinothamar/Mediator) 3.0.2 — source-generated
+  dispatch, singleton lifetime by default — joins the table as the `MediatorSg_*` rows, running
+  its out-of-the-box defaults just as the MediatR rows run theirs.
+* New Ergosfare rows make the comparison honest in both directions: `Command_Void_Memoized`
+  (`ForceMemoizedHandlers()` — the zero-allocation shape that matches Mediator's singleton
+  default), `Query_Result_Generated`, grouped rows for command dispatch and event publish, and
+  the engine's typed void dispatch.
+
+Per-operation numbers (BenchmarkDotNet v0.15.8, Windows 11, AMD Ryzen 7 7800X3D, .NET 9.0.11,
+RyuJIT x86-64-v4), measured 2026-08-07:
+
+| Method | Cat | Mean | Alloc |
+|---|---|---:|---:|
+| Engine_Void | Root | 35.16 ns | 24 B |
+| Engine_Void_Typed | Root | 29.60 ns | 24 B |
+| Command_Void | Root | 32.90 ns | 24 B |
+| Command_Void_Generated | Root | **21.21 ns** | 24 B |
+| Command_Void_Memoized | Root | 24.48 ns | **0 B** |
+| Command_Void_Grouped | Root | 36.73 ns | 24 B |
+| Query_Result | Root | 44.10 ns | 24 B |
+| Query_Result_Generated | Root | **25.04 ns** | 24 B |
+| Event_Publish | Root | 56.93 ns | 48 B |
+| Event_Publish_Grouped | Root | 56.22 ns | 48 B |
+| MediatR_Send_Void / _Result / _Publish | Root | 66.22 / 52.88 / 84.90 ns | 192 / 192 / 440 B |
+| MediatorSg_Send_Void / _Result / _Publish | Root | 8.31 / 8.21 / 15.90 ns | 0 / 0 / 0 B |
+| Engine_Void_Scoped | Scoped | 92.67 ns | 200 B |
+| Command_Void_Scoped | Scoped | 89.80 ns | 192 B |
+| Query_Result_Scoped | Scoped | 97.70 ns | 200 B |
+| Event_Publish_Scoped | Scoped | 107.90 ns | 232 B |
+| MediatR (void/result/publish, Scoped) | Scoped | 106.96 / 106.67 / 143.95 ns | 352 / 352 / 600 B |
+| MediatorSg (void/result/publish, Scoped) | Scoped | 56.57 / 56.92 / 70.64 ns | 128 / 128 / 128 B |
+
+The honest reading: Ergosfare leads MediatR on every row, and Mediator — which trades runtime
+registration, group filtering, polymorphic dispatch and the execution-context model for a fully
+static dispatch — leads Ergosfare. This cycle narrowed that gap on the planned void path from
+~3.4× to ~2.3×; the grouped publish row shows the grouped lane reaching parity with the
+group-less one; the remaining lifetime-honoring difference (24 B transient handler per dispatch
+vs. Mediator's shared singletons) is a semantic choice, not an overhead — `Command_Void_Memoized`
+is the like-for-like row.
+
+### NativeAOT smoke in CI
+
+* `examples/AotSmoke` publishes with `PublishAot=true` (trim/AOT analyzer warnings are errors)
+  and runs every dispatch shape — void and result commands through their generated plans, a
+  query, a two-handler class-event broadcast, and a struct event exercising the value-type
+  generic instantiations only generated roots can anchor. The new `AotSmoke` workflow publishes
+  and executes the binary on every push and PR.
+
+### Notes
+
+* **Public API additions:** `MessageDispatchEngine.DispatchVoidAsync<TMessage>`;
+  `GeneratedDispatchRoots.AddResultPlan`/`FindResultPlan` with `ResultPlanRoot`/
+  `IResultPlanRootVisitor`; `Func<THandler>`-taking overloads of `AddVoidPlan`/`AddResultPlan`.
+  Nothing is removed or changed in shape.
+* **Deliberate behavioral edges:** (1) a custom `IMessageMediator` registration decorating the
+  scope's mediator no longer sees grouped publishes or streams on engine-backed facades — those
+  lanes now run the engine directly, consistent with the group-less lane since v2.3.0-preview;
+  wrapped-construction facades and foreign mediator implementations keep the original path.
+  (2) Because the lifetime capture moved to first resolution, handler registrations added after
+  `AddErgosfare` are now honored by the memoized fast path too — strictly closer to the
+  container's own behavior.
+* The static plan/executor holders root the last-serving container's executor graph past
+  container disposal (at most one graph per message type — in a single-container process, the
+  live one). A `WeakReference` would tax every hot-path read instead; called out for review.
+
 ## v2.3.0-preview – '2026-07-28'
 
 Preview release. The theme: **event publishing joins the fast lane, and resolving a mediator stops

--- a/examples/AotSmoke/AotSmoke.csproj
+++ b/examples/AotSmoke/AotSmoke.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <!-- Single-TFM override of the repo-wide multi-targeting: the smoke publishes one
+             concrete AOT binary. -->
+        <TargetFramework>net9.0</TargetFramework>
+        <PublishAot>true</PublishAot>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <!-- Trim/AOT analyzer findings in this app or the library fail the smoke instead
+             of scrolling by as warnings. -->
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- The Stella.Ergosfare.* prefix is reserved: reference scanning skips library
+             assemblies, so the app must live outside it to be scanned itself. -->
+        <AssemblyName>Ergosfare.AotSmoke</AssemblyName>
+        <RootNamespace>Ergosfare.AotSmoke</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Stella.Ergosfare\Stella.Ergosfare.csproj" />
+        <ProjectReference Include="..\..\src\Stella.Ergosfare.SourceGenerator\Stella.Ergosfare.SourceGenerator.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+</Project>

--- a/examples/AotSmoke/Directory.Build.props
+++ b/examples/AotSmoke/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+    <!-- Deliberately does not import the repo root props: the smoke app pins a single
+         TFM for its NativeAOT publish, and the repo-wide net10.0;net9.0 multi-targeting
+         would fight that (and misresolve the ILCompiler pack). -->
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/examples/AotSmoke/Program.cs
+++ b/examples/AotSmoke/Program.cs
@@ -1,0 +1,149 @@
+// End-to-end NativeAOT smoke: source-generated registration + every dispatch shape the
+// library advertises for AOT, executed in a PublishAot=true binary. Any failure exits
+// non-zero, so CI treats the published binary's run as the assertion.
+
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+var provider = new ServiceCollection()
+    .AddErgosfare(options =>
+    {
+        options.AddCommandModule(commands => commands.RegisterGenerated());
+        options.AddQueryModule(queries => queries.RegisterGenerated());
+        options.AddEventModule(events => events.RegisterGenerated());
+    })
+    .BuildServiceProvider();
+
+await using var _ = provider;
+
+var failures = new List<string>();
+
+// Void command — the generated void plan's devirtualized, directly-constructed path.
+var commands = provider.GetRequiredService<ICommandMediator>();
+var voidSettings = new CommandMediationSettings();
+await commands.SendAsync(new Ergosfare.AotSmoke.CreateNote(), voidSettings);
+if (!Equals(voidSettings.Items["noteCreated"], true))
+{
+    failures.Add("void command handler did not run");
+}
+
+// Result command — the generated result plan.
+var echoed = await commands.SendAsync(new Ergosfare.AotSmoke.EchoNote { Text = "aot" });
+if (echoed != "aot!")
+{
+    failures.Add($"result command returned '{echoed}', expected 'aot!'");
+}
+
+// Query — result executor over a value-type result.
+var queries = provider.GetRequiredService<IQueryMediator>();
+var answer = await queries.QueryAsync(new Ergosfare.AotSmoke.TheAnswer());
+if (answer != 42)
+{
+    failures.Add($"query returned {answer}, expected 42");
+}
+
+// Class event broadcast with two handlers.
+var events = provider.GetRequiredService<IEventMediator>();
+var publishSettings = new EventMediationSettings();
+await events.PublishAsync(new Ergosfare.AotSmoke.NotePublished(), publishSettings);
+if (!Equals(publishSettings.Items["firstSubscriber"], true) || !Equals(publishSettings.Items["secondSubscriber"], true))
+{
+    failures.Add("event broadcast did not reach both handlers");
+}
+
+// Struct event — the value-type generic instantiations only generated roots anchor
+// under AOT (shared generic code cannot cover them).
+var structSettings = new EventMediationSettings();
+await events.PublishAsync(new Ergosfare.AotSmoke.StructPing(7), structSettings);
+if (!Equals(structSettings.Items["structPayload"], 7))
+{
+    failures.Add("struct event handler did not observe the payload");
+}
+
+if (failures.Count > 0)
+{
+    foreach (var failure in failures)
+    {
+        Console.Error.WriteLine($"AOT smoke FAILED: {failure}");
+    }
+
+    return 1;
+}
+
+Console.WriteLine("AOT smoke passed: all dispatch shapes completed.");
+return 0;
+
+namespace Ergosfare.AotSmoke
+{
+    public sealed class CreateNote : ICommand { }
+
+    public sealed class CreateNoteHandler : ICommandHandler<CreateNote>
+    {
+        public ValueTask HandleAsync(CreateNote command, IExecutionContext context)
+        {
+            context.Set("noteCreated", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class EchoNote : ICommand<string>
+    {
+        public string Text { get; init; } = string.Empty;
+    }
+
+    public sealed class EchoNoteHandler : ICommandHandler<EchoNote, string>
+    {
+        public ValueTask<string> HandleAsync(EchoNote command, IExecutionContext context)
+            => ValueTask.FromResult(command.Text + "!");
+    }
+
+    public sealed class TheAnswer : IQuery<int> { }
+
+    public sealed class TheAnswerHandler : IQueryHandler<TheAnswer, int>
+    {
+        public ValueTask<int> HandleAsync(TheAnswer query, IExecutionContext context)
+            => ValueTask.FromResult(42);
+    }
+
+    public sealed class NotePublished : IEvent { }
+
+    public sealed class FirstNoteSubscriber : IEventHandler<NotePublished>
+    {
+        public ValueTask HandleAsync(NotePublished @event, IExecutionContext context)
+        {
+            context.Set("firstSubscriber", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class SecondNoteSubscriber : IEventHandler<NotePublished>
+    {
+        public ValueTask HandleAsync(NotePublished @event, IExecutionContext context)
+        {
+            context.Set("secondSubscriber", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public readonly struct StructPing(int payload) : IEvent
+    {
+        public int Payload { get; } = payload;
+    }
+
+    public sealed class StructPingHandler : IEventHandler<StructPing>
+    {
+        public ValueTask HandleAsync(StructPing @event, IExecutionContext context)
+        {
+            context.Set("structPayload", @event.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
@@ -20,6 +20,7 @@ public static class GeneratedDispatchRoots
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Results = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Streams = new();
     private static readonly ConcurrentDictionary<Type, VoidPlanRoot> VoidPlans = new();
+    private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), ResultPlanRoot> ResultPlans = new();
 
     /// <summary>Roots the void dispatch generics of a message type. Idempotent.</summary>
     public static void AddMessage<TMessage>() where TMessage : IMessage
@@ -59,9 +60,51 @@ public static class GeneratedDispatchRoots
         where THandler : class, IAsyncHandler<TMessage>
         => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>());
 
+    /// <summary>
+    /// Variant of <see cref="AddVoidPlan{TMessage, THandler}()"/> carrying a compile-time
+    /// construction path for the handler: the generator emits
+    /// <c>static () => new THandler()</c> for handlers with an accessible parameterless
+    /// constructor that are not disposable. The factory is advisory like the plan itself —
+    /// the executor uses it only after verifying at runtime that the handler's DI
+    /// registration is the module's own plain transient one (no user factory, no lifetime
+    /// override, not memoized), where container resolution and direct construction are
+    /// semantically identical. Idempotent.
+    /// </summary>
+    public static void AddVoidPlan<TMessage, THandler>(Func<THandler> directHandlerFactory)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>
+        => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>(directHandlerFactory));
+
     /// <summary>The void pipeline plan of the message type, or <c>null</c> when none was generated.</summary>
     public static VoidPlanRoot? FindVoidPlan(Type messageType)
         => VoidPlans.TryGetValue(messageType, out var root) ? root : null;
+
+    /// <summary>
+    /// Result-producing counterpart of <see cref="AddVoidPlan{TMessage, THandler}()"/>:
+    /// roots a compile-time pipeline plan for a message whose entire pipeline is a single
+    /// async result handler, so the dispatch executor invokes it devirtualized. The plan
+    /// is advisory and re-validated per registry version exactly like the void plan.
+    /// Idempotent.
+    /// </summary>
+    public static void AddResultPlan<TMessage, TResult, THandler>()
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>
+        => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>());
+
+    /// <summary>
+    /// Variant of <see cref="AddResultPlan{TMessage, TResult, THandler}()"/> carrying the
+    /// compile-time handler construction path; see
+    /// <see cref="AddVoidPlan{TMessage, THandler}(Func{THandler})"/> for the contract.
+    /// Idempotent.
+    /// </summary>
+    public static void AddResultPlan<TMessage, TResult, THandler>(Func<THandler> directHandlerFactory)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>
+        => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>(directHandlerFactory));
+
+    /// <summary>The result pipeline plan of the (message, result) pair, or <c>null</c> when none was generated.</summary>
+    public static ResultPlanRoot? FindResultPlan(Type messageType, Type resultType)
+        => ResultPlans.TryGetValue((messageType, resultType), out var root) ? root : null;
 }
 
 /// <summary>
@@ -125,6 +168,13 @@ public abstract class VoidPlanRoot
 {
     /// <summary>Invokes the visitor with this plan's message and handler types as the generic arguments.</summary>
     public abstract TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state);
+
+    /// <summary>
+    /// The compile-time handler construction path — a <c>Func&lt;THandler&gt;</c> carried
+    /// erased, cast back inside the executor's closed generic context — or <c>null</c>
+    /// when the generator emitted no factory for the handler.
+    /// </summary>
+    internal virtual object? DirectHandlerFactory => null;
 }
 
 /// <summary>The concrete closure of <see cref="VoidPlanRoot"/>; instantiated by generated code.</summary>
@@ -132,6 +182,18 @@ public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
+    private readonly Func<THandler>? _directHandlerFactory;
+
+    /// <summary>Creates a plan without a compile-time construction path.</summary>
+    public VoidPlanRoot()
+    {
+    }
+
+    internal VoidPlanRoot(Func<THandler> directHandlerFactory)
+        => _directHandlerFactory = directHandlerFactory;
+
+    internal override object? DirectHandlerFactory => _directHandlerFactory;
+
     /// <inheritdoc />
     public override TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state)
         => visitor.Visit<TMessage, THandler>(state);
@@ -144,4 +206,49 @@ public interface IVoidPlanRootVisitor<out TReturn, in TState>
     TReturn Visit<TMessage, THandler>(TState state)
         where TMessage : notnull, IMessage
         where THandler : class, IAsyncHandler<TMessage>;
+}
+
+/// <summary>
+/// A compile-time pipeline plan closed over a result-producing message, its result type
+/// and its sole async handler; the result-producing counterpart of
+/// <see cref="VoidPlanRoot"/>.
+/// </summary>
+public abstract class ResultPlanRoot
+{
+    /// <summary>Invokes the visitor with this plan's message, result and handler types as the generic arguments.</summary>
+    public abstract TReturn Accept<TReturn, TState>(IResultPlanRootVisitor<TReturn, TState> visitor, TState state);
+
+    /// <inheritdoc cref="VoidPlanRoot.DirectHandlerFactory"/>
+    internal virtual object? DirectHandlerFactory => null;
+}
+
+/// <summary>The concrete closure of <see cref="ResultPlanRoot"/>; instantiated by generated code.</summary>
+public sealed class ResultPlanRoot<TMessage, TResult, THandler> : ResultPlanRoot
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage, TResult>
+{
+    private readonly Func<THandler>? _directHandlerFactory;
+
+    /// <summary>Creates a plan without a compile-time construction path.</summary>
+    public ResultPlanRoot()
+    {
+    }
+
+    internal ResultPlanRoot(Func<THandler> directHandlerFactory)
+        => _directHandlerFactory = directHandlerFactory;
+
+    internal override object? DirectHandlerFactory => _directHandlerFactory;
+
+    /// <inheritdoc />
+    public override TReturn Accept<TReturn, TState>(IResultPlanRootVisitor<TReturn, TState> visitor, TState state)
+        => visitor.Visit<TMessage, TResult, THandler>(state);
+}
+
+/// <summary>Generic re-entry point for consumers of <see cref="ResultPlanRoot"/>.</summary>
+public interface IResultPlanRootVisitor<out TReturn, in TState>
+{
+    /// <summary>Called with the plan's message, result and handler types as the generic arguments.</summary>
+    TReturn Visit<TMessage, TResult, THandler>(TState state)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>;
 }

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -89,23 +89,61 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
             RegisterHandlersFromDescriptor(descriptor, allHandlerTypes);
         }
 
-        // Capture the effective DI lifetime of every handler type (a user registration made
-        // before AddErgosfare wins over the TryAddTransient defaults above). Messages whose
-        // whole pipeline is singleton-registered keep the memoized fast path; the rest are
-        // resolved per scope so scoped/transient dependencies are honored.
-        var handlerLifetimes = new Dictionary<Type, ServiceLifetime>();
-        foreach (var serviceDescriptor in services)
-        {
-            if (allHandlerTypes.Contains(serviceDescriptor.ServiceType))
-            {
-                handlerLifetimes[serviceDescriptor.ServiceType] = serviceDescriptor.Lifetime;
-            }
-        }
-
-        services.TryAddSingleton(new HandlerLifetimeRegistry(handlerLifetimes));
+        // The lifetime registry is registered as a FACTORY so the capture runs at first
+        // resolution — after BuildServiceProvider, when the collection is final. A snapshot
+        // taken here (inside AddErgosfare) would miss registrations the user adds
+        // afterwards; for memoization that staleness only cost the fast path, but the
+        // plans' direct-construction gate must never claim a handler whose effective
+        // registration the user has overridden. The captured set of handler types keeps
+        // the scan bounded to pipeline participants.
+        var registeredHandlerTypes = allHandlerTypes;
+        services.TryAddSingleton(_ => CaptureHandlerLifetimes(services, registeredHandlerTypes));
     }
     
     
+    /// <summary>
+    /// Builds the lifetime registry from the finalized service collection: the effective
+    /// DI lifetime of every handler type (last registration wins, mirroring
+    /// <c>GetRequiredService</c>), and the subset whose effective registration is a plain
+    /// transient self-registration — the shape the module's own <c>TryAddTransient</c>
+    /// produces, and the only shape for which a generated plan may construct the handler
+    /// directly. Keyed descriptors throw on the implementation members, so they are
+    /// excluded up front.
+    /// </summary>
+    private static HandlerLifetimeRegistry CaptureHandlerLifetimes(
+        IServiceCollection services, HashSet<Type> handlerTypes)
+    {
+        var handlerLifetimes = new Dictionary<Type, ServiceLifetime>();
+        var plainTransientRegistrations = new HashSet<Type>();
+
+        foreach (var serviceDescriptor in services)
+        {
+            if (!handlerTypes.Contains(serviceDescriptor.ServiceType))
+            {
+                continue;
+            }
+
+            handlerLifetimes[serviceDescriptor.ServiceType] = serviceDescriptor.Lifetime;
+
+            var isPlain = !serviceDescriptor.IsKeyedService
+                          && serviceDescriptor.Lifetime == ServiceLifetime.Transient
+                          && serviceDescriptor.ImplementationType == serviceDescriptor.ServiceType
+                          && serviceDescriptor.ImplementationFactory is null
+                          && serviceDescriptor.ImplementationInstance is null;
+
+            if (isPlain)
+            {
+                plainTransientRegistrations.Add(serviceDescriptor.ServiceType);
+            }
+            else
+            {
+                plainTransientRegistrations.Remove(serviceDescriptor.ServiceType);
+            }
+        }
+
+        return new HandlerLifetimeRegistry(handlerLifetimes, plainTransientRegistrations);
+    }
+
     /// <summary>
     /// Collects and registers all handler types defined in the given message descriptor.
     /// </summary>

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -46,6 +46,16 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
                     ? typedRegistry.Version
                     : _registry.Count;
 
+    /// <summary>
+    /// Whether the handler type's effective DI registration is the module's own plain
+    /// transient shape, making container resolution and direct construction semantically
+    /// identical; see <see cref="HandlerLifetimeRegistry.IsPlainTransientRegistration"/>.
+    /// Always <c>false</c> before the first <see cref="Create"/> resolves the registry —
+    /// executors only consult this after building their dependencies.
+    /// </summary>
+    internal bool IsPlainTransientRegistration(Type handlerType)
+        => _servicesResolved && (_handlerLifetimes?.IsPlainTransientRegistration(handlerType) ?? false);
+
     public IMessageDependencies Create(Type messageType, IMessageDescriptor descriptor, IEnumerable<string> groups)
     {
         var cache = _cache ??= serviceProvider.GetRequiredService<MessageDescriptorCache>();

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
@@ -83,6 +83,7 @@ internal sealed class MessageDependencies : IMessageDependencies
             && FinalInterceptors.Count == 0;
 
         FastSingleHandler = HasNoInterceptors && Handlers.Count == 1 ? Handlers[0] : null;
+        MemoizedInstances = memoizedProvider is not null;
     }
 
     /// <summary>
@@ -104,6 +105,13 @@ internal sealed class MessageDependencies : IMessageDependencies
     /// stages; <c>null</c> otherwise. Computed once at construction.
     /// </summary>
     internal IHandlerReference<IHandler, IMainHandlerDescriptor>? FastSingleHandler { get; }
+
+    /// <summary>
+    /// Whether references resolve once and cache the instance (memoized mode). Generated
+    /// plans must not construct handlers directly in this mode — the memoized instance is
+    /// the semantic contract.
+    /// </summary>
+    internal bool MemoizedInstances { get; }
 
     /// <summary>
     /// Wraps the shape's planned handlers in resolvable references. Runs once per

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -178,7 +178,8 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     IMessageDescriptor descriptor,
     IMessageDependenciesFactory dependenciesFactory,
     IResultAdapterService? resultAdapterService,
-    string[] groups) : IPipelineExecutor
+    string[] groups,
+    Func<THandler>? directHandlerFactory = null) : IPipelineExecutor
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
@@ -187,9 +188,23 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
+    // Compile-time construction path for the planned handler; discarded up front for
+    // disposable handlers — the container tracks transient disposables in the resolving
+    // scope, direct construction would not.
+    private readonly Func<THandler>? _directHandlerFactory =
+        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler))
+            ? null
+            : directHandlerFactory;
+
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
     private int _cachedVersion = int.MinValue;
+
+    // Re-validated with the dependency cache: true only while the registry's sole handler
+    // is the planned type, instances are not memoized, and the handler's effective DI
+    // registration is the module's own plain transient one — the exact conditions under
+    // which GetRequiredService is observably nothing but a constructor call.
+    private bool _useDirectConstruction;
 
     public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -199,7 +214,12 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             && !_foreignAdapters
             && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
         {
-            var handler = handlerReference.Resolve(serviceProvider);
+            // The handler-type re-check pins the racy flag to the reference actually in
+            // hand: a version transition observed halfway can only route back through the
+            // container, never construct a type the registry no longer plans.
+            IHandler handler = _useDirectConstruction && handlerReference.HandlerType == typeof(THandler)
+                ? _directHandlerFactory!()
+                : handlerReference.Resolve(serviceProvider);
 
             // The compile-time plan's handler type: a devirtualized call, no pattern
             // match. A runtime re-registration can put a differently-typed handler here;
@@ -237,15 +257,114 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             }
 
             var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
-            _cachedFastDependencies = dependencies as MessageDependencies;
+            var fastDependencies = dependencies as MessageDependencies;
+            _cachedFastDependencies = fastDependencies;
             _cachedDependencies = dependencies;
+            _useDirectConstruction = _directHandlerFactory is not null
+                && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
+                && plannedType == typeof(THandler)
+                && typedFactory.IsPlainTransientRegistration(typeof(THandler));
             _cachedVersion = typedFactory.CurrentRegistryVersion;
             return dependencies;
         }
 
+        _useDirectConstruction = false;
         return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }
+
+/// <summary>
+/// Result-producing counterpart of
+/// <see cref="GeneratedVoidPipelineExecutor{TMessage, THandler}"/>: closed over the
+/// message, its result and its compile-time-known sole async handler, so the handler call
+/// devirtualizes instead of walking the contract pattern match. The same advisory-plan
+/// contract applies — the registry-version-guarded dependency cache re-validates the
+/// pipeline and any mismatch falls back to the runtime dispatch shape.
+/// </summary>
+#pragma warning disable CS8714 // TResult is used as a pattern type argument; handler contracts declare notnull results
+internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups,
+    Func<THandler>? directHandlerFactory = null) : IPipelineExecutor<TResult>
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage, TResult>
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);
+
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private readonly Func<THandler>? _directHandlerFactory =
+        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler))
+            ? null
+            : directHandlerFactory;
+
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependencies? _cachedFastDependencies;
+    private int _cachedVersion = int.MinValue;
+    private bool _useDirectConstruction;
+
+    public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = GetDependencies();
+
+        if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
+            && !_foreignAdapters
+            && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
+        {
+            IHandler handler = _useDirectConstruction && handlerReference.HandlerType == typeof(THandler)
+                ? _directHandlerFactory!()
+                : handlerReference.Resolve(serviceProvider);
+
+            if (handler is THandler planned)
+            {
+                return planned.HandleAsync((TMessage)message, context);
+            }
+
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage, TResult> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, TResult> syncHandler:
+                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+            }
+        }
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            var fastDependencies = dependencies as MessageDependencies;
+            _cachedFastDependencies = fastDependencies;
+            _cachedDependencies = dependencies;
+            _useDirectConstruction = _directHandlerFactory is not null
+                && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
+                && plannedType == typeof(THandler)
+                && typedFactory.IsPlainTransientRegistration(typeof(THandler));
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        _useDirectConstruction = false;
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+    }
+}
+#pragma warning restore CS8714
 
 /// <summary>
 /// Process-wide cache of pipeline executors, one per (message runtime type, result type,
@@ -285,6 +404,140 @@ internal sealed class PipelineExecutorCache(
         public readonly object Executor = executor;
     }
 
+    // Last-used grouped executor per message type: an ordinal element-wise compare of the
+    // caller's group sequence against the slot's snapshot replaces the per-dispatch group
+    // materialization and joined-string key of the composite stores — the overwhelmingly
+    // common grouped caller dispatches one message type with one stable group set. A slot
+    // miss falls back to the composite store, which stays authoritative so executor
+    // identity (and its dependency cache) is preserved when group sets alternate.
+    private readonly ConcurrentDictionary<Type, GroupedVoidExecutorSlot> _groupedVoidSlotsByType = new();
+    private readonly ConcurrentDictionary<Type, GroupedResultExecutorSlot> _groupedResultSlotsByType = new();
+
+    /// <summary>Immutable (groups, executor) pair; see <see cref="ResultExecutorSlot"/> for the refresh contract.</summary>
+    private sealed class GroupedVoidExecutorSlot(string[] groups, IPipelineExecutor executor)
+    {
+        public readonly string[] Groups = groups;
+        public readonly IPipelineExecutor Executor = executor;
+    }
+
+    /// <summary>Immutable (groups, result type, executor) triple; see <see cref="ResultExecutorSlot"/>.</summary>
+    private sealed class GroupedResultExecutorSlot(string[] groups, Type resultType, object executor)
+    {
+        public readonly string[] Groups = groups;
+        public readonly Type ResultType = resultType;
+        public readonly object Executor = executor;
+    }
+
+    /// <summary>
+    /// Ordinal element-wise comparison of the caller's group sequence against a cached
+    /// snapshot, allocation-free for the array and list shapes settings expose. Order is
+    /// significant, matching the joined composite key exactly.
+    /// </summary>
+    internal static bool GroupsMatch(IEnumerable<string> groups, string[] cached)
+    {
+        switch (groups)
+        {
+            case string[] array:
+            {
+                if (array.Length != cached.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < array.Length; i++)
+                {
+                    if (!string.Equals(array[i], cached[i], StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            case List<string> list:
+            {
+                if (list.Count != cached.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < cached.Length; i++)
+                {
+                    if (!string.Equals(list[i], cached[i], StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            default:
+            {
+                var index = 0;
+
+                foreach (var group in groups)
+                {
+                    if (index >= cached.Length || !string.Equals(group, cached[index], StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+
+                    index++;
+                }
+
+                return index == cached.Length;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Group-less void executor lookup for a compile-time-known message type: a
+    /// static-generic slot replaces the dictionary lookup with a field read and a cache
+    /// identity check. The slot is keyed by this cache instance, so containers stay
+    /// isolated — a foreign cache's executor is never served, and the authoritative
+    /// per-type dictionary below preserves executor identity across slot refreshes.
+    /// Callers must guard with <c>message.GetType() == typeof(TMessage)</c>; a base-typed
+    /// generic call must keep resolving by the runtime type.
+    /// </summary>
+    public IPipelineExecutor GetVoidExecutor<TMessage>() where TMessage : IMessage
+    {
+        var slot = VoidExecutorHolder<TMessage>.Slot;
+
+        if (slot is not null && ReferenceEquals(slot.Cache, this))
+        {
+            return slot.Executor;
+        }
+
+        var executor = GetVoidExecutor(typeof(TMessage));
+        VoidExecutorHolder<TMessage>.Slot = new VoidExecutorSlot(this, executor);
+
+        return executor;
+    }
+
+    /// <summary>
+    /// Immutable (cache, executor) pair — immutability makes the racy slot refresh safe:
+    /// a reader that observes the reference sees both fields.
+    /// </summary>
+    private sealed class VoidExecutorSlot(PipelineExecutorCache cache, IPipelineExecutor executor)
+    {
+        public readonly PipelineExecutorCache Cache = cache;
+        public readonly IPipelineExecutor Executor = executor;
+    }
+
+    /// <summary>
+    /// Per-message-type slot for the last cache instance that served a typed void lookup.
+    /// Multiple containers alternating over one message type refresh the slot each time —
+    /// correct either way, and the single-container case (every production process) reads
+    /// a stable field forever. The strong reference deliberately roots the last-serving
+    /// cache (and through it that container's executor graph) past container disposal:
+    /// at most one graph per message type, which in a single-container process is the
+    /// live one anyway — a WeakReference would tax every hot-path read instead.
+    /// </summary>
+    private static class VoidExecutorHolder<TMessage> where TMessage : IMessage
+    {
+        public static VoidExecutorSlot? Slot;
+    }
+
     public IPipelineExecutor GetVoidExecutor(Type messageType, IEnumerable<string>? groups = null)
     {
         if (groups is null)
@@ -298,6 +551,12 @@ internal sealed class PipelineExecutorCache(
                 static (t, cache) => cache.CreateVoidExecutor(t, EmptyGroups), this);
         }
 
+        if (_groupedVoidSlotsByType.TryGetValue(messageType, out var slot)
+            && GroupsMatch(groups, slot.Groups))
+        {
+            return slot.Executor;
+        }
+
         var materializedGroups = MaterializeGroups(groups);
         var key = (messageType, GroupsKey(materializedGroups));
 
@@ -307,6 +566,8 @@ internal sealed class PipelineExecutorCache(
                 static (k, state) => state.Cache.CreateVoidExecutor(k.MessageType, state.Groups),
                 (Cache: this, Groups: materializedGroups));
         }
+
+        _groupedVoidSlotsByType[messageType] = new GroupedVoidExecutorSlot(materializedGroups, executor);
 
         return executor;
     }
@@ -327,6 +588,15 @@ internal sealed class PipelineExecutorCache(
             return GetExecutorSlow<TResult>(messageType);
         }
 
+        if (_groupedResultSlotsByType.TryGetValue(messageType, out var groupedSlot)
+            && ReferenceEquals(groupedSlot.ResultType, typeof(TResult))
+            && GroupsMatch(groups, groupedSlot.Groups))
+        {
+            // Slot entries are only ever created as IPipelineExecutor<TResult> for their
+            // recorded result type; see the group-less slot above.
+            return Unsafe.As<IPipelineExecutor<TResult>>(groupedSlot.Executor);
+        }
+
         var materializedGroups = MaterializeGroups(groups);
         var key = (messageType, typeof(TResult), GroupsKey(materializedGroups));
 
@@ -336,6 +606,8 @@ internal sealed class PipelineExecutorCache(
                 static (k, state) => state.Cache.CreateResultExecutor(k.MessageType, k.ResultType, state.Groups),
                 (Cache: this, Groups: materializedGroups));
         }
+
+        _groupedResultSlotsByType[messageType] = new GroupedResultExecutorSlot(materializedGroups, typeof(TResult), executor);
 
         return (IPipelineExecutor<TResult>)executor;
     }
@@ -386,7 +658,8 @@ internal sealed class PipelineExecutorCache(
         {
             return plan.Accept(
                 GeneratedVoidExecutorVisitor.Instance,
-                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups));
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups,
+                    plan.DirectHandlerFactory));
         }
 
         // Generated dispatch roots close the executor generic at compile time; the
@@ -413,6 +686,17 @@ internal sealed class PipelineExecutorCache(
     {
         var descriptor = FindDescriptor(messageType);
 
+        // Generated result plan: closed over (message, result, handler) at compile time,
+        // so the fast path calls the handler devirtualized. Group-less pipelines only,
+        // mirroring the void plan above.
+        if (groups.Length == 0 && GeneratedDispatchRoots.FindResultPlan(messageType, resultType) is { } plan)
+        {
+            return plan.Accept(
+                GeneratedResultExecutorVisitor.Instance,
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups,
+                    plan.DirectHandlerFactory));
+        }
+
         if (GeneratedDispatchRoots.FindResult(messageType, resultType) is { } root)
         {
             return root.Accept(
@@ -425,12 +709,18 @@ internal sealed class PipelineExecutorCache(
         return Activator.CreateInstance(executorType, descriptor, dependenciesFactory, resultAdapterService, groups)!;
     }
 
-    /// <summary>Constructor arguments carried into the generic re-entry of a dispatch root.</summary>
+    /// <summary>
+    /// Constructor arguments carried into the generic re-entry of a dispatch root.
+    /// <paramref name="DirectHandlerFactory"/> is a plan's erased <c>Func&lt;THandler&gt;</c>
+    /// (cast back inside the closed generic), or <c>null</c> for plain roots and plans
+    /// without a construction path.
+    /// </summary>
     private readonly record struct ExecutorState(
         IMessageDescriptor Descriptor,
         IMessageDependenciesFactory DependenciesFactory,
         IResultAdapterService? ResultAdapterService,
-        string[] Groups);
+        string[] Groups,
+        object? DirectHandlerFactory = null);
 
     /// <summary>
     /// Re-enters a generic context with a root's message type and constructs the closed
@@ -468,7 +758,25 @@ internal sealed class PipelineExecutorCache(
             where TMessage : notnull, IMessage
             where THandler : class, IAsyncHandler<TMessage>
             => new GeneratedVoidPipelineExecutor<TMessage, THandler>(
-                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups);
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
+                state.DirectHandlerFactory as Func<THandler>);
+    }
+
+    /// <summary>
+    /// Re-enters a generic context with a generated result plan's (message, result,
+    /// handler) triple and constructs the plan-closed executor there; the result-producing
+    /// counterpart of <see cref="GeneratedVoidExecutorVisitor"/>.
+    /// </summary>
+    private sealed class GeneratedResultExecutorVisitor : IResultPlanRootVisitor<object, ExecutorState>
+    {
+        public static readonly GeneratedResultExecutorVisitor Instance = new();
+
+        public object Visit<TMessage, TResult, THandler>(ExecutorState state)
+            where TMessage : notnull, IMessage
+            where THandler : class, IAsyncHandler<TMessage, TResult>
+            => new GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
+                state.DirectHandlerFactory as Func<THandler>);
     }
 
     private IMessageDescriptor FindDescriptor(Type messageType)

--- a/src/Stella.Ergosfare.Core/Internal/Registry/HandlerLifetimeRegistry.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/HandlerLifetimeRegistry.cs
@@ -10,8 +10,30 @@ namespace Stella.Ergosfare.Core.Internal.Registry;
 /// memoized fast path). Types with no known registration are treated as non-singleton,
 /// which routes them to the always-correct per-scope resolution path.
 /// </summary>
-internal sealed class HandlerLifetimeRegistry(IReadOnlyDictionary<Type, ServiceLifetime> lifetimes)
+/// <param name="lifetimes">Effective DI lifetime per handler type, captured at module initialization.</param>
+/// <param name="plainTransientRegistrations">
+/// Handler types whose effective registration is a plain transient self-registration
+/// (implementation type equals the service type, no factory, no instance, unkeyed) — the
+/// exact shape the module's own <c>TryAddTransient</c> produces. For these, container
+/// resolution and direct construction are semantically identical, which is what licenses
+/// a generated plan's <c>new()</c> fast path. Types not in the set — user factories,
+/// lifetime overrides, runtime-only registrations — always resolve through the container.
+/// </param>
+internal sealed class HandlerLifetimeRegistry(
+    IReadOnlyDictionary<Type, ServiceLifetime> lifetimes,
+    IReadOnlyCollection<Type>? plainTransientRegistrations = null)
 {
+    private readonly HashSet<Type> _plainTransients =
+        plainTransientRegistrations as HashSet<Type> ?? [.. plainTransientRegistrations ?? []];
+
+    /// <summary>
+    /// Whether the handler type's effective registration is the module's own plain
+    /// transient shape; see the constructor documentation. Captured at initialization —
+    /// the same capture window the lifetime dictionary (and with it the memoized fast
+    /// path) already relies on.
+    /// </summary>
+    public bool IsPlainTransientRegistration(Type handlerType) => _plainTransients.Contains(handlerType);
+
     private readonly ConcurrentDictionary<Type, bool> _allSingletonByMessageType = new();
     private int _version = -1;
 

--- a/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
+++ b/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
@@ -97,6 +97,74 @@ public sealed class MessageDispatchEngine
     }
 
     /// <summary>
+    /// Typed void dispatch: when the compile-time <typeparamref name="TMessage"/> is the
+    /// message's runtime type (the overwhelmingly common concrete-typed call), the
+    /// executor comes from a static-generic holder instead of the type-keyed dictionary —
+    /// the last lookup on the group-less hot path. A base-typed generic call falls back to
+    /// resolving by the runtime type, so dispatch semantics are identical to
+    /// <see cref="DispatchAsync(object, IServiceProvider, IDictionary{object, object?}?, CancellationToken, IEnumerable{string}?)"/>;
+    /// group-filtered dispatches stay on that overload.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT a <c>DispatchAsync</c> overload: a same-name generic would join
+    /// the candidate set of every explicit <c>DispatchAsync&lt;T&gt;(msg, ...)</c> call, and
+    /// whenever the message expression is convertible to the type argument (an echo-typed
+    /// result dispatch — legal since <c>ICommand&lt;TResult&gt; : ICommand : IMessage</c>) the
+    /// identity conversion would out-rank the result overload's <c>object</c> parameter,
+    /// silently rerouting a result dispatch through the void pipeline or breaking the
+    /// caller with a return-type mismatch. The distinct name keeps the typed fast path
+    /// out of that candidate set entirely.
+    /// </remarks>
+    /// <typeparam name="TMessage">The compile-time message type.</typeparam>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="serviceProvider">The scope provider handlers resolve against.</param>
+    /// <param name="items">Optional contextual items exposed to the pipeline.</param>
+    /// <param name="cancellationToken">Cancellation token for the dispatch.</param>
+    public ValueTask DispatchVoidAsync<TMessage>(TMessage message, IServiceProvider serviceProvider,
+        IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default)
+        where TMessage : notnull, IMessage
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = message.GetType() == typeof(TMessage)
+            ? _executorCache.GetVoidExecutor<TMessage>()
+            : _executorCache.GetVoidExecutor(message.GetType());
+        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
+        ValueTask task;
+
+        try
+        {
+            task = executor.Execute(message, context, serviceProvider);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
     /// Result-producing counterpart of
     /// <see cref="DispatchAsync(object, IServiceProvider, IDictionary{object, object?}?, CancellationToken, IEnumerable{string}?)"/>.
     /// </summary>

--- a/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
+++ b/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
@@ -16,5 +16,7 @@
         <InternalsVisibleTo Include="Ergosfare.Core.Extensions.MicrosoftDependencyInjection" />
         <!-- The event broadcast invoker rents/returns pooled execution contexts directly. -->
         <InternalsVisibleTo Include="Stella.Ergosfare.Events" />
+        <!-- The query stream invoker's fast lane builds contexts and version-guarded plans directly. -->
+        <InternalsVisibleTo Include="Stella.Ergosfare.Queries" />
     </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -87,15 +87,18 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
         try
         {
-            // Fast lane: for the group-less publish against the concrete mediator, run the
-            // broadcast strategy directly against the invoker-cached pipeline plan (the
-            // executors' registry-version-guarded pattern) — no MediateOptions, no
-            // per-publish descriptor lookup, no Mediate wrapper. Grouped publishes and
-            // foreign mediator implementations keep the original Mediate path.
-            if ((settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 })
-                && mediator is MessageMediator concreteMediator)
+            // Fast lane: against the concrete mediator, run the broadcast strategy
+            // directly against the invoker-cached pipeline plan (the executors'
+            // registry-version-guarded pattern) — no MediateOptions, no per-publish
+            // descriptor lookup, no Mediate wrapper. Grouped publishes resolve the same
+            // group-filtered dependencies the Mediate path would build, from the grouped
+            // plan slot; only foreign mediator implementations keep the original path.
+            if (mediator is MessageMediator concreteMediator)
             {
-                var dependencies = GetPlan(concreteMediator.DependenciesFactory, resolveStrategy);
+                var groups = settings?.Filters.Groups;
+                var dependencies = groups is null or List<string> { Count: 0 } or string[] { Length: 0 }
+                    ? GetPlan(concreteMediator.DependenciesFactory, resolveStrategy)
+                    : GetGroupedPlan(concreteMediator.DependenciesFactory, resolveStrategy, groups);
 
                 // Straight-through broadcast: with no interceptor stages and no handler
                 // filtering requested, loop the handler arrays directly — synchronously
@@ -168,8 +171,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null)
     {
-        if (externalContext is not null
-            || !(settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 }))
+        if (externalContext is not null)
         {
             return Publish(@event, settings, cancellationToken,
                 ResolveMediator(serviceProvider), resolveStrategy, resultAdapterService, externalContext);
@@ -181,7 +183,10 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
         try
         {
-            var dependencies = GetPlan(engine.DependenciesFactory, resolveStrategy);
+            var groups = settings?.Filters.Groups;
+            var dependencies = groups is null or List<string> { Count: 0 } or string[] { Length: 0 }
+                ? GetPlan(engine.DependenciesFactory, resolveStrategy)
+                : GetGroupedPlan(engine.DependenciesFactory, resolveStrategy, groups);
 
             if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
                 && (settings is null
@@ -269,14 +274,66 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 return cached;
             }
 
-            var dependencies = BuildPlan(typedFactory, resolveStrategy);
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
             _cachedDependencies = dependencies;
             _cachedFactory = typedFactory;
             _cachedVersion = typedFactory.CurrentRegistryVersion;
             return dependencies;
         }
 
-        return BuildPlan(dependenciesFactory, resolveStrategy);
+        return BuildPlan(dependenciesFactory, resolveStrategy, EmptyGroups);
+    }
+
+    /// <summary>
+    /// Grouped counterpart of <see cref="GetPlan"/>: a single last-used
+    /// (factory, group set) slot serves the overwhelmingly common shape — one stable
+    /// group set per event type — with an ordinal element-wise compare instead of a
+    /// per-publish key materialization. The dependencies come from the same factory call
+    /// the Mediate path would make, so the group-filtered pipeline is identical; a slot
+    /// miss (alternating group sets, another container, a registry change) only rebuilds
+    /// through the factory's own process-wide dependency cache. The slot snapshots the
+    /// caller's group sequence, so later caller-side mutation of a reused settings
+    /// instance is seen as a different group set, never as a stale hit.
+    /// </summary>
+    private GroupedPlanSlot? _cachedGroupedPlan;
+
+    private sealed class GroupedPlanSlot(
+        MessageDependenciesFactory factory,
+        string[] groups,
+        IMessageDependencies dependencies,
+        int version)
+    {
+        public readonly MessageDependenciesFactory Factory = factory;
+        public readonly string[] Groups = groups;
+        public readonly IMessageDependencies Dependencies = dependencies;
+        public readonly int Version = version;
+    }
+
+    private IMessageDependencies GetGroupedPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IEnumerable<string> groups)
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var slot = _cachedGroupedPlan;
+
+            if (slot is not null
+                && ReferenceEquals(slot.Factory, typedFactory)
+                && slot.Version == typedFactory.CurrentRegistryVersion
+                && PipelineExecutorCache.GroupsMatch(groups, slot.Groups))
+            {
+                return slot.Dependencies;
+            }
+
+            string[] materialized = [.. groups];
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
+            _cachedGroupedPlan = new GroupedPlanSlot(
+                typedFactory, materialized, dependencies, typedFactory.CurrentRegistryVersion);
+            return dependencies;
+        }
+
+        return BuildPlan(dependenciesFactory, resolveStrategy, [.. groups]);
     }
 
     /// <summary>
@@ -383,7 +440,8 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
     private static IMessageDependencies BuildPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory factory,
-        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        string[] groups)
     {
         // Mirrors MessageMediator.Mediate's descriptor handling for the options the old
         // path used: RegisterPlainMessagesOnSpot was never set for events, so an
@@ -391,7 +449,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         var descriptor = resolveStrategy.Find(typeof(TEvent))
                          ?? throw new NoHandlerFoundException(typeof(TEvent));
 
-        return factory.Create(typeof(TEvent), descriptor, EmptyGroups);
+        return factory.Create(typeof(TEvent), descriptor, groups);
     }
 }
 

--- a/src/Stella.Ergosfare.Queries/QueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries/QueryMediator.cs
@@ -113,8 +113,14 @@ public class QueryMediator : IQueryMediator
     public IAsyncEnumerable<TResult> StreamAsync<TResult>(IStreamQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
-            query, queryMediationSettings, cancellationToken, RequireMessageMediator(), _messageResolveStrategy);
+        // Engine-backed facades stream against the invoker-cached pipeline plan — no
+        // per-call mediator resolution, MediateOptions or descriptor lookup; the wrapped
+        // shape keeps the original Mediate path for foreign mediator implementations.
+        return _engine is not null
+            ? QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
+                query, queryMediationSettings, cancellationToken, _engine, _serviceProvider!, _messageResolveStrategy)
+            : QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
+                query, queryMediationSettings, cancellationToken, RequireMessageMediator(), _messageResolveStrategy);
     }
 
     /// <summary>
@@ -138,9 +144,10 @@ public class QueryMediator : IQueryMediator
     }
 
     /// <summary>
-    /// The mediator the streaming path (untouched by the engine: it mediates through
-    /// <c>Mediate(options)</c>) runs against — the wrapped instance, or on the engine
-    /// shape the scope's own registration, resolved on demand.
+    /// The mediator the wrapped-shape streaming path (which mediates through
+    /// <c>Mediate(options)</c>) runs against — the wrapped instance, or the scope's own
+    /// registration resolved on demand. Engine-backed facades never call this: their
+    /// streams run the invoker's engine fast lane.
     /// </summary>
     private IMessageMediator RequireMessageMediator()
         => _messageMediator

--- a/src/Stella.Ergosfare.Queries/StreamInvoker.cs
+++ b/src/Stella.Ergosfare.Queries/StreamInvoker.cs
@@ -2,7 +2,10 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Core.Internal.Factories;
 using Stella.Ergosfare.Queries.Abstractions;
 
 namespace Stella.Ergosfare.Queries;
@@ -18,6 +21,17 @@ internal interface IQueryStreamInvoker<out TResult>
 {
     IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy);
+
+    /// <summary>
+    /// Engine-backed streaming: the concrete dispatch machinery is known by construction,
+    /// so the stream runs against the invoker-cached, registry-version-guarded pipeline
+    /// plan — no <c>MediateOptions</c>, no per-call descriptor lookup, no scope-resolved
+    /// mediator. Grouped streams resolve the same group-filtered dependencies the Mediate
+    /// path would build, from a last-used group-set slot.
+    /// </summary>
+    IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy);
 }
 
 internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<TResult>
@@ -25,12 +39,19 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
 {
     private static readonly string[] EmptyGroups = [];
 
+    /// <summary>
+    /// The stream path has always run against a fresh, empty adapter service (the facade
+    /// carries none); a single shared empty instance preserves that behavior without the
+    /// per-call allocation. Never exposed, so it cannot be mutated.
+    /// </summary>
+    private static readonly ResultAdapterService SharedEmptyAdapters = new();
+
     public IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
     {
         var options = new MediateOptions<TQuery, IAsyncEnumerable<TResult>>
         {
-            MessageMediationStrategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(new ResultAdapterService(), cancellationToken),
+            MessageMediationStrategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(SharedEmptyAdapters, cancellationToken),
             MessageResolveStrategy = resolveStrategy,
             CancellationToken = cancellationToken,
             Items = settings?.Items,
@@ -38,6 +59,123 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
         };
 
         return mediator.Mediate((TQuery)query, options);
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        var groups = settings?.Filters.Groups;
+        var dependencies = groups is null or List<string> { Count: 0 } or string[] { Length: 0 }
+            ? GetPlan(engine.DependenciesFactory, resolveStrategy)
+            : GetGroupedPlan(engine.DependenciesFactory, resolveStrategy, groups);
+
+        // Exactly the construction Mediate performs for streams: a fresh, unpooled
+        // context — enumeration happens after this call returns, so its completion is
+        // not observable here and the context cannot be pooled.
+        var context = new ErgosfareExecutionContext(settings?.Items, cancellationToken);
+        var strategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(SharedEmptyAdapters, cancellationToken);
+
+        return strategy.Mediate((TQuery)query, dependencies, context, serviceProvider);
+    }
+
+    /// <summary>
+    /// The group-less pipeline plan for <typeparamref name="TQuery"/>, cached on the
+    /// invoker and re-validated against the registry version — the broadcast invoker's
+    /// pattern. The invoker is process-wide while factories are per-container, so the
+    /// factory reference is part of the cache key and one container's plan is never
+    /// served to another.
+    /// </summary>
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependenciesFactory? _cachedFactory;
+    private int _cachedVersion = int.MinValue;
+
+    private IMessageDependencies GetPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null
+                && ReferenceEquals(_cachedFactory, typedFactory)
+                && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
+            _cachedDependencies = dependencies;
+            _cachedFactory = typedFactory;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return BuildPlan(dependenciesFactory, resolveStrategy, EmptyGroups);
+    }
+
+    /// <summary>
+    /// Grouped counterpart of <see cref="GetPlan"/>: a single last-used
+    /// (factory, group set) slot with an ordinal element-wise compare, snapshotting the
+    /// caller's group sequence so later mutation of a reused settings instance reads as a
+    /// different group set. A slot miss only rebuilds through the factory's process-wide
+    /// dependency cache.
+    /// </summary>
+    private GroupedPlanSlot? _cachedGroupedPlan;
+
+    private sealed class GroupedPlanSlot(
+        MessageDependenciesFactory factory,
+        string[] groups,
+        IMessageDependencies dependencies,
+        int version)
+    {
+        public readonly MessageDependenciesFactory Factory = factory;
+        public readonly string[] Groups = groups;
+        public readonly IMessageDependencies Dependencies = dependencies;
+        public readonly int Version = version;
+    }
+
+    private IMessageDependencies GetGroupedPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IEnumerable<string> groups)
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var slot = _cachedGroupedPlan;
+
+            if (slot is not null
+                && ReferenceEquals(slot.Factory, typedFactory)
+                && slot.Version == typedFactory.CurrentRegistryVersion
+                && Core.Internal.Mediator.PipelineExecutorCache.GroupsMatch(groups, slot.Groups))
+            {
+                return slot.Dependencies;
+            }
+
+            string[] materialized = [.. groups];
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
+            _cachedGroupedPlan = new GroupedPlanSlot(
+                typedFactory, materialized, dependencies, typedFactory.CurrentRegistryVersion);
+            return dependencies;
+        }
+
+        return BuildPlan(dependenciesFactory, resolveStrategy, [.. groups]);
+    }
+
+    private static IMessageDependencies BuildPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory factory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        string[] groups)
+    {
+        // Mirrors MessageMediator.Mediate's descriptor handling for the options the
+        // original path used: RegisterPlainMessagesOnSpot was never set for streams, so
+        // an unregistered query type throws NoHandlerFoundException here as it did there.
+        var descriptor = resolveStrategy.Find(typeof(TQuery))
+                         ?? throw new NoHandlerFoundException(typeof(TQuery));
+
+        return factory.Create(typeof(TQuery), descriptor, groups);
     }
 }
 

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -105,7 +105,9 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 QueryBuilderHasRegisterDescriptors: HasRegisterDescriptors(queryBuilder),
                 EventBuilderHasRegisterDescriptors: HasRegisterDescriptors(eventBuilder),
                 HasDispatchRoots: dispatchRoots is not null,
-                DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty);
+                DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty,
+                DispatchRootsHasResultPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddResultPlan").IsEmpty,
+                DispatchRootsHasPlanFactories: dispatchRoots is not null && HasFactoryOverload(dispatchRoots));
         });
 
         // Reference scanning is default-on; consumers opt out per project through the
@@ -128,6 +130,71 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
 
     private static bool HasRegisterDescriptors(INamedTypeSymbol? builder)
         => builder is not null && !builder.GetMembers("RegisterDescriptors").IsEmpty;
+
+    /// <summary>
+    ///     Whether the referenced <c>GeneratedDispatchRoots</c> accepts a plan overload
+    ///     with a direct-construction factory parameter — the surface the
+    ///     <c>static () => new THandler()</c> emission requires.
+    /// </summary>
+    private static bool HasFactoryOverload(INamedTypeSymbol dispatchRoots)
+    {
+        foreach (var member in dispatchRoots.GetMembers("AddVoidPlan"))
+        {
+            if (member is IMethodSymbol { Parameters.Length: 1 })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Whether generated code can construct the type with <c>new()</c> and doing so
+    ///     is provably interchangeable with resolving its plain transient registration:
+    ///     a concrete, non-generic class whose ONLY instance constructor is public and
+    ///     parameterless (the container's greedy constructor selection would pick any
+    ///     richer constructor, and it only considers public ones), with no <c>required</c>
+    ///     members (a generated <c>new()</c> would fail compilation), implementing
+    ///     neither <c>IDisposable</c> nor <c>IAsyncDisposable</c> (the container tracks
+    ///     transient disposables; direct construction would not).
+    /// </summary>
+    private static bool IsDirectlyConstructible(INamedTypeSymbol symbol)
+    {
+        if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract || symbol.IsGenericType)
+        {
+            return false;
+        }
+
+        foreach (var iface in symbol.AllInterfaces)
+        {
+            if (iface is { Name: "IDisposable" or "IAsyncDisposable", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } })
+            {
+                return false;
+            }
+        }
+
+        // Required members anywhere in the hierarchy make an emitted `new()` a compile
+        // error (CS9035); the reflection-based container activation the plan replaces
+        // does not enforce them, so such types stay on the container path.
+        for (var type = symbol; type is not null; type = type.BaseType)
+        {
+            foreach (var member in type.GetMembers())
+            {
+                if (member is IPropertySymbol { IsRequired: true } or IFieldSymbol { IsRequired: true })
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Exactly one instance constructor, public and parameterless: with any richer
+        // constructor present (records' synthesized copy constructor included), the
+        // container's selection and `new()` can diverge — dropping dependencies the
+        // container would have injected.
+        return symbol.InstanceConstructors.Length == 1
+               && symbol.InstanceConstructors[0] is { Parameters.IsEmpty: true, DeclaredAccessibility: Accessibility.Public };
+    }
 
     /// <summary>
     ///     Projects a candidate type declaration to its registration model, or <c>null</c>
@@ -180,6 +247,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             DiscoveryKeys = GetDiscoveryKeys(symbol),
             IsDispatchableMessage = isDispatchable,
             DispatchResults = isDispatchable ? GetDispatchResults(symbol) : ImmutableArray<DispatchResultModel>.Empty,
+            IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
         };
     }
 
@@ -551,6 +619,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             DiscoveryKeys = GetDiscoveryKeys(symbol),
             IsDispatchableMessage = isDispatchable,
             DispatchResults = isDispatchable ? GetDispatchResults(symbol) : ImmutableArray<DispatchResultModel>.Empty,
+            IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
         };
     }
 
@@ -628,7 +697,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             ? ComputeVoidPlans(types)
             : (IReadOnlyList<VoidPlanModel>)Array.Empty<VoidPlanModel>();
 
-        var source = RegistrationEmitter.Emit(types, availability, voidPlans, GeneratorVersion);
+        var resultPlans = availability.DispatchRootsHasResultPlans
+            ? ComputeResultPlans(types)
+            : (IReadOnlyList<ResultPlanModel>)Array.Empty<ResultPlanModel>();
+
+        var source = RegistrationEmitter.Emit(types, availability, voidPlans, resultPlans, GeneratorVersion);
         context.AddSource("ErgosfareRegistrations.g.cs", SourceText.From(source, Encoding.UTF8));
     }
 
@@ -646,9 +719,102 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     /// </summary>
     private static List<VoidPlanModel> ComputeVoidPlans(List<RegistrableTypeModel> types)
     {
-        var handlerCounts = new Dictionary<string, int>(StringComparer.Ordinal);
-        var soleHandlers = new Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)>(StringComparer.Ordinal);
-        var interceptedMessages = new HashSet<string>(StringComparer.Ordinal);
+        CollectPipelineFacts(types, out var handlerCounts, out var soleHandlers, out var interceptedMessages);
+
+        var plans = new List<VoidPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || !type.IsCommand)
+            {
+                continue;
+            }
+
+            if (!TryGetSolePlannableHandler(type, handlerCounts, soleHandlers, interceptedMessages,
+                    out var handler, out var descriptor))
+            {
+                continue;
+            }
+
+            // The sole handler must be the async void contract.
+            if (descriptor.ResultTypeExpression != ValueTaskExpression)
+            {
+                continue;
+            }
+
+            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression, handler.IsDirectlyConstructible));
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    ///     Result-producing counterpart of <see cref="ComputeVoidPlans"/>: a dispatchable
+    ///     command/query with exactly one closed, non-stream result contract qualifies
+    ///     when its whole discovered pipeline is a single async handler producing exactly
+    ///     that result. Equally conservative and equally advisory — the runtime
+    ///     re-validates per registry version.
+    /// </summary>
+    private static List<ResultPlanModel> ComputeResultPlans(List<RegistrableTypeModel> types)
+    {
+        CollectPipelineFacts(types, out var handlerCounts, out var soleHandlers, out var interceptedMessages);
+
+        var plans = new List<ResultPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || (!type.IsCommand && !type.IsQuery))
+            {
+                continue;
+            }
+
+            // Exactly one closed result contract, and not a streaming one — a message
+            // with several result shapes is dispatched with executor-side result typing
+            // the plan cannot pin down.
+            if (type.DispatchResults.Length != 1 || type.DispatchResults[0].IsStream)
+            {
+                continue;
+            }
+
+            var dispatchResult = type.DispatchResults[0];
+
+            if (!TryGetSolePlannableHandler(type, handlerCounts, soleHandlers, interceptedMessages,
+                    out var handler, out var descriptor))
+            {
+                continue;
+            }
+
+            // The sole handler must be the async contract producing exactly the message's
+            // declared result (sync contracts carry the bare result type and fall out).
+            if (descriptor.ResultTypeExpression != ValueTaskExpression + "<" + dispatchResult.ResultTypeExpression + ">")
+            {
+                continue;
+            }
+
+            plans.Add(new ResultPlanModel(
+                type.TypeofExpression,
+                dispatchResult.ResultTypeExpression,
+                handler.TypeofExpression,
+                handler.IsDirectlyConstructible));
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    ///     Indexes the discovered descriptors by message type: main-handler counts, the
+    ///     (last-seen) sole handler per message, and the set of messages any interceptor
+    ///     targets directly — the shared facts both plan computations qualify against.
+    /// </summary>
+    private static void CollectPipelineFacts(
+        List<RegistrableTypeModel> types,
+        out Dictionary<string, int> handlerCounts,
+        out Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)> soleHandlers,
+        out HashSet<string> interceptedMessages)
+    {
+        handlerCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        soleHandlers = new Dictionary<string, (RegistrableTypeModel, DescriptorModel)>(StringComparer.Ordinal);
+        interceptedMessages = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var type in types)
         {
@@ -666,43 +832,41 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 }
             }
         }
+    }
 
-        var plans = new List<VoidPlanModel>();
+    /// <summary>
+    ///     The shared plan qualification: the message has exactly one discovered main
+    ///     handler, no interceptor targets it directly, and that handler is accessible
+    ///     and discoverable by default (an unkeyed, ungrouped registration — anything
+    ///     else may not be registered, or not in the default-group pipeline the plan
+    ///     serves).
+    /// </summary>
+    private static bool TryGetSolePlannableHandler(
+        RegistrableTypeModel type,
+        Dictionary<string, int> handlerCounts,
+        Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)> soleHandlers,
+        HashSet<string> interceptedMessages,
+        out RegistrableTypeModel handler,
+        out DescriptorModel descriptor)
+    {
+        handler = default;
+        descriptor = default;
 
-        foreach (var type in types)
+        if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
         {
-            if (!type.IsDispatchableMessage || !type.IsCommand)
-            {
-                continue;
-            }
-
-            if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
-            {
-                continue;
-            }
-
-            if (interceptedMessages.Contains(type.TypeofExpression))
-            {
-                continue;
-            }
-
-            var (handler, descriptor) = soleHandlers[type.TypeofExpression];
-
-            // The sole handler must be the async void contract, discoverable by default
-            // (an unkeyed, ungrouped registration — anything else may not be registered,
-            // or not in the default-group pipeline the plan serves).
-            if (descriptor.ResultTypeExpression != ValueTaskExpression
-                || !handler.IsAccessible
-                || !handler.DiscoveryKeys.IsEmpty
-                || handler.GroupsExpression is not null)
-            {
-                continue;
-            }
-
-            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression));
+            return false;
         }
 
-        return plans;
+        if (interceptedMessages.Contains(type.TypeofExpression))
+        {
+            return false;
+        }
+
+        (handler, descriptor) = soleHandlers[type.TypeofExpression];
+
+        return handler.IsAccessible
+               && handler.DiscoveryKeys.IsEmpty
+               && handler.GroupsExpression is null;
     }
 
     private static void AddModels(

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -18,6 +18,12 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// <param name="EventBuilderHasRegisterDescriptors">Whether the event builder exposes <c>RegisterDescriptors</c>.</param>
 /// <param name="HasDispatchRoots">Whether the <c>GeneratedDispatchRoots</c> store is resolvable.</param>
 /// <param name="DispatchRootsHasVoidPlans">Whether the store exposes <c>AddVoidPlan</c> (compile-time pipeline plans).</param>
+/// <param name="DispatchRootsHasResultPlans">Whether the store exposes <c>AddResultPlan</c> (result pipeline plans).</param>
+/// <param name="DispatchRootsHasPlanFactories">
+///     Whether the plan surface accepts direct-construction factories (the
+///     <c>Func&lt;THandler&gt;</c> overloads); older packages take only the parameterless
+///     form, and emission degrades accordingly.
+/// </param>
 internal readonly record struct ModuleBuilderAvailability(
     bool HasMessageRegistry,
     bool HasCommandModuleBuilder,
@@ -28,4 +34,6 @@ internal readonly record struct ModuleBuilderAvailability(
     bool QueryBuilderHasRegisterDescriptors,
     bool EventBuilderHasRegisterDescriptors,
     bool HasDispatchRoots,
-    bool DispatchRootsHasVoidPlans);
+    bool DispatchRootsHasVoidPlans,
+    bool DispatchRootsHasResultPlans,
+    bool DispatchRootsHasPlanFactories);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -93,6 +93,15 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
     /// </summary>
     public required ImmutableArray<DispatchResultModel> DispatchResults { get; init; }
 
+    /// <summary>
+    ///     Whether generated code can construct the type with <c>new()</c> and doing so is
+    ///     interchangeable with a plain transient container resolution: a concrete,
+    ///     non-generic class with an accessible parameterless constructor that is neither
+    ///     <c>IDisposable</c> nor <c>IAsyncDisposable</c>. Feeds the pipeline plans'
+    ///     direct-construction factories; meaningful for handler types only.
+    /// </summary>
+    public required bool IsDirectlyConstructible { get; init; }
+
     public bool Equals(RegistrableTypeModel other)
     {
         if (TypeofExpression != other.TypeofExpression
@@ -106,6 +115,7 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
             || GroupsExpression != other.GroupsExpression
             || ReferencedAssemblyName != other.ReferencedAssemblyName
             || IsDispatchableMessage != other.IsDispatchableMessage
+            || IsDirectlyConstructible != other.IsDirectlyConstructible
             || Descriptors.Length != other.Descriptors.Length
             || DiscoveryKeys.Length != other.DiscoveryKeys.Length
             || DispatchResults.Length != other.DispatchResults.Length)

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
@@ -1,0 +1,23 @@
+namespace Stella.Ergosfare.SourceGenerator.Models;
+
+/// <summary>
+///     A compile-time result pipeline plan: a dispatchable command/query message with a
+///     single closed result contract whose entire discovered pipeline is one
+///     default-discovery, default-group async result handler. Emitted as
+///     <c>GeneratedDispatchRoots.AddResultPlan&lt;TMessage, TResult, THandler&gt;()</c> so
+///     the runtime executor closes over all three types and calls the handler
+///     devirtualized. Advisory exactly like the void plan: the runtime re-validates the
+///     pipeline per registry version and a mismatched plan only loses the speedup.
+/// </summary>
+/// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
+/// <param name="ResultTypeExpression">Fully qualified expression of the closed result type.</param>
+/// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>
+/// <param name="HasDirectConstruction">
+///     Whether the handler qualifies for the plan's direct-construction factory; see
+///     <see cref="RegistrableTypeModel.IsDirectlyConstructible"/>.
+/// </param>
+internal readonly record struct ResultPlanModel(
+    string MessageTypeExpression,
+    string ResultTypeExpression,
+    string HandlerTypeExpression,
+    bool HasDirectConstruction);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
@@ -10,6 +10,12 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// </summary>
 /// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
 /// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>
+/// <param name="HasDirectConstruction">
+///     Whether the handler qualifies for the plan's direct-construction factory
+///     (<c>static () => new THandler()</c>); see
+///     <see cref="RegistrableTypeModel.IsDirectlyConstructible"/>.
+/// </param>
 internal readonly record struct VoidPlanModel(
     string MessageTypeExpression,
-    string HandlerTypeExpression);
+    string HandlerTypeExpression,
+    bool HasDirectConstruction);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -41,6 +41,7 @@ internal static class RegistrationEmitter
         IReadOnlyList<RegistrableTypeModel> types,
         ModuleBuilderAvailability builders,
         IReadOnlyList<VoidPlanModel> voidPlans,
+        IReadOnlyList<ResultPlanModel> resultPlans,
         string generatorVersion)
     {
         var useDescriptors = builders.HasDescriptorFactory;
@@ -98,7 +99,8 @@ internal static class RegistrationEmitter
 
         if (emitDispatchRoots)
         {
-            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans);
+            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans, resultPlans,
+                builders.DispatchRootsHasPlanFactories);
         }
 
         EmitMatchesHelper(sb, ref wroteMember);
@@ -243,7 +245,9 @@ internal static class RegistrationEmitter
         StringBuilder sb,
         ref bool wroteMember,
         IReadOnlyList<RegistrableTypeModel> types,
-        IReadOnlyList<VoidPlanModel> voidPlans)
+        IReadOnlyList<VoidPlanModel> voidPlans,
+        IReadOnlyList<ResultPlanModel> resultPlans,
+        bool emitPlanFactories)
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        private static void RootDispatchInstantiations()");
@@ -270,13 +274,38 @@ internal static class RegistrationEmitter
 
         // Compile-time pipeline plans: the runtime re-validates each one against the
         // registry per version, so a plan can only lose its speedup, never change
-        // behavior.
+        // behavior. Directly-constructible handlers additionally carry a construction
+        // factory, which the runtime uses only after verifying the handler's effective
+        // DI registration is the module's own plain transient one.
         foreach (var plan in voidPlans)
         {
             sb.Append("            ").Append(DispatchRootsFullName)
               .Append(".AddVoidPlan<").Append(plan.MessageTypeExpression)
               .Append(", ").Append(plan.HandlerTypeExpression)
-              .AppendLine(">();");
+              .Append(">(");
+
+            if (emitPlanFactories && plan.HasDirectConstruction)
+            {
+                sb.Append("static () => new ").Append(plan.HandlerTypeExpression).Append("()");
+            }
+
+            sb.AppendLine(");");
+        }
+
+        foreach (var plan in resultPlans)
+        {
+            sb.Append("            ").Append(DispatchRootsFullName)
+              .Append(".AddResultPlan<").Append(plan.MessageTypeExpression)
+              .Append(", ").Append(plan.ResultTypeExpression)
+              .Append(", ").Append(plan.HandlerTypeExpression)
+              .Append(">(");
+
+            if (emitPlanFactories && plan.HasDirectConstruction)
+            {
+                sb.Append("static () => new ").Append(plan.HandlerTypeExpression).Append("()");
+            }
+
+            sb.AppendLine(");");
         }
 
         sb.AppendLine("        }");

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -4,7 +4,9 @@ using BenchmarkDotNet.Running;
 using Microsoft.Extensions.DependencyInjection;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
@@ -53,6 +55,63 @@ public sealed class SecondPingEventHandler : IEventHandler<PingEvent>
     public ValueTask HandleAsync(PingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
+// Grouped variants on their own message types, so the grouped rows measure the grouped
+// lane without changing the default rows' pipelines (a second handler on VoidCommand
+// would suppress its compile-time plan, for instance).
+
+public sealed class GroupedCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+
+[Group("bench")]
+public sealed class GroupedCommandHandler : ICommandHandler<GroupedCommand>
+{
+    public ValueTask HandleAsync(GroupedCommand command, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+public sealed class GroupedPingEvent : IEvent { }
+
+[Group("bench")]
+public sealed class FirstGroupedPingEventHandler : IEventHandler<GroupedPingEvent>
+{
+    public ValueTask HandleAsync(GroupedPingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+[Group("bench")]
+public sealed class SecondGroupedPingEventHandler : IEventHandler<GroupedPingEvent>
+{
+    public ValueTask HandleAsync(GroupedPingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+// ---------------------------------------------------------------------------
+// Mediator (martinothamar/Mediator, source-generated) messages & handlers
+// ---------------------------------------------------------------------------
+
+public sealed class MediatorSgVoidCommand : Mediator.ICommand { }
+
+public sealed class MediatorSgVoidCommandHandler : Mediator.ICommandHandler<MediatorSgVoidCommand>
+{
+    public ValueTask<Mediator.Unit> Handle(MediatorSgVoidCommand command, CancellationToken cancellationToken)
+        => new(Mediator.Unit.Value);
+}
+
+public sealed class MediatorSgIntQuery : Mediator.IQuery<int> { }
+
+public sealed class MediatorSgIntQueryHandler : Mediator.IQueryHandler<MediatorSgIntQuery, int>
+{
+    public ValueTask<int> Handle(MediatorSgIntQuery query, CancellationToken cancellationToken) => new(7);
+}
+
+public sealed class MediatorSgPingNotification : Mediator.INotification { }
+
+public sealed class FirstMediatorSgPingHandler : Mediator.INotificationHandler<MediatorSgPingNotification>
+{
+    public ValueTask Handle(MediatorSgPingNotification notification, CancellationToken cancellationToken) => default;
+}
+
+public sealed class SecondMediatorSgPingHandler : Mediator.INotificationHandler<MediatorSgPingNotification>
+{
+    public ValueTask Handle(MediatorSgPingNotification notification, CancellationToken cancellationToken) => default;
+}
+
 // ---------------------------------------------------------------------------
 // MediatR requests & handlers
 // ---------------------------------------------------------------------------
@@ -93,7 +152,14 @@ public sealed class SecondMediatrPingHandler : INotificationHandler<MediatrPingN
 /// baseline — that is the floor the public facades add their convenience on top of, and
 /// the Ratio column reads as "what does the facade (or MediatR) cost relative to it".
 /// Within each category: a void dispatch, a result-returning dispatch, and a two-handler
-/// event publish, for Ergosfare and MediatR alike.
+/// event publish, for Ergosfare and the competitors alike.
+/// <para>Competitors run their out-of-the-box defaults: MediatR (reflection-based,
+/// transient handlers) as the ubiquitous baseline, and martinothamar/Mediator
+/// (source-generated dispatch, singleton lifetime by default) as the fastest widely-used
+/// alternative — the <c>MediatorSg_*</c> rows. Ergosfare's default rows resolve transient
+/// handlers per dispatch; the <c>Command_Void_Memoized</c> row shows the zero-allocation
+/// shape <c>ForceMemoizedHandlers()</c> (or plain singleton handler registration) yields,
+/// which is the apples-to-apples comparison against Mediator's singleton default.</para>
 /// </summary>
 [MemoryDiagnoser]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
@@ -102,21 +168,39 @@ public class MediationBenchmark
 {
     private ServiceProvider _ergosfare = null!;
     private ServiceProvider _ergosfareGenerated = null!;
+    private ServiceProvider _ergosfareMemoized = null!;
     private ServiceProvider _mediatr = null!;
+    private ServiceProvider _mediatorSg = null!;
 
     private IMessageMediator _engine = null!;
+    private MessageDispatchEngine _dispatchEngine = null!;
     private ICommandMediator _commands = null!;
     private ICommandMediator _generatedCommands = null!;
+    private ICommandMediator _memoizedCommands = null!;
     private IQueryMediator _queries = null!;
+    private IQueryMediator _generatedQueries = null!;
     private IEventMediator _events = null!;
     private IMediator _mediator = null!;
+    private Mediator.IMediator _martinMediator = null!;
 
     private readonly VoidCommand _voidCommand = new();
     private readonly IntQuery _intQuery = new();
     private readonly PingEvent _pingEvent = new();
+    private readonly GroupedCommand _groupedCommand = new();
+    private readonly GroupedPingEvent _groupedPingEvent = new();
+
+    private static readonly string[] BenchGroups = ["bench"];
+
+    // Reused across dispatches, mirroring a caller that keeps its settings: the grouped
+    // rows measure the grouped lane itself, not per-call settings construction.
+    private readonly CommandMediationSettings _groupedCommandSettings = new() { Filters = { Groups = BenchGroups } };
+    private readonly EventMediationSettings _groupedEventSettings = new() { Filters = { Groups = BenchGroups } };
     private readonly MediatrVoidRequest _mediatrVoid = new();
     private readonly MediatrIntRequest _mediatrInt = new();
     private readonly MediatrPingNotification _mediatrPing = new();
+    private readonly MediatorSgVoidCommand _mediatorSgVoid = new();
+    private readonly MediatorSgIntQuery _mediatorSgInt = new();
+    private readonly MediatorSgPingNotification _mediatorSgPing = new();
 
     [GlobalSetup]
     public void Setup()
@@ -124,17 +208,24 @@ public class MediationBenchmark
         _ergosfare = new ServiceCollection()
             .AddErgosfare(options =>
             {
-                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+                options.AddCommandModule(commands =>
+                {
+                    commands.Register<VoidCommandHandler>();
+                    commands.Register<GroupedCommandHandler>();
+                });
                 options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
                 options.AddEventModule(events =>
                 {
                     events.Register<FirstPingEventHandler>();
                     events.Register<SecondPingEventHandler>();
+                    events.Register<FirstGroupedPingEventHandler>();
+                    events.Register<SecondGroupedPingEventHandler>();
                 });
             })
             .BuildServiceProvider();
 
         _engine = _ergosfare.GetRequiredService<IMessageMediator>();
+        _dispatchEngine = _ergosfare.GetRequiredService<MessageDispatchEngine>();
         _commands = _ergosfare.GetRequiredService<ICommandMediator>();
         _queries = _ergosfare.GetRequiredService<IQueryMediator>();
         _events = _ergosfare.GetRequiredService<IEventMediator>();
@@ -144,6 +235,12 @@ public class MediationBenchmark
             .BuildServiceProvider();
 
         _mediator = _mediatr.GetRequiredService<IMediator>();
+
+        _mediatorSg = new ServiceCollection()
+            .AddMediator()
+            .BuildServiceProvider();
+
+        _martinMediator = _mediatorSg.GetRequiredService<Mediator.IMediator>();
     }
 
     [GlobalCleanup]
@@ -151,6 +248,7 @@ public class MediationBenchmark
     {
         _ergosfare.Dispose();
         _mediatr.Dispose();
+        _mediatorSg.Dispose();
     }
 
     /// <summary>
@@ -159,20 +257,52 @@ public class MediationBenchmark
     /// void pipeline plans process-wide, and the targeted setup keeps that installation
     /// away from the runtime-registration rows' processes so the comparison stays honest.
     /// </summary>
-    [GlobalSetup(Targets = [nameof(Command_Void_Generated)])]
+    [GlobalSetup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
     public void SetupGenerated()
     {
         _ergosfareGenerated = new ServiceCollection()
-            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated()))
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => commands.RegisterGenerated());
+                options.AddQueryModule(queries => queries.RegisterGenerated());
+            })
             .BuildServiceProvider();
 
         _generatedCommands = _ergosfareGenerated.GetRequiredService<ICommandMediator>();
+        _generatedQueries = _ergosfareGenerated.GetRequiredService<IQueryMediator>();
     }
 
-    [GlobalCleanup(Targets = [nameof(Command_Void_Generated)])]
+    [GlobalCleanup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
     public void CleanupGenerated()
     {
         _ergosfareGenerated.Dispose();
+    }
+
+    /// <summary>
+    /// Zero-allocation variant: <c>ForceMemoizedHandlers()</c> resolves each handler graph
+    /// once and reuses it for every dispatch, so the transient handler instance — the last
+    /// 24 B on the default root path — disappears. Plain singleton handler registration
+    /// reaches the same shape without the switch. Isolated to its own process via targets,
+    /// like the generated variant above.
+    /// </summary>
+    [GlobalSetup(Targets = [nameof(Command_Void_Memoized)])]
+    public void SetupMemoized()
+    {
+        _ergosfareMemoized = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.ForceMemoizedHandlers();
+                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+            })
+            .BuildServiceProvider();
+
+        _memoizedCommands = _ergosfareMemoized.GetRequiredService<ICommandMediator>();
+    }
+
+    [GlobalCleanup(Targets = [nameof(Command_Void_Memoized)])]
+    public void CleanupMemoized()
+    {
+        _ergosfareMemoized.Dispose();
     }
 
     // ------------------------------------------------------------------
@@ -182,6 +312,13 @@ public class MediationBenchmark
     [Benchmark(Baseline = true), BenchmarkCategory("Root")]
     public ValueTask Engine_Void() => _engine.DispatchAsync(_voidCommand);
 
+    /// <summary>
+    /// Typed engine dispatch: the compile-time message type resolves the executor from a
+    /// static-generic holder — no dictionary lookup on the hot path.
+    /// </summary>
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Engine_Void_Typed() => _dispatchEngine.DispatchVoidAsync(_voidCommand, _ergosfare);
+
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
 
@@ -189,10 +326,22 @@ public class MediationBenchmark
     public ValueTask Command_Void_Generated() => _generatedCommands.SendAsync(_voidCommand);
 
     [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Memoized() => _memoizedCommands.SendAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);
 
     [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> Query_Result_Generated() => _generatedQueries.QueryAsync(_intQuery);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Grouped() => _commands.SendAsync(_groupedCommand, _groupedCommandSettings);
+
+    [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Event_Publish() => _events.PublishAsync(_pingEvent);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Event_Publish_Grouped() => _events.PublishAsync(_groupedPingEvent, _groupedEventSettings);
 
     [Benchmark, BenchmarkCategory("Root")]
     public Task MediatR_Send_Void() => _mediator.Send(_mediatrVoid);
@@ -202,6 +351,15 @@ public class MediationBenchmark
 
     [Benchmark, BenchmarkCategory("Root")]
     public Task MediatR_Publish() => _mediator.Publish(_mediatrPing);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<Mediator.Unit> MediatorSg_Send_Void() => _martinMediator.Send(_mediatorSgVoid);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> MediatorSg_Send_Result() => _martinMediator.Send(_mediatorSgInt);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask MediatorSg_Publish() => _martinMediator.Publish(_mediatorSgPing);
 
     // ------------------------------------------------------------------
     // Scoped — a fresh DI scope and mediator resolution per dispatch
@@ -254,5 +412,26 @@ public class MediationBenchmark
     {
         using var scope = _mediatr.CreateScope();
         await scope.ServiceProvider.GetRequiredService<IMediator>().Publish(_mediatrPing);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatorSg_Send_Void_Scoped()
+    {
+        using var scope = _mediatorSg.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<Mediator.IMediator>().Send(_mediatorSgVoid);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task<int> MediatorSg_Send_Result_Scoped()
+    {
+        using var scope = _mediatorSg.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<Mediator.IMediator>().Send(_mediatorSgInt);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatorSg_Publish_Scoped()
+    {
+        using var scope = _mediatorSg.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<Mediator.IMediator>().Publish(_mediatorSgPing);
     }
 }

--- a/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
+++ b/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
@@ -9,6 +9,11 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageReference Include="MediatR" Version="12.4.1" />
+        <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+        <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     </ItemGroup>
     <PropertyGroup>

--- a/test/Stella.Ergosfare.Command.Test/GeneratedPlanDirectConstructionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedPlanDirectConstructionTests.cs
@@ -1,0 +1,233 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime gating of the plans' direct-construction factories: the factory is used only
+/// while the handler's effective DI registration is the module's own plain transient one,
+/// and any user customization — a factory registration, a lifetime override, forced
+/// memoization — routes the dispatch back through the container. The tests install plans
+/// whose factories construct marked instances, which generated code never does, precisely
+/// so the chosen construction path is observable. Helper types are excluded from discovery
+/// so assembly scans (the registry is process-wide) cannot alter these pipelines.
+/// </summary>
+public class GeneratedPlanDirectConstructionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class ConstructedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class ConstructedCommandHandler : ICommandHandler<ConstructedCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public bool ViaPlanFactory { get; init; }
+
+        public ValueTask HandleAsync(ConstructedCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            context.Set("viaPlanFactory", ViaPlanFactory);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static async Task<(Guid Id, bool ViaPlanFactory)> DispatchAndProbe(ICommandMediator mediator)
+    {
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new ConstructedCommand(), settings);
+        return (Assert.IsType<Guid>(settings.Items["handlerId"]),
+            Assert.IsType<bool>(settings.Items["viaPlanFactory"]));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlainTransientRegistration_ConstructsThroughThePlanFactory()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<ConstructedCommand, ConstructedCommandHandler>(
+            static () => new ConstructedCommandHandler { ViaPlanFactory = true });
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ConstructedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The module's own plain transient registration: the factory constructs, and
+        // transient semantics stay — a fresh instance per dispatch.
+        var first = await DispatchAndProbe(mediator);
+        var second = await DispatchAndProbe(mediator);
+
+        Assert.True(first.ViaPlanFactory);
+        Assert.True(second.ViaPlanFactory);
+        Assert.NotEqual(first.Id, second.Id);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class UserFactoryCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class UserFactoryCommandHandler : ICommandHandler<UserFactoryCommand>
+    {
+        public bool ViaUserFactory { get; init; }
+
+        public ValueTask HandleAsync(UserFactoryCommand command, IExecutionContext context)
+        {
+            context.Set("viaUserFactory", ViaUserFactory);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task UserFactoryRegistration_KeepsResolvingThroughTheContainer()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<UserFactoryCommand, UserFactoryCommandHandler>(
+            static () => new UserFactoryCommandHandler());
+
+        // The user's factory registration (made before AddErgosfare, so the module's
+        // TryAddTransient defers to it) customizes construction — the plan factory would
+        // skip that customization and must therefore stay unused.
+        var provider = new ServiceCollection()
+            .AddTransient(_ => new UserFactoryCommandHandler { ViaUserFactory = true })
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<UserFactoryCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new UserFactoryCommand(), settings);
+
+        Assert.Equal(true, settings.Items["viaUserFactory"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class LateOverrideCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class LateOverrideCommandHandler : ICommandHandler<LateOverrideCommand>
+    {
+        public bool ViaUser { get; init; }
+
+        public ValueTask HandleAsync(LateOverrideCommand command, IExecutionContext context)
+        {
+            context.Set("viaUser", ViaUser);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task RegistrationAfterAddErgosfare_KeepsResolvingThroughTheContainer()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<LateOverrideCommand, LateOverrideCommandHandler>(
+            static () => new LateOverrideCommandHandler());
+
+        // The override lands AFTER AddErgosfare but before BuildServiceProvider — the
+        // window a snapshot taken inside AddErgosfare would miss. The lifetime capture
+        // runs at first resolution, so the user's instance must win over the plan factory
+        // exactly as it wins over GetRequiredService.
+        var services = new ServiceCollection();
+        services.AddErgosfare(x => x.AddCommandModule(c => c.Register<LateOverrideCommandHandler>()));
+        services.AddSingleton(new LateOverrideCommandHandler { ViaUser = true });
+
+        await using var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new LateOverrideCommand(), settings);
+
+        Assert.Equal(true, settings.Items["viaUser"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class SingletonCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class SingletonCommandHandler : ICommandHandler<SingletonCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(SingletonCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task SingletonLifetimeOverride_KeepsTheSharedInstance()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<SingletonCommand, SingletonCommandHandler>(
+            static () => new SingletonCommandHandler());
+
+        var provider = new ServiceCollection()
+            .AddSingleton<SingletonCommandHandler>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<SingletonCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // A plan-factory construction would hand out fresh instances; the user's
+        // singleton override must keep sharing one.
+        var first = new CommandMediationSettings();
+        await mediator.SendAsync(new SingletonCommand(), first);
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new SingletonCommand(), second);
+
+        Assert.Equal(first.Items["handlerId"], second.Items["handlerId"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedPlanCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedPlanCommandHandler : ICommandHandler<MemoizedPlanCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(MemoizedPlanCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ForceMemoizedHandlers_KeepsTheMemoizedInstance()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<MemoizedPlanCommand, MemoizedPlanCommandHandler>(
+            static () => new MemoizedPlanCommandHandler());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x =>
+            {
+                x.ForceMemoizedHandlers();
+                x.AddCommandModule(c => c.Register<MemoizedPlanCommandHandler>());
+            })
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new CommandMediationSettings();
+        await mediator.SendAsync(new MemoizedPlanCommand(), first);
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new MemoizedPlanCommand(), second);
+
+        Assert.Equal(first.Items["handlerId"], second.Items["handlerId"]);
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/GeneratedResultPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedResultPlanExecutionTests.cs
@@ -1,0 +1,100 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime behavior of generated result pipeline plans, installed through the public
+/// <see cref="GeneratedDispatchRoots.AddResultPlan{TMessage, TResult, THandler}()"/>
+/// surface exactly as generated code would — the result-producing counterpart of
+/// <see cref="GeneratedVoidPlanExecutionTests"/>. Helper types are excluded from discovery
+/// so assembly scans (the registry is process-wide) cannot alter these pipelines.
+/// </summary>
+public class GeneratedResultPlanExecutionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class PlannedEcho : ICommand<string>
+    {
+        public string Payload { get; init; } = string.Empty;
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class PlannedEchoHandler : ICommandHandler<PlannedEcho, string>
+    {
+        public bool ViaPlanFactory { get; init; }
+
+        public ValueTask<string> HandleAsync(PlannedEcho command, IExecutionContext context)
+        {
+            context.Set("viaPlanFactory", ViaPlanFactory);
+            return ValueTask.FromResult(command.Payload + "!");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlannedResultDispatch_ReturnsTheResult_AndConstructsThroughTheFactory()
+    {
+        GeneratedDispatchRoots.AddResultPlan<PlannedEcho, string, PlannedEchoHandler>(
+            static () => new PlannedEchoHandler { ViaPlanFactory = true });
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<PlannedEchoHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+
+        var result = await mediator.SendAsync(new PlannedEcho { Payload = "hi" }, settings);
+
+        Assert.Equal("hi!", result);
+        Assert.Equal(true, settings.Items["viaPlanFactory"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedEcho : ICommand<string> { }
+
+    /// <summary>Registered handler — not the type the plan claims.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ActualMismatchedEchoHandler : ICommandHandler<MismatchedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(MismatchedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("actual");
+    }
+
+    /// <summary>The plan's claimed handler; never registered anywhere.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ClaimedMismatchedEchoHandler : ICommandHandler<MismatchedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(MismatchedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("claimed");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ResultPlanClaimingTheWrongHandler_StillDispatchesTheRegisteredOne()
+    {
+        GeneratedDispatchRoots.AddResultPlan<MismatchedEcho, string, ClaimedMismatchedEchoHandler>(
+            static () => new ClaimedMismatchedEchoHandler());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ActualMismatchedEchoHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The plan claims a handler the registry never saw: the factory must stay unused
+        // (its type differs from the registered reference) and the registered handler
+        // must run, exactly as the runtime executor would dispatch it.
+        var result = await mediator.SendAsync(new MismatchedEcho());
+
+        Assert.Equal("actual", result);
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/GroupedExecutorSlotTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GroupedExecutorSlotTests.cs
@@ -1,0 +1,114 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// The grouped executor lookup's last-used slot: alternating group sets on one message
+/// type must always dispatch the requested group's executor (the composite store stays
+/// authoritative on a slot miss), for the void and the result shape alike. Helper types
+/// are excluded from discovery so assembly scans cannot alter these pipelines.
+/// </summary>
+public class GroupedExecutorSlotTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class RoutedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    [Group("east")]
+    public sealed class EastHandler : ICommandHandler<RoutedCommand>
+    {
+        public ValueTask HandleAsync(RoutedCommand command, IExecutionContext context)
+        {
+            context.Set("ran", "east");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("west")]
+    public sealed class WestHandler : ICommandHandler<RoutedCommand>
+    {
+        public ValueTask HandleAsync(RoutedCommand command, IExecutionContext context)
+        {
+            context.Set("ran", "west");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task AlternatingGroupSets_DispatchTheRequestedGroupsExecutor()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<EastHandler>();
+                c.Register<WestHandler>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+        Assert.Equal("west", await Dispatch(mediator, "west"));
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+
+        static async Task<string> Dispatch(ICommandMediator mediator, params string[] groups)
+        {
+            var settings = new CommandMediationSettings { Filters = { Groups = groups } };
+            await mediator.SendAsync(new RoutedCommand(), settings);
+            return Assert.IsType<string>(settings.Items["ran"]);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class RoutedEcho : ICommand<string> { }
+
+    [ExcludeFromDiscovery]
+    [Group("east")]
+    public sealed class EastEchoHandler : ICommandHandler<RoutedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(RoutedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("east");
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("west")]
+    public sealed class WestEchoHandler : ICommandHandler<RoutedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(RoutedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("west");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task AlternatingGroupSets_DispatchTheRequestedGroupsResultExecutor()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<EastEchoHandler>();
+                c.Register<WestEchoHandler>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+        Assert.Equal("west", await Dispatch(mediator, "west"));
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+
+        static async Task<string> Dispatch(ICommandMediator mediator, params string[] groups)
+        {
+            var settings = new CommandMediationSettings { Filters = { Groups = groups } };
+            return await mediator.SendAsync(new RoutedEcho(), settings);
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/TypedEngineDispatchTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/TypedEngineDispatchTests.cs
@@ -1,0 +1,156 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Covers the typed void dispatch overload on <see cref="MessageDispatchEngine"/>: the
+/// static-generic executor holder serves the exact-typed call, base-typed generic calls
+/// keep resolving by the message's runtime type, and the holder's cache-identity guard
+/// keeps containers isolated from each other's cached executors.
+/// </summary>
+public class TypedEngineDispatchTests
+{
+    public sealed class TypedProbeCommand : ICommand { }
+
+    public sealed class TypedProbeCommandHandler : ICommandHandler<TypedProbeCommand>
+    {
+        public ValueTask HandleAsync(TypedProbeCommand command, IExecutionContext context)
+        {
+            context.Set("typedProbe", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class UnregisteredCommand : ICommand { }
+
+    public sealed class IdentityProbeCommand : ICommand { }
+
+    public sealed class IdentityProbeCommandHandler : ICommandHandler<IdentityProbeCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(IdentityProbeCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider BuildProvider()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<TypedProbeCommandHandler>()))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_RunsThePipeline_AndRepeatsThroughTheHolder()
+    {
+        await using var provider = BuildProvider();
+        var engine = provider.GetRequiredService<MessageDispatchEngine>();
+
+        // First call populates the static-generic slot, second call is served from it;
+        // both must run the full pipeline.
+        for (var i = 0; i < 2; i++)
+        {
+            var items = new Dictionary<object, object?>();
+
+            await engine.DispatchVoidAsync(new TypedProbeCommand(), provider, items);
+
+            Assert.Equal(true, items["typedProbe"]);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_BaseTypedGenericCall_ResolvesByRuntimeType()
+    {
+        await using var provider = BuildProvider();
+        var engine = provider.GetRequiredService<MessageDispatchEngine>();
+
+        // TMessage closes over ICommand here, so the holder guard must reject the slot
+        // and resolve the executor by the runtime type — the concrete pipeline still runs.
+        ICommand baseTyped = new TypedProbeCommand();
+        var items = new Dictionary<object, object?>();
+
+        await engine.DispatchVoidAsync(baseTyped, provider, items);
+
+        Assert.Equal(true, items["typedProbe"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_DoesNotServeAnotherContainersExecutor()
+    {
+        // The message registry is process-wide, so a second container can dispatch the
+        // same message type. What must not leak between containers is the executor: it
+        // carries the container's dependencies factory — and with it the container's
+        // lifetime semantics, made observable here via ForceMemoizedHandlers.
+        await using var transientContainer = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<IdentityProbeCommandHandler>()))
+            .BuildServiceProvider();
+        var transientEngine = transientContainer.GetRequiredService<MessageDispatchEngine>();
+
+        // Populate the static-generic slot from the transient container: every dispatch
+        // resolves a fresh handler instance.
+        var first = await DispatchAndReadId(transientEngine, transientContainer);
+        var second = await DispatchAndReadId(transientEngine, transientContainer);
+        Assert.NotEqual(first, second);
+
+        await using var memoizedContainer = new ServiceCollection()
+            .AddErgosfare(x =>
+            {
+                x.ForceMemoizedHandlers();
+                x.AddCommandModule(c => c.Register<IdentityProbeCommandHandler>());
+            })
+            .BuildServiceProvider();
+        var memoizedEngine = memoizedContainer.GetRequiredService<MessageDispatchEngine>();
+
+        // Served through its own executor the memoized container reuses one handler
+        // instance; the transient container's cached executor would hand out fresh ones.
+        var memoizedFirst = await DispatchAndReadId(memoizedEngine, memoizedContainer);
+        var memoizedSecond = await DispatchAndReadId(memoizedEngine, memoizedContainer);
+        Assert.Equal(memoizedFirst, memoizedSecond);
+
+        // And after the slot moved on, the original container still dispatches through
+        // its own transient-resolving executor.
+        var third = await DispatchAndReadId(transientEngine, transientContainer);
+        Assert.NotEqual(memoizedFirst, third);
+
+        static async Task<Guid> DispatchAndReadId(MessageDispatchEngine engine, IServiceProvider provider)
+        {
+            var items = new Dictionary<object, object?>();
+            await engine.DispatchVoidAsync(new IdentityProbeCommand(), provider, items);
+            return Assert.IsType<Guid>(items["handlerId"]);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_UnregisteredMessage_FailsLikeErasedDispatch()
+    {
+        await using var provider = BuildProvider();
+        var engine = provider.GetRequiredService<MessageDispatchEngine>();
+
+        // The registry is process-wide, so suites running in parallel may add assignable
+        // descriptors (say, an interceptor-only base-interface pipeline) that change WHICH
+        // exception an unhandled message produces. The contract under test is exception
+        // parity: the typed overload fails exactly like the erased one.
+        var erased = await Record.ExceptionAsync(async () =>
+            await engine.DispatchAsync((object)new UnregisteredCommand(), provider));
+        var typed = await Record.ExceptionAsync(async () =>
+            await engine.DispatchVoidAsync(new UnregisteredCommand(), provider));
+
+        Assert.NotNull(erased);
+        Assert.NotNull(typed);
+        Assert.IsType(erased.GetType(), typed);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
@@ -76,7 +76,7 @@ public class EngineBackedEventFacadeTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task Publish_WithGroups_TakesTheMediateFallback_AndFiltersHandlers()
+    public async Task Publish_WithGroups_FiltersHandlers()
     {
         var provider = Build();
         await using var _ = provider;
@@ -88,7 +88,8 @@ public class EngineBackedEventFacadeTests
 
         await mediator.PublishAsync(new GroupedEvent(), settings);
 
-        // The grouped publish leaves the fast lane; only the requested group's handler runs.
+        // The grouped publish runs the group-filtered plan; only the requested group's
+        // handler runs.
         Assert.Equal(true, settings.Items["auditRan"]);
         Assert.False(settings.Items.ContainsKey("defaultRan"));
     }

--- a/test/Stella.Ergosfare.Events.Test/GroupedBroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/GroupedBroadcastFastLaneTests.cs
@@ -1,0 +1,173 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// The grouped broadcast fast lane: grouped publishes resolve the same group-filtered
+/// pipeline the Mediate path built, served from a last-used (factory, group set) plan
+/// slot. The tests stress the slot's weak spots — alternating group sets, a reused
+/// settings instance whose group list is mutated in place, and a grouped pipeline that
+/// carries an interceptor (which must keep the strategy path, not the straight-through
+/// loop).
+/// </summary>
+public class GroupedBroadcastFastLaneTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class LaneEvent : IEvent { }
+
+    [ExcludeFromDiscovery]
+    [Group("alpha")]
+    public sealed class AlphaHandler : IEventHandler<LaneEvent>
+    {
+        public ValueTask HandleAsync(LaneEvent @event, IExecutionContext context)
+        {
+            context.Set("alphaRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("beta")]
+    public sealed class BetaHandler : IEventHandler<LaneEvent>
+    {
+        public ValueTask HandleAsync(LaneEvent @event, IExecutionContext context)
+        {
+            context.Set("betaRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider Build()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<AlphaHandler>();
+                e.Register<BetaHandler>();
+            }))
+            .BuildServiceProvider();
+
+    private static async Task<IDictionary<object, object?>> Publish(IEventMediator mediator, params string[] groups)
+    {
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = groups;
+
+        await mediator.PublishAsync(new LaneEvent(), settings);
+
+        return settings.Items;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task AlternatingGroupSets_AlwaysRunTheRequestedGroup()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // alpha populates the slot, beta must not be served alpha's plan, and alpha
+        // again must survive the slot having moved on.
+        var first = await Publish(mediator, "alpha");
+        Assert.Equal(true, first["alphaRan"]);
+        Assert.False(first.ContainsKey("betaRan"));
+
+        var second = await Publish(mediator, "beta");
+        Assert.Equal(true, second["betaRan"]);
+        Assert.False(second.ContainsKey("alphaRan"));
+
+        var third = await Publish(mediator, "alpha");
+        Assert.Equal(true, third["alphaRan"]);
+        Assert.False(third.ContainsKey("betaRan"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task MutatedReusedGroupList_IsSeenAsANewGroupSet()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // One settings instance, one List instance — mutated between publishes. The slot
+        // snapshots group contents, so the second publish must re-resolve, not replay
+        // alpha's plan.
+        var groups = new List<string> { "alpha" };
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = groups;
+
+        await mediator.PublishAsync(new LaneEvent(), settings);
+        Assert.Equal(true, settings.Items["alphaRan"]);
+
+        groups.Clear();
+        groups.Add("beta");
+        settings.Items.Clear();
+
+        await mediator.PublishAsync(new LaneEvent(), settings);
+        Assert.Equal(true, settings.Items["betaRan"]);
+        Assert.False(settings.Items.ContainsKey("alphaRan"));
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedLaneEvent : IEvent { }
+
+    [ExcludeFromDiscovery]
+    [Group("guarded")]
+    public sealed class GuardedHandler : IEventHandler<InterceptedLaneEvent>
+    {
+        public ValueTask HandleAsync(InterceptedLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("guardedRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("guarded")]
+    public sealed class GuardedInterceptor : IEventPreInterceptor<InterceptedLaneEvent>
+    {
+        public ValueTask<InterceptedLaneEvent> HandleAsync(InterceptedLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("guardedInterceptorRan", true);
+            return ValueTask.FromResult(@event);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task GroupedPipelineWithInterceptor_RunsTheFullStrategy()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        // Register the intercepted pipeline in its own container to keep the fixture
+        // handlers' pipelines interceptor-free.
+        await using var guarded = new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<GuardedHandler>();
+                e.Register<GuardedInterceptor>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = guarded.GetRequiredService<IEventMediator>();
+
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = ["guarded"];
+
+        await mediator.PublishAsync(new InterceptedLaneEvent(), settings);
+
+        // A grouped pipeline that carries an interceptor must leave the straight-through
+        // loop to the strategy, which runs the interceptor before the handler.
+        Assert.Equal(true, settings.Items["guardedInterceptorRan"]);
+        Assert.Equal(true, settings.Items["guardedRan"]);
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
@@ -37,7 +37,7 @@ public class EngineBackedQueryFacadeTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task DiResolvedFacade_Streams_ResolvingTheScopesMediatorOnDemand()
+    public async Task DiResolvedFacade_Streams_ThroughTheEngineFastLane()
     {
         var provider = new ServiceCollection()
             .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStreamStringResultQueryHandler>()))

--- a/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
@@ -1,0 +1,141 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Queries.Test;
+
+/// <summary>
+/// The engine-backed streaming fast lane: streams run against the invoker-cached,
+/// registry-version-guarded pipeline plan instead of the per-call Mediate options path.
+/// Covers plan reuse across streams, grouped streams alternating group sets on the
+/// last-used slot, caller-visible items, and the unregistered-query failure parity.
+/// Helper types are excluded from discovery so assembly scans (the registry is
+/// process-wide) cannot alter these pipelines.
+/// </summary>
+public class StreamFastLaneTests
+{
+    [ExcludeFromDiscovery]
+    public sealed record NumberStream : IStreamQuery<int>;
+
+    [ExcludeFromDiscovery]
+    public sealed class NumberStreamHandler : IStreamQueryHandler<NumberStream, int>
+    {
+        public async IAsyncEnumerable<int> StreamAsync(NumberStream query, IExecutionContext context)
+        {
+            context.Set("streamRan", true);
+            yield return 1;
+            await Task.Yield();
+            yield return 2;
+            yield return 3;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task RepeatedStreams_ServeThePlan_AndFlowItemsToTheCaller()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<NumberStreamHandler>()))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        // First stream builds the invoker's plan, second is served from it; both must
+        // yield the full sequence and surface handler writes through the settings items.
+        for (var i = 0; i < 2; i++)
+        {
+            var settings = new QueryMediationSettings();
+            var items = new List<int>();
+
+            await foreach (var item in mediator.StreamAsync(new NumberStream(), settings))
+            {
+                items.Add(item);
+            }
+
+            Assert.Equal([1, 2, 3], items);
+            Assert.Equal(true, settings.Items["streamRan"]);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed record RoutedStream : IStreamQuery<string>;
+
+    [ExcludeFromDiscovery]
+    [Group("east")]
+    public sealed class EastStreamHandler : IStreamQueryHandler<RoutedStream, string>
+    {
+        public async IAsyncEnumerable<string> StreamAsync(RoutedStream query, IExecutionContext context)
+        {
+            await Task.Yield();
+            yield return "east";
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("west")]
+    public sealed class WestStreamHandler : IStreamQueryHandler<RoutedStream, string>
+    {
+        public async IAsyncEnumerable<string> StreamAsync(RoutedStream query, IExecutionContext context)
+        {
+            await Task.Yield();
+            yield return "west";
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task GroupedStreams_AlternatingGroupSets_RunTheRequestedGroup()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q =>
+            {
+                q.Register<EastStreamHandler>();
+                q.Register<WestStreamHandler>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        Assert.Equal("east", await StreamOne(mediator, "east"));
+        Assert.Equal("west", await StreamOne(mediator, "west"));
+        Assert.Equal("east", await StreamOne(mediator, "east"));
+
+        static async Task<string> StreamOne(IQueryMediator mediator, params string[] groups)
+        {
+            var settings = new QueryMediationSettings { Filters = { Groups = groups } };
+
+            await foreach (var item in mediator.StreamAsync(new RoutedStream(), settings))
+            {
+                return item;
+            }
+
+            throw new InvalidOperationException("stream yielded nothing");
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed record UnhandledStream : IStreamQuery<int>;
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task UnregisteredStreamQuery_ThrowsAtCallTime_LikeTheMediatePath()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(_ => { }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        // The Mediate path threw from the StreamAsync call itself (descriptor resolution
+        // precedes enumeration); the fast lane must keep that timing.
+        Assert.Throws<NoHandlerFoundException>(() => mediator.StreamAsync(new UnhandledStream()));
+        await Task.CompletedTask;
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
@@ -29,8 +29,127 @@ public class VoidPlanEmissionTests
 
         Assert.Empty(result.GeneratorDiagnostics);
         Assert.Empty(result.CompilationErrors);
+
+        // The handler has an accessible parameterless constructor and is not disposable,
+        // so the plan carries the direct-construction factory.
         Assert.Contains(
-            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.SoloPing, global::TestApp.SoloPingHandler>();",
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.SoloPing, global::TestApp.SoloPingHandler>(static () => new global::TestApp.SoloPingHandler());",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ConstructorDependency_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record NeedyPing : ICommand;
+
+                public sealed class NeedyPingHandler : ICommandHandler<NeedyPing>
+                {
+                    public NeedyPingHandler(string dependency) { }
+
+                    public ValueTask HandleAsync(NeedyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.NeedyPing, global::TestApp.NeedyPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void AdditionalConstructor_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record PickyPing : ICommand;
+
+                public sealed class PickyPingHandler : ICommandHandler<PickyPing>
+                {
+                    public PickyPingHandler() { }
+
+                    public PickyPingHandler(string dependency) { }
+
+                    public ValueTask HandleAsync(PickyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // The container's greedy constructor selection would pick the richer constructor;
+        // a `new()` factory would silently drop that dependency — plan only, no factory.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.PickyPing, global::TestApp.PickyPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void RequiredMember_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record NamedPing : ICommand;
+
+                public sealed class NamedPingHandler : ICommandHandler<NamedPing>
+                {
+                    public required string Name { get; init; }
+
+                    public ValueTask HandleAsync(NamedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // An emitted `new()` would fail compilation with CS9035 — plan only, no factory.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.NamedPing, global::TestApp.NamedPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void DisposableHandler_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record LeakyPing : ICommand;
+
+                public sealed class LeakyPingHandler : ICommandHandler<LeakyPing>, IDisposable
+                {
+                    public ValueTask HandleAsync(LeakyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+
+                    public void Dispose() { }
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.LeakyPing, global::TestApp.LeakyPingHandler>();",
             result.GeneratedSource);
     }
 
@@ -149,5 +268,64 @@ public class VoidPlanEmissionTests
         Assert.Empty(result.CompilationErrors);
         Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
         Assert.Contains("AddResult<global::TestApp.TypedPing, string>", result.GeneratedSource);
+
+        // The same solo-async-handler shape on the result side produces the result plan
+        // instead, factory included.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddResultPlan<global::TestApp.TypedPing, string, global::TestApp.TypedPingHandler>(static () => new global::TestApp.TypedPingHandler());",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void DiscoveredInterceptor_SuppressesTheResultPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record GuardedTypedPing : ICommand<string>;
+
+                public sealed class GuardedTypedPingHandler : ICommandHandler<GuardedTypedPing, string>
+                {
+                    public ValueTask<string> HandleAsync(GuardedTypedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(string.Empty);
+                }
+
+                public sealed class GuardedTypedPingInterceptor : ICommandPreInterceptor<GuardedTypedPing>
+                {
+                    public ValueTask<GuardedTypedPing> HandleAsync(GuardedTypedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddResultPlan<", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void StreamContract_DoesNotProduceAResultPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Queries.Abstractions;
+            using System.Collections.Generic;
+
+            namespace TestApp
+            {
+                public sealed record NumberStream : IStreamQuery<int>;
+
+                public sealed class NumberStreamHandler : IStreamQueryHandler<NumberStream, int>
+                {
+                    public IAsyncEnumerable<int> StreamAsync(NumberStream message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => throw new System.NotImplementedException();
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddResultPlan<", result.GeneratedSource);
+        Assert.Contains("AddStream<global::TestApp.NumberStream, int>", result.GeneratedSource);
     }
 }


### PR DESCRIPTION
## v2.4.0-preview

The theme: **the remaining lanes join the fast path.** Grouped publishes/dispatches, streaming queries and result pipelines all move onto the executors' cached-plan pattern; generated plans learn to construct their handlers directly; the benchmark gains a real competitor; CI gains a NativeAOT gate. Behavior preserved on every path (two deliberate edges in the changelog Notes).

### What's here

- **Compile-time result plans + direct handler construction.** `AddResultPlan<TMessage, TResult, THandler>` plus `static () => new THandler()` factories on both plan shapes. Compile-time gate: sole public parameterless ctor, no `required` members, not disposable. Runtime gate: only while the handler's effective registration is the module's own plain transient — user factory / lifetime override / memoization / late registration all route back through the container (all covered by tests). Lifetime capture now runs at first resolution, so post-`AddErgosfare` registrations are honored (this also closes the memoized path's stale direction).
- **Grouped fast lane.** Per-message-type last-used group-set slots for command/query executors (no per-dispatch materialization/joined key); grouped publishes leave the `Mediate` fallback and run the broadcast fast lane against a (factory, group set) plan slot — straight-through included.
- **Streaming on the executor path.** Engine-backed `StreamAsync` drops `MediateOptions`, per-call descriptor lookup and the scope-resolved mediator; context semantics byte-for-byte unchanged.
- **`DispatchVoidAsync<TMessage>`** on the engine (static-generic executor holder). Deliberately a distinct name: a same-name generic would hijack echo-typed `DispatchAsync<T>` calls via identity conversion (`ICommand<TResult> : ICommand` makes them legal) — verified with before/after compiles.
- **Benchmark: martinothamar/Mediator 3.0.2** at its defaults, plus memoized / generated-query / grouped / typed rows so the table is honest in both directions.
- **NativeAOT smoke in CI**: `examples/AotSmoke` (struct event included) published with `PublishAot=true` and executed on ubuntu per push/PR.

### Numbers (2026-08-07, 7800X3D, .NET 9)

| Row | Mean | Alloc |
|---|---:|---:|
| Command_Void_Generated | **21.2 ns** (was 26.5) | 24 B |
| Query_Result_Generated | **25.0 ns** (runtime path: 44.1) | 24 B |
| Command_Void_Memoized | 24.5 ns | 0 B |
| Event_Publish_Grouped | 56.2 ns — **parity with group-less 56.9** | 48 B |
| MediatorSg_Send_Void | 8.3 ns | 0 B |
| MediatR_Send_Void | 66.2 ns | 192 B |

Planned-void gap to Mediator narrowed from ~3.4× to ~2.3×. Full table + honest reading in the changelog entry.

### Verification

- Full no-incremental build: 0 warnings. All tests green on net9.0 + net10.0 (≈340, +30 new).
- Two adversarial review passes (11-agent + independent re-review). Confirmed findings all fixed: same-name overload hijack (→ distinct `DispatchVoidAsync`), multi-ctor `new()` divergence from MS.DI's greedy selection, `required`-member CS9035, internal-ctor inconsistency, and the lifetime-capture staleness (→ lazy capture). Grouped/stream lanes, slots and AOT smoke verdicts: sound.
- Local win-x64 native link fails on this machine's VS layout (ilcompiler's vswhere discovery; VS on `G:`) — unrelated to the library; the CI job is the gate and the app's logic exits 0 under CoreCLR.

### Notes for review

- Custom `IMessageMediator` decorators no longer see grouped publishes/streams on engine-backed facades (consistent with the group-less lane since v2.3.0-preview).
- Static plan/executor holders root the last-serving container's executor graph past disposal (at most one per message type); a `WeakReference` would tax the hot path — flagged in the changelog Notes for your call.
- Streams have always run against an empty result-adapter set (facade carries none) — pre-existing, now just allocation-free; separate topic if you want stream adapters.

After merge: tag `v2.4.0-preview` (ancestry check passes once merged), then the preview→main promotion and the main-side changelog as separate PRs per your sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)