### PR TITLE
Promote v2 preview line to stable v2.1.0

### DIFF
--- a/.github/workflows/aot_smoke.yml
+++ b/.github/workflows/aot_smoke.yml
@@ -1,0 +1,36 @@
+name: AotSmoke
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - main
+      - preview
+
+jobs:
+  aot-smoke:
+    # End-to-end NativeAOT gate: publishes the sample app with PublishAot=true (trim/AOT
+    # analyzer warnings are errors there) and runs the produced binary — every dispatch
+    # shape must work without the JIT's MakeGenericType fallback actually jitting.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        # Both SDKs: the referenced library projects multi-target net9.0 and net10.0, so
+        # restore needs to evaluate both even though the smoke app publishes net9.0.
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Publish NativeAOT Smoke App
+        run: dotnet publish examples/AotSmoke/AotSmoke.csproj -c Release -r linux-x64
+
+      - name: Run NativeAOT Smoke App
+        run: ./examples/AotSmoke/bin/Release/net9.0/linux-x64/publish/Ergosfare.AotSmoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,143 @@
+## v2.4.0-preview – '2026-08-07'
+
+Preview release. The theme: **the remaining lanes join the fast path.** v2.3.0-preview left three
+entry points on the original `Mediate` machinery — grouped publishes, grouped dispatches paying
+per-call key materialization, and streaming queries — and resolved every planned handler through
+the container even when the container had nothing to add. This release moves all of them onto the
+executors' cached-plan pattern, teaches generated plans to construct their handlers directly, and
+puts the benchmark up against the fastest widely-used alternative instead of only MediatR. CI
+gains an end-to-end NativeAOT gate. Behavior is preserved on every path (see Notes for the two
+deliberate edges).
+
+### Compile-time result plans and direct handler construction
+
+* The generator now emits `GeneratedDispatchRoots.AddResultPlan<TMessage, TResult, THandler>()`
+  for a dispatchable command/query with exactly one closed, non-stream result contract whose
+  whole discovered pipeline is a single async result handler — the void plan's eligibility rules,
+  applied to the result shape. The executor closes over all three types and invokes the handler
+  devirtualized.
+* Both plan shapes can additionally carry a **direct-construction factory**
+  (`static () => new THandler()`). The compile-time gate is deliberately strict: the handler's
+  *only* instance constructor must be public and parameterless (the container's greedy
+  constructor selection would pick any richer one), no `required` members (an emitted `new()`
+  would not compile), and no `IDisposable`/`IAsyncDisposable` (the container tracks transient
+  disposables; direct construction would not).
+* The factory is as advisory as the plan itself. At runtime it is used only while the handler's
+  *effective* DI registration is the module's own plain transient self-registration — no user
+  factory, no lifetime override, no forced memoization — re-validated with the same
+  registry-version guard as the dependency cache. Any customization routes the dispatch back
+  through the container.
+* The lifetime capture behind that verdict (and behind the existing memoized fast path) now runs
+  **at first resolution instead of inside `AddErgosfare`**, so registrations added between
+  `AddErgosfare` and `BuildServiceProvider` are honored by both features.
+* This reverses v2.3.0-preview's note that a result plan "showed no gain": devirtualization alone
+  did not pay, but together with direct construction the planned query path drops from ~44 ns to
+  ~25 ns per dispatch (see Benchmark).
+
+### Grouped dispatch fast lane
+
+* Grouped command/query dispatch used to materialize the caller's group sequence and build a
+  joined string key on every call. A per-message-type **last-used group-set slot** (void and
+  result alike) now answers the common shape — one message type, one stable group set — with an
+  ordinal element-wise compare: no materialization, no key, no per-dispatch allocation. Misses
+  fall back to the composite stores, which stay authoritative, so executor identity and its
+  version-guarded dependency cache are preserved when group sets alternate. The slot snapshots
+  the group contents, so mutating a reused settings instance reads as a new group set, never a
+  stale hit.
+* **Grouped publishes leave the `Mediate` fallback.** The broadcast invoker resolves the same
+  group-filtered dependencies the old path built — same factory call, same descriptor semantics —
+  from a last-used (factory, group set) plan slot, then runs the same strategy, including the
+  straight-through loop for interceptor-free, unfiltered pipelines. A grouped publish now costs
+  what a group-less one does (see Benchmark).
+
+### Streaming joins the executor path
+
+* Engine-backed facades no longer stream through `Mediate(options)`: no per-call
+  `MediateOptions`, no per-call descriptor lookup, no resolving the scope's `IMessageMediator`.
+  The stream invoker holds the query's pipeline plan (group-less and grouped slots, factory-keyed
+  and version-guarded) and runs the same streaming strategy against it. Context construction is
+  unchanged — one fresh, unpooled context per `StreamAsync` call, shared across re-enumerations
+  exactly as before — and an unregistered query still throws at call time, not at enumeration.
+
+### Typed void dispatch on the engine
+
+* `MessageDispatchEngine.DispatchVoidAsync<TMessage>` resolves its executor from a
+  static-generic holder — a field read and a cache-identity check instead of the type-keyed
+  dictionary lookup — guarded by `message.GetType() == typeof(TMessage)`, so base-typed generic
+  calls keep resolving by runtime type. It is deliberately **not** a `DispatchAsync` overload: a
+  same-name generic would join the candidate set of every explicit `DispatchAsync<T>(msg, …)`
+  call, and for echo-typed shapes (`ICommand<TResult> : ICommand : IMessage` makes them legal)
+  the identity conversion would out-rank the result overload — silently rerouting result
+  dispatches through the void pipeline or breaking compilation. The facade-level counterpart is
+  blocked by the same C# overload-resolution fact and was not shipped.
+
+### Benchmark: a real competitor
+
+* [martinothamar/Mediator](https://github.com/martinothamar/Mediator) 3.0.2 — source-generated
+  dispatch, singleton lifetime by default — joins the table as the `MediatorSg_*` rows, running
+  its out-of-the-box defaults just as the MediatR rows run theirs.
+* New Ergosfare rows make the comparison honest in both directions: `Command_Void_Memoized`
+  (`ForceMemoizedHandlers()` — the zero-allocation shape that matches Mediator's singleton
+  default), `Query_Result_Generated`, grouped rows for command dispatch and event publish, and
+  the engine's typed void dispatch.
+
+Per-operation numbers (BenchmarkDotNet v0.15.8, Windows 11, AMD Ryzen 7 7800X3D, .NET 9.0.11,
+RyuJIT x86-64-v4), measured 2026-08-07:
+
+| Method | Cat | Mean | Alloc |
+|---|---|---:|---:|
+| Engine_Void | Root | 35.16 ns | 24 B |
+| Engine_Void_Typed | Root | 29.60 ns | 24 B |
+| Command_Void | Root | 32.90 ns | 24 B |
+| Command_Void_Generated | Root | **21.21 ns** | 24 B |
+| Command_Void_Memoized | Root | 24.48 ns | **0 B** |
+| Command_Void_Grouped | Root | 36.73 ns | 24 B |
+| Query_Result | Root | 44.10 ns | 24 B |
+| Query_Result_Generated | Root | **25.04 ns** | 24 B |
+| Event_Publish | Root | 56.93 ns | 48 B |
+| Event_Publish_Grouped | Root | 56.22 ns | 48 B |
+| MediatR_Send_Void / _Result / _Publish | Root | 66.22 / 52.88 / 84.90 ns | 192 / 192 / 440 B |
+| MediatorSg_Send_Void / _Result / _Publish | Root | 8.31 / 8.21 / 15.90 ns | 0 / 0 / 0 B |
+| Engine_Void_Scoped | Scoped | 92.67 ns | 200 B |
+| Command_Void_Scoped | Scoped | 89.80 ns | 192 B |
+| Query_Result_Scoped | Scoped | 97.70 ns | 200 B |
+| Event_Publish_Scoped | Scoped | 107.90 ns | 232 B |
+| MediatR (void/result/publish, Scoped) | Scoped | 106.96 / 106.67 / 143.95 ns | 352 / 352 / 600 B |
+| MediatorSg (void/result/publish, Scoped) | Scoped | 56.57 / 56.92 / 70.64 ns | 128 / 128 / 128 B |
+
+The honest reading: Ergosfare leads MediatR on every row, and Mediator — which trades runtime
+registration, group filtering, polymorphic dispatch and the execution-context model for a fully
+static dispatch — leads Ergosfare. This cycle narrowed that gap on the planned void path from
+~3.4× to ~2.3×; the grouped publish row shows the grouped lane reaching parity with the
+group-less one; the remaining lifetime-honoring difference (24 B transient handler per dispatch
+vs. Mediator's shared singletons) is a semantic choice, not an overhead — `Command_Void_Memoized`
+is the like-for-like row.
+
+### NativeAOT smoke in CI
+
+* `examples/AotSmoke` publishes with `PublishAot=true` (trim/AOT analyzer warnings are errors)
+  and runs every dispatch shape — void and result commands through their generated plans, a
+  query, a two-handler class-event broadcast, and a struct event exercising the value-type
+  generic instantiations only generated roots can anchor. The new `AotSmoke` workflow publishes
+  and executes the binary on every push and PR.
+
+### Notes
+
+* **Public API additions:** `MessageDispatchEngine.DispatchVoidAsync<TMessage>`;
+  `GeneratedDispatchRoots.AddResultPlan`/`FindResultPlan` with `ResultPlanRoot`/
+  `IResultPlanRootVisitor`; `Func<THandler>`-taking overloads of `AddVoidPlan`/`AddResultPlan`.
+  Nothing is removed or changed in shape.
+* **Deliberate behavioral edges:** (1) a custom `IMessageMediator` registration decorating the
+  scope's mediator no longer sees grouped publishes or streams on engine-backed facades — those
+  lanes now run the engine directly, consistent with the group-less lane since v2.3.0-preview;
+  wrapped-construction facades and foreign mediator implementations keep the original path.
+  (2) Because the lifetime capture moved to first resolution, handler registrations added after
+  `AddErgosfare` are now honored by the memoized fast path too — strictly closer to the
+  container's own behavior.
+* The static plan/executor holders root the last-serving container's executor graph past
+  container disposal (at most one graph per message type — in a single-container process, the
+  live one). A `WeakReference` would tax every hot-path read instead; called out for review.
+
 ## v2.3.0-preview – '2026-07-28'
 
 Preview release. The theme: **event publishing joins the fast lane, and resolving a mediator stops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,72 @@
+## v2.3.0-preview – '2026-07-28'
+
+Preview release. The theme: **event publishing joins the fast lane, and resolving a mediator stops
+costing more than dispatching through it.** v2.2.0-preview put commands and queries on the
+executor fast path; this release brings event broadcasting onto the same footing, collapses every
+facade resolution to a single object over a shared dispatch engine, and ships the source
+generator's first compile-time pipeline plans. Behavior is unchanged on every path; the public API
+grows (see Notes) but nothing breaks.
+
+### Broadcast fast lane
+
+* **Pooled publish contexts and allocation-free default publishes.** A group-less `PublishAsync` without settings rents a pooled execution context and reuses a cached default broadcast strategy — no `EventMediationSettings`, no filter list, no strategy allocation. Caller-supplied settings items are adopted for the dispatch and detached untouched on return, so handler writes stay visible to the caller exactly as before.
+* **Invoker-cached pipeline plan.** The broadcast invoker holds the event's resolved pipeline directly, re-validated against the registry version — the executors' pattern applied to publishing. The plan is keyed by the dependencies-factory reference, so one container's plan (which may pin that container's provider for memoized pipelines) is never served to another container.
+* **Straight-through broadcast.** An unfiltered publish over an interceptor-free pipeline loops the handler arrays directly — synchronously while handlers complete synchronously, bailing to an awaiting helper on the first suspension, preserving strict sequential order. Exceptions propagate raw; `ThrowIfNoHandlerFound` is honored.
+* **Fixed:** a broadcast now continues with the event instance a pre-interceptor returns, matching the documented pre-interceptor contract.
+* Grouped publishes, handler-predicate filters, externally owned contexts and foreign `IMessageMediator` implementations keep the original `Mediate` path unchanged.
+
+### Single-object facades: `MessageDispatchEngine`
+
+* Resolving a facade used to build two transients per scope — the facade plus its `IMessageMediator` — while MediatR builds one. The executor dispatch bodies now live in **`MessageDispatchEngine`**, a process-wide singleton that takes the calling scope's provider per call; `IMessageMediator`'s executor overloads delegate to it unchanged.
+* `CommandMediator`, `QueryMediator` and `EventMediator` gain a public engine constructor, and DI binds single-constructor engine-backed shapes — constructor injection compiles the engine into a constant callsite, avoiding both MS.DI's ambiguous-constructor rejection and the per-resolution service lookup a factory registration would pay. The original `IMessageMediator` constructors remain for direct construction and foreign mediator implementations; `EventMediator` is unsealed to admit its DI shape.
+* Scoped handler resolution still binds to the calling scope (verified under `ValidateScopes = true`); the streaming and grouped paths resolve the scope's `IMessageMediator` on demand and are otherwise untouched.
+
+### Cheaper result-executor lookup
+
+* Group-less result dispatch paid a (message type, result type) composite-key hash per call while the void path got by on a single `Type`-keyed lookup. A per-message-type **last-used result-executor slot** closes the gap: one `Type` lookup plus a reference check on the recorded result type. Misses fall back to the composite store, which stays authoritative, so executor identity — and its registry-version-guarded dependency cache — is preserved.
+
+### Typed publish without the dictionary
+
+* The generic `PublishAsync<TEvent>` overload resolves its invoker from a static-generic holder (`Holder<TEvent>.Instance`), guarded by `@event.GetType() == typeof(TEvent)` — a base-typed generic call keeps resolving by runtime type, so polymorphic publishes dispatch exactly as before. The interface-erased overload keeps the dictionary path.
+
+### Compile-time pipeline plans (source generator)
+
+* When the generator can prove a dispatchable command's whole discovered pipeline is a single default-discovery, default-group async handler, it emits `GeneratedDispatchRoots.AddVoidPlan<TMessage, THandler>()` alongside the dispatch roots. The executor cache closes an executor over both types, so the fast path invokes the handler **devirtualized** — no contract pattern match, inlineable for sealed handlers.
+* The plan is advisory, never authoritative: the registry-version-guarded dependency cache re-validates the pipeline, so runtime registrations invalidate generated plans exactly as they invalidate runtime executors; a plan whose handler no longer matches falls through to the ordinary contract switch, then the strategy — behavior identical, only the speedup is lost. Grouped pipelines and `RegisterFromAssembly`/manual-registration users never see a plan.
+* Eligibility is conservative by design: one main-handler descriptor for the message across the compilation and scanned references, async void contract, unkeyed and ungrouped handler, no interceptor targeting the message, and a referenced package that exposes the plan surface (older packages keep the previous emission).
+
+### Benchmark
+
+Per-operation BenchmarkDotNet numbers (v0.15.8, Windows 11, AMD Ryzen 7 7800X3D, .NET 9.0.11,
+RyuJIT x86-64-v4), measured 2026-07-28. *Root* resolves mediators once; *Scoped* creates a fresh
+DI scope per dispatch and includes resolution in the measurement. MediatR columns are from the
+same runs.
+
+| Method | Cat | Mean | Alloc |
+|---|---|---:|---:|
+| Engine_Void | Root | 30.26 ns | 24 B |
+| Command_Void | Root | 30.52 ns | 24 B |
+| Command_Void_Generated | Root | **26.49 ns** | 24 B |
+| Query_Result | Root | 34.43 ns | 24 B |
+| Event_Publish | Root | 49.32 ns | 48 B |
+| MediatR_Send_Void / _Result / _Publish | Root | 60.29 / 53.79 / 83.42 ns | 192 / 192 / 440 B |
+| Engine_Void_Scoped | Scoped | 86.08 ns | 200 B |
+| Command_Void_Scoped | Scoped | 81.72 ns | 192 B |
+| Query_Result_Scoped | Scoped | 85.89 ns | 200 B |
+| Event_Publish_Scoped | Scoped | 100.90 ns | 232 B |
+| MediatR_Send_Void_Scoped / _Result_Scoped / _Publish_Scoped | Scoped | 101.48 / 115.76 / 130.32 ns | 352 / 352 / 600 B |
+
+Across this release cycle the scoped rows moved: command 91.4 → 81.7 ns (224 → 192 B), query
+109.7 → 85.9 ns (232 → 200 B), event publish 117.7 → 100.9 ns (264 → 232 B). The scoped query —
+the one row that still trailed MediatR when the cycle started — now leads it comfortably. The
+generated void-command plan beats the hand-written fast path by ~12%.
+
+### Notes
+
+* **Public API additions:** `MessageDispatchEngine` (constructed by DI only); engine-accepting public constructors on `CommandMediator`, `QueryMediator`, `EventMediator`; `GeneratedDispatchRoots.AddVoidPlan`/`FindVoidPlan` with `VoidPlanRoot`/`IVoidPlanRootVisitor`. `EventMediator` is no longer sealed. Nothing is removed or changed in shape; applications resolving mediators from DI see identical behavior with no migration steps.
+* A result-producing counterpart of the void plan was implemented and measured during the cycle: it showed no gain (the runtime contract switch's first arm already matches the async contract, and tiered PGO devirtualizes it), so it was deliberately not shipped.
+* Two runtime-registration test facts were shielded from assembly-scan pollution with `[ExcludeFromDiscovery]` — the registry is process-wide, and another test's `RegisterFromAssembly` sweep could slip a late-registered type into a pipeline before its fact warmed the cache. Test-only; no product change.
+
 ## v2.2.0-preview – '2026-07-28'
 
 Preview release. The theme: **the dispatch path stops re-deriving what it already knows.** v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v2.1.0 – '2026-08-07'
+
+Stable release. Promotes the entire preview cycle since v2.0.0 to the stable channel — the
+contents of the v2.2.0-preview, v2.3.0-preview and v2.4.0-preview entries below, exactly as
+shipped there: the dispatch fast path (executor-level dependency caches, sync fast path,
+transient facades), the shared dispatch engine with single-object facades and the broadcast
+fast lane, compile-time pipeline plans — void and result — with direct handler construction,
+the grouped and streaming fast lanes, the typed dispatch holders, and the NativeAOT smoke
+gate in CI. (v2.1.0-preview carried repository chores only.) No API or behavior changes
+beyond those entries; see them for the full details and benchmark tables.
+
 ## v2.4.0-preview – '2026-08-07'
 
 Preview release. The theme: **the remaining lanes join the fast path.** v2.3.0-preview left three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+## v2.2.0-preview – '2026-07-28'
+
+Preview release. The theme: **the dispatch path stops re-deriving what it already knows.** v2.0.0
+moved dispatch-shape work off the per-call path and onto compile time or a once-per-message-type
+plan; this release removes what was left — the per-dispatch lookup of that plan, the pipeline
+machinery around a pipeline that has exactly one stage, and a DI lifetime that charged the
+dispatch path for a scope entry it never used. No public API changes and no behavioral changes.
+
+### Dispatch fast path
+
+* **Executor-level dependency cache.** A pipeline executor is already per (message type, result type, group set), so it now holds its resolved `IMessageDependencies` directly, re-validated against the registry version on each dispatch. The per-dispatch factory call and its `ConcurrentDictionary` lookup collapse to a field read and an integer compare. Runtime registrations bump the version and the next dispatch rebuilds, so late registration keeps working; concurrent rebuilds are benign, since both writers publish equivalent state.
+* **Straight-through dispatch.** When a message's plan resolves to exactly one main handler, no interceptors in any of the four stages, and no registered result adapters, the executor invokes the handler's typed member and returns its `ValueTask` unchanged — no mediation-strategy object, no async state machine, no interface-dispatched stage-count checks. The condition is precomputed once when the plan is built (`MessageDependencies.FastSingleHandler`), not evaluated per dispatch. Adding a single interceptor returns the message to the full staged pipeline; a handler contract the fast path does not recognize falls through to the strategy, which raises its canonical `NotSupportedException`.
+* **Group-less executor lookup keyed by message type alone.** Dispatches that pass no groups — nearly all of them — skip group materialization and composite-key hashing entirely, hitting a `ConcurrentDictionary<Type, …>` instead.
+* **Adapter check split by shape.** `ResultAdapterService` exposes an internal emptiness check, read live so a late `AddAdapter` is observed, letting the fast path skip adapter consultation when none are registered. A foreign `IResultAdapterService` implementation always routes through the strategy.
+* **Which entry points this covers.** Both optimizations live in the pipeline executors, so they apply to `ICommandMediator.SendAsync`, `IQueryMediator.QueryAsync` and `IMessageMediator.DispatchAsync`. Event publishing (`IEventMediator`/`IPublisher.PublishAsync`, which broadcasts through `AsyncBroadcastMediationStrategy`) and streaming queries (`IQueryMediator.StreamAsync`) still dispatch through the options path, as does `IMessageMediator.Mediate` itself — they resolve dependencies per dispatch and build an unpooled context. Bringing those onto the executor path is future work.
+
+### Mediator lifetime
+
+* **The mediator facades are registered transient instead of scoped** — `ICommandMediator`, `IQueryMediator`, `IEventMediator`, `IPublisher` and `IMessageMediator`. A facade is stateless; the only thing it captures is the provider that resolved it, and DI hands a transient service the resolving scope's provider exactly as it does a scoped one, so handlers still resolve from the calling scope and scoped handler dependencies are honored unchanged (verified under `ValidateScopes = true`).
+* What changes is cost. Resolving a scoped service takes the scope's lock and writes the instance into the scope's resolved-services dictionary. That amortizes across a long-lived scope and never amortizes at all when every dispatch creates its own scope — and because `ICommandMediator` → `IMessageMediator` were both scoped, the scope-per-dispatch path paid it twice. This is the single largest contributor to the web-server-shape numbers below.
+
+### Benchmark
+
+100k sequential no-op dispatches per operation. BenchmarkDotNet v0.15.8, Windows 11, AMD Ryzen 7
+7800X3D, .NET 9.0.11 (RyuJIT x86-64-v4), measured 2026-07-28.
+
+| Scenario | v2.1.0-preview | v2.2.0-preview | MediatR (same runs) |
+|---|---:|---:|---:|
+| Typical usage — mean | 6.76 ms | **2.97 ms** | 5.79 ms |
+| Typical usage — allocated | 2.29 MB | 2.29 MB | 18.31 MB |
+| Web-server shape (scope per dispatch) — mean | 20.11 ms | **8.46 ms** | 10.28 ms |
+| Web-server shape — allocated | 38.91 MB | **21.36 MB** | 33.57 MB |
+
+The two Ergosfare columns are back-to-back runs on the same machine. The web-server shape was the
+one scenario v2.0.0 documented as a loss against MediatR; it is now a win on both axes, though the
+time margin there (~18%) is narrower than the allocation margin (~36%) and that row is dominated by
+DI scope creation for both libraries.
+
+The internal engine path (`IMessageMediator.Mediate` with pre-built `MediateOptions`) is unchanged
+at ~6.3 ms and now trails the public facade: it is a separate entry point that runs its own resolve
+and mediation strategies, so it reaches neither the executor's cached plan nor the straight-through
+path. It remains supported for custom mediation strategies.
+
+### Notes
+
+* No public API changes; no migration steps. Applications resolving mediators from DI see identical behavior.
+* Custom modules registering their own facade should follow suit and use `TryAddTransient`; see the plugins guide.
+
 ## v2.0.0 – '2026-07-25'
 
 First stable release of the v2 line. The theme: **all dispatch-shape work moves to compile time

--- a/examples/AotSmoke/AotSmoke.csproj
+++ b/examples/AotSmoke/AotSmoke.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <!-- Single-TFM override of the repo-wide multi-targeting: the smoke publishes one
+             concrete AOT binary. -->
+        <TargetFramework>net9.0</TargetFramework>
+        <PublishAot>true</PublishAot>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <!-- Trim/AOT analyzer findings in this app or the library fail the smoke instead
+             of scrolling by as warnings. -->
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- The Stella.Ergosfare.* prefix is reserved: reference scanning skips library
+             assemblies, so the app must live outside it to be scanned itself. -->
+        <AssemblyName>Ergosfare.AotSmoke</AssemblyName>
+        <RootNamespace>Ergosfare.AotSmoke</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Stella.Ergosfare\Stella.Ergosfare.csproj" />
+        <ProjectReference Include="..\..\src\Stella.Ergosfare.SourceGenerator\Stella.Ergosfare.SourceGenerator.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+</Project>

--- a/examples/AotSmoke/Directory.Build.props
+++ b/examples/AotSmoke/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+    <!-- Deliberately does not import the repo root props: the smoke app pins a single
+         TFM for its NativeAOT publish, and the repo-wide net10.0;net9.0 multi-targeting
+         would fight that (and misresolve the ILCompiler pack). -->
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/examples/AotSmoke/Program.cs
+++ b/examples/AotSmoke/Program.cs
@@ -1,0 +1,149 @@
+// End-to-end NativeAOT smoke: source-generated registration + every dispatch shape the
+// library advertises for AOT, executed in a PublishAot=true binary. Any failure exits
+// non-zero, so CI treats the published binary's run as the assertion.
+
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+var provider = new ServiceCollection()
+    .AddErgosfare(options =>
+    {
+        options.AddCommandModule(commands => commands.RegisterGenerated());
+        options.AddQueryModule(queries => queries.RegisterGenerated());
+        options.AddEventModule(events => events.RegisterGenerated());
+    })
+    .BuildServiceProvider();
+
+await using var _ = provider;
+
+var failures = new List<string>();
+
+// Void command — the generated void plan's devirtualized, directly-constructed path.
+var commands = provider.GetRequiredService<ICommandMediator>();
+var voidSettings = new CommandMediationSettings();
+await commands.SendAsync(new Ergosfare.AotSmoke.CreateNote(), voidSettings);
+if (!Equals(voidSettings.Items["noteCreated"], true))
+{
+    failures.Add("void command handler did not run");
+}
+
+// Result command — the generated result plan.
+var echoed = await commands.SendAsync(new Ergosfare.AotSmoke.EchoNote { Text = "aot" });
+if (echoed != "aot!")
+{
+    failures.Add($"result command returned '{echoed}', expected 'aot!'");
+}
+
+// Query — result executor over a value-type result.
+var queries = provider.GetRequiredService<IQueryMediator>();
+var answer = await queries.QueryAsync(new Ergosfare.AotSmoke.TheAnswer());
+if (answer != 42)
+{
+    failures.Add($"query returned {answer}, expected 42");
+}
+
+// Class event broadcast with two handlers.
+var events = provider.GetRequiredService<IEventMediator>();
+var publishSettings = new EventMediationSettings();
+await events.PublishAsync(new Ergosfare.AotSmoke.NotePublished(), publishSettings);
+if (!Equals(publishSettings.Items["firstSubscriber"], true) || !Equals(publishSettings.Items["secondSubscriber"], true))
+{
+    failures.Add("event broadcast did not reach both handlers");
+}
+
+// Struct event — the value-type generic instantiations only generated roots anchor
+// under AOT (shared generic code cannot cover them).
+var structSettings = new EventMediationSettings();
+await events.PublishAsync(new Ergosfare.AotSmoke.StructPing(7), structSettings);
+if (!Equals(structSettings.Items["structPayload"], 7))
+{
+    failures.Add("struct event handler did not observe the payload");
+}
+
+if (failures.Count > 0)
+{
+    foreach (var failure in failures)
+    {
+        Console.Error.WriteLine($"AOT smoke FAILED: {failure}");
+    }
+
+    return 1;
+}
+
+Console.WriteLine("AOT smoke passed: all dispatch shapes completed.");
+return 0;
+
+namespace Ergosfare.AotSmoke
+{
+    public sealed class CreateNote : ICommand { }
+
+    public sealed class CreateNoteHandler : ICommandHandler<CreateNote>
+    {
+        public ValueTask HandleAsync(CreateNote command, IExecutionContext context)
+        {
+            context.Set("noteCreated", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class EchoNote : ICommand<string>
+    {
+        public string Text { get; init; } = string.Empty;
+    }
+
+    public sealed class EchoNoteHandler : ICommandHandler<EchoNote, string>
+    {
+        public ValueTask<string> HandleAsync(EchoNote command, IExecutionContext context)
+            => ValueTask.FromResult(command.Text + "!");
+    }
+
+    public sealed class TheAnswer : IQuery<int> { }
+
+    public sealed class TheAnswerHandler : IQueryHandler<TheAnswer, int>
+    {
+        public ValueTask<int> HandleAsync(TheAnswer query, IExecutionContext context)
+            => ValueTask.FromResult(42);
+    }
+
+    public sealed class NotePublished : IEvent { }
+
+    public sealed class FirstNoteSubscriber : IEventHandler<NotePublished>
+    {
+        public ValueTask HandleAsync(NotePublished @event, IExecutionContext context)
+        {
+            context.Set("firstSubscriber", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class SecondNoteSubscriber : IEventHandler<NotePublished>
+    {
+        public ValueTask HandleAsync(NotePublished @event, IExecutionContext context)
+        {
+            context.Set("secondSubscriber", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public readonly struct StructPing(int payload) : IEvent
+    {
+        public int Payload { get; } = payload;
+    }
+
+    public sealed class StructPingHandler : IEventHandler<StructPing>
+    {
+        public ValueTask HandleAsync(StructPing @event, IExecutionContext context)
+        {
+            context.Set("structPayload", @event.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ registry scan, no `AsyncLocal`, and no per-dispatch context allocation on the ho
 |----------|-----------|
 | Compile-time registration | Source generator discovers handlers in your compilation **and referenced assemblies**, pre-computes descriptors, emits `RegisterGenerated()` |
 | Reflection-free dispatch | Generated dispatch roots close executor generics at compile time; pipeline plans pre-close generic handler types |
-| ~2.3 MB / 100k dispatches | Pooled execution contexts, `ValueTask`-first surface, synchronous fast paths (MediatR: 18.3 MB) |
+| ~3.0 ms · ~2.3 MB / 100k dispatches | Pooled execution contexts, `ValueTask`-first surface, straight-through dispatch for single-handler pipelines (MediatR: ~5.8 ms · 18.3 MB) |
 | Nested dispatch | `context.CreateScope()` — isolated child context with inherited cancellation for mediator calls inside handlers |
 | DI-lifetime correctness | Instances resolve per dispatch from the calling scope: singleton → container-cached, scoped → one per scope, transient → one per dispatch |
 | Native AOT & trimming | Every construct referenced statically via `typeof`; dispatch roots anchor all generic instantiations, value-type messages included |
@@ -164,7 +164,7 @@ dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking
 ```
 
 Environment: BenchmarkDotNet v0.15.8 · Windows 11 · AMD Ryzen 7 7800X3D · .NET 9.0.11
-(RyuJIT x86-64-v4). Measured 2026-07-24, on the tree released as v2.0.0.
+(RyuJIT x86-64-v4). Measured 2026-07-28, on the tree released as v2.2.0-preview.
 
 Two shapes are measured, for three mediators:
 
@@ -175,21 +175,28 @@ Two shapes are measured, for three mediators:
 
 | Scenario (100k dispatches/op) | Mean | Allocated | Gen0/1k ops |
 |---|---:|---:|---:|
-| **Ergosfare** — typical usage | 6.87 ms | **2.29 MB** | 47 |
-| **MediatR** — typical usage | 6.09 ms | 18.31 MB | 375 |
-| **LiteBus** — typical usage | 146.96 ms | 714.87 MB | 14 750 |
-| **Ergosfare** — web-server shape | 18.81 ms | 38.91 MB | 813 |
-| **MediatR** — web-server shape | 10.09 ms | 33.57 MB | 688 |
-| Ergosfare — internal engine path (reference row) | 6.49 ms | 5.34 MB | 109 |
+| **Ergosfare** — typical usage | **2.97 ms** | **2.29 MB** | 47 |
+| **MediatR** — typical usage | 5.79 ms | 18.31 MB | 375 |
+| **LiteBus** — typical usage | 139.62 ms | 714.87 MB | 14 750 |
+| **Ergosfare** — web-server shape | **8.46 ms** | **21.36 MB** | 438 |
+| **MediatR** — web-server shape | 10.28 ms | 33.57 MB | 688 |
+| Ergosfare — internal engine path (reference row) | 6.31 ms | 5.34 MB | 109 |
 
 Scenario notes:
 
-- The typical-usage rows are the headline: at comparable latency, Ergosfare allocates
-  **an eighth of MediatR's garbage**, with Gen0 collection pressure down accordingly —
-  the effect of pooled execution contexts and the `ValueTask`-first pipeline.
-- The *internal engine path* row drives `IMessageMediator` directly with pre-built
-  options, bypassing the public facade and its pooled context. It exists to show the
-  facade adds no hidden cost — you would not write application code this way.
+- The typical-usage rows are the headline: Ergosfare runs the loop in **about half
+  MediatR's time** while allocating **an eighth of its garbage**, with Gen0 collection
+  pressure down accordingly — pooled execution contexts and the `ValueTask`-first
+  pipeline for the allocation, straight-through dispatch and the executor's cached plan
+  for the time.
+- The web-server shape is the closer race. Ergosfare leads on both axes, but by ~18% on
+  time against ~36% on allocation, and that row is dominated by DI scope creation, which
+  both libraries pay identically. It read 18.81 ms / 38.91 MB before v2.2.0-preview.
+- The *internal engine path* row drives `IMessageMediator.Mediate` with pre-built
+  `MediateOptions` — a separate entry point that runs its own resolve and mediation
+  strategies, so it reaches neither the executor's cached plan nor the straight-through
+  path. That is why it now trails the public facade. It remains supported for custom
+  mediation strategies; you would not write ordinary application code this way.
 - LiteBus is included as a reference point: Ergosfare's API surface was heavily inspired
   by it, but the runtime is an independent implementation.
 - Transient handlers intentionally allocate one instance per dispatch (that is what a

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,15 @@
 
 ![Ergosfare Logo](./7101c7df-6cac-4b25-994a-60e2adbdc546.png)
 
-[![NuGet (preview)](https://img.shields.io/nuget/vpre/Stella.Ergosfare.svg?label=nuget%20preview)](https://www.nuget.org/packages/Stella.Ergosfare/absoluteLatest)
+[![NuGet](https://img.shields.io/nuget/v/Stella.Ergosfare.svg?label=nuget)](https://www.nuget.org/packages/Stella.Ergosfare)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
-![Tests](https://img.shields.io/github/actions/workflow/status/stellayazilim/Ergosfare/coverage_tests.yml?branch=preview&label=tests)
+![Tests](https://img.shields.io/github/actions/workflow/status/stellayazilim/Ergosfare/coverage_tests.yml?branch=main&label=tests)
 [![Coverage](https://raw.githubusercontent.com/stellayazilim/Ergosfare/badges/.badges/coverage.svg)](https://github.com/stellayazilim/Ergosfare/actions/workflows/coverage_tests.yml)
 
-> **You are on the `preview` branch.** Releases from here are `-preview` pre-releases and
-> APIs may change between them; install with `--prerelease`. The stable line is
-> [`main`](https://github.com/stellayazilim/Ergosfare/tree/main) — see
-> [Versioning & release model](#versioning--release-model).
+> **v2 is the stable line**, released from [`main`](https://github.com/stellayazilim/Ergosfare/tree/main).
+> Work in progress lands on [`preview`](https://github.com/stellayazilim/Ergosfare/tree/preview)
+> first and ships as `-preview` pre-releases; see [Versioning & release model](#versioning--release-model).
+> Coming from v1? See [Migrating from v1 to v2](https://stellayazilim.github.io/ergosfare.docs/migration/v1-to-v2).
 
 - **Docs** → https://stellayazilim.github.io/ergosfare.docs
 - **Changelog** → https://stellayazilim.github.io/ergosfare.changelog
@@ -44,8 +44,8 @@ registry scan, no `AsyncLocal`, and no per-dispatch context allocation on the ho
 ## Quick start
 
 ```bash
-dotnet add package Stella.Ergosfare --prerelease
-dotnet add package Stella.Ergosfare.SourceGenerator --prerelease
+dotnet add package Stella.Ergosfare
+dotnet add package Stella.Ergosfare.SourceGenerator
 ```
 
 ```csharp
@@ -164,7 +164,8 @@ dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking
 ```
 
 Environment: BenchmarkDotNet v0.15.8 · Windows 11 · AMD Ryzen 7 7800X3D · .NET 9.0.11
-(RyuJIT x86-64-v4). Measured 2026-07-28, on the tree released as v2.2.0-preview.
+(RyuJIT x86-64-v4). Measured 2026-07-28, on the tree released as v2.2.0-preview — included
+in stable v2.1.0.
 
 Two shapes are measured, for three mediators:
 
@@ -276,10 +277,10 @@ Current experimental surface: none — the gate is in place for future experimen
 
 ## Installation
 
-Pre-release packages are published to nuget.org and GitHub Packages:
+Packages are published to nuget.org and GitHub Packages:
 
 ```bash
-dotnet add package Stella.Ergosfare --prerelease
+dotnet add package Stella.Ergosfare
 ```
 
 Module packages (`Stella.Ergosfare.Commands`, `.Queries`, `.Events`, plus their

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,15 @@
 
 ![Ergosfare Logo](./7101c7df-6cac-4b25-994a-60e2adbdc546.png)
 
-[![NuGet](https://img.shields.io/nuget/v/Stella.Ergosfare.svg?label=nuget)](https://www.nuget.org/packages/Stella.Ergosfare)
+[![NuGet (preview)](https://img.shields.io/nuget/vpre/Stella.Ergosfare.svg?label=nuget%20preview)](https://www.nuget.org/packages/Stella.Ergosfare/absoluteLatest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
-![Tests](https://img.shields.io/github/actions/workflow/status/stellayazilim/ergosfare/coverage_tests.yml?branch=main&label=tests)
+![Tests](https://img.shields.io/github/actions/workflow/status/stellayazilim/Ergosfare/coverage_tests.yml?branch=preview&label=tests)
 [![Coverage](https://raw.githubusercontent.com/stellayazilim/Ergosfare/badges/.badges/coverage.svg)](https://github.com/stellayazilim/Ergosfare/actions/workflows/coverage_tests.yml)
 
-> **v2 is the stable line**, released from [`main`](https://github.com/stellayazilim/Ergosfare/tree/main).
-> Work in progress lands on [`preview`](https://github.com/stellayazilim/Ergosfare/tree/preview)
-> first and ships as `-preview` pre-releases; see [Versioning & release model](#versioning--release-model).
-> Coming from v1? See [Migrating from v1 to v2](https://stellayazilim.github.io/ergosfare.docs/migration/v1-to-v2).
+> **You are on the `preview` branch.** Releases from here are `-preview` pre-releases and
+> APIs may change between them; install with `--prerelease`. The stable line is
+> [`main`](https://github.com/stellayazilim/Ergosfare/tree/main) — see
+> [Versioning & release model](#versioning--release-model).
 
 - **Docs** → https://stellayazilim.github.io/ergosfare.docs
 - **Changelog** → https://stellayazilim.github.io/ergosfare.changelog
@@ -44,8 +44,8 @@ registry scan, no `AsyncLocal`, and no per-dispatch context allocation on the ho
 ## Quick start
 
 ```bash
-dotnet add package Stella.Ergosfare
-dotnet add package Stella.Ergosfare.SourceGenerator
+dotnet add package Stella.Ergosfare --prerelease
+dotnet add package Stella.Ergosfare.SourceGenerator --prerelease
 ```
 
 ```csharp
@@ -269,10 +269,10 @@ Current experimental surface: none — the gate is in place for future experimen
 
 ## Installation
 
-Packages are published to nuget.org and GitHub Packages:
+Pre-release packages are published to nuget.org and GitHub Packages:
 
 ```bash
-dotnet add package Stella.Ergosfare
+dotnet add package Stella.Ergosfare --prerelease
 ```
 
 Module packages (`Stella.Ergosfare.Commands`, `.Queries`, `.Events`, plus their

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
@@ -28,7 +28,11 @@ internal class CommandModule : IModule
     {
         _builder(new CommandModuleBuilder(configuration.MessageRegistry));
 
-        // Scoped so per-dispatch handler resolution binds to the calling scope's provider.
-        configuration.Services.TryAddScoped<ICommandMediator, CommandMediator>();
+        // Transient: the mediator is a stateless facade whose only per-instance state is the
+        // provider that resolved it — a transient still receives the calling scope's provider,
+        // so per-dispatch handler resolution binds to the right scope. Scoped registration
+        // would pay the scope lock + resolved-services dictionary insert on every fresh
+        // scope (the scope-per-dispatch hot path) with nothing to amortize it.
+        configuration.Services.TryAddTransient<ICommandMediator, CommandMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
@@ -32,7 +32,8 @@ internal class CommandModule : IModule
         // provider that resolved it — a transient still receives the calling scope's provider,
         // so per-dispatch handler resolution binds to the right scope. Scoped registration
         // would pay the scope lock + resolved-services dictionary insert on every fresh
-        // scope (the scope-per-dispatch hot path) with nothing to amortize it.
-        configuration.Services.TryAddTransient<ICommandMediator, CommandMediator>();
+        // scope (the scope-per-dispatch hot path) with nothing to amortize it. The
+        // engine-backed shape makes the facade the only object built per resolution.
+        configuration.Services.TryAddTransient<ICommandMediator, EngineBackedCommandMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/EngineBackedCommandMediator.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/EngineBackedCommandMediator.cs
@@ -1,0 +1,13 @@
+using Stella.Ergosfare.Core;
+
+namespace Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+
+/// <summary>
+/// DI-facing shape of <see cref="CommandMediator"/> with exactly one constructor, so
+/// container activation binds the engine-backed path deterministically — no
+/// multi-constructor ambiguity, and no per-resolution service lookup a factory
+/// registration would pay. Resolving <see cref="Stella.Ergosfare.Commands.Abstractions.ICommandMediator"/>
+/// builds this single object; the engine itself is a process-wide singleton.
+/// </summary>
+internal sealed class EngineBackedCommandMediator(MessageDispatchEngine engine, IServiceProvider serviceProvider)
+    : CommandMediator(engine, serviceProvider);

--- a/src/Stella.Ergosfare.Commands/CommandMediator.cs
+++ b/src/Stella.Ergosfare.Commands/CommandMediator.cs
@@ -1,4 +1,5 @@
 using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 
 namespace Stella.Ergosfare.Commands;
@@ -8,19 +9,68 @@ namespace Stella.Ergosfare.Commands;
 /// runtime type: handlers are always invoked through their typed members, and the dispatch
 /// path carries no object-typed bridge, options object, or erased strategy.
 /// </summary>
-public class CommandMediator(IMessageMediator messageMediator) : ICommandMediator
+public class CommandMediator : ICommandMediator
 {
+    /// <summary>
+    /// The mediator backing the original construction shape; null when the facade is
+    /// engine-backed.
+    /// </summary>
+    private readonly IMessageMediator? _messageMediator;
+
+    /// <summary>
+    /// The singleton dispatch engine; null when the facade wraps an
+    /// <see cref="IMessageMediator"/>.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine;
+
+    /// <summary>
+    /// The scope provider handlers resolve against on the engine path.
+    /// </summary>
+    private readonly IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Wraps an existing <see cref="IMessageMediator"/> — the original construction shape,
+    /// kept for direct construction and foreign mediator implementations.
+    /// </summary>
+    public CommandMediator(IMessageMediator messageMediator)
+    {
+        _messageMediator = messageMediator;
+    }
+
+    /// <summary>
+    /// Engine-backed construction: dispatches go straight to the process-wide engine with
+    /// <paramref name="serviceProvider"/> as the handler-resolution scope, making the
+    /// facade the only object built per resolution.
+    /// </summary>
+    /// <param name="engine">The singleton dispatch engine.</param>
+    /// <param name="serviceProvider">The provider of the scope this facade serves.</param>
+    public CommandMediator(MessageDispatchEngine engine, IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _engine = engine;
+        _serviceProvider = serviceProvider;
+    }
+
     /// <summary>
     /// Sends a void command through the executor pipeline.
     /// </summary>
     public ValueTask SendAsync(ICommand commandConstruct, CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return messageMediator.DispatchAsync(
-            commandConstruct,
-            commandMediationSettings?.Items,
-            cancellationToken,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync(
+                commandConstruct,
+                _serviceProvider!,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync(
+                commandConstruct,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
@@ -35,11 +85,18 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
         CommandMediationSettings? commandMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            commandConstruct,
-            commandMediationSettings?.Items,
-            cancellationToken,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                commandConstruct,
+                _serviceProvider!,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                commandConstruct,
+                commandMediationSettings?.Items,
+                cancellationToken,
+                commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
@@ -51,10 +108,16 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
     public ValueTask SendAsync(ICommand commandConstruct, IExecutionContext context,
         CommandMediationSettings? commandMediationSettings = null)
     {
-        return messageMediator.DispatchAsync(
-            commandConstruct,
-            context,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync(
+                commandConstruct,
+                context,
+                _serviceProvider!,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync(
+                commandConstruct,
+                context,
+                commandMediationSettings?.Filters.Groups);
     }
 
     /// <summary>
@@ -64,9 +127,15 @@ public class CommandMediator(IMessageMediator messageMediator) : ICommandMediato
     public ValueTask<TResult> SendAsync<TResult>(ICommand<TResult> commandConstruct, IExecutionContext context,
         CommandMediationSettings? commandMediationSettings = null)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            commandConstruct,
-            context,
-            commandMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                commandConstruct,
+                context,
+                _serviceProvider!,
+                commandMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                commandConstruct,
+                context,
+                commandMediationSettings?.Filters.Groups);
     }
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
@@ -20,6 +20,7 @@ public static class GeneratedDispatchRoots
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Results = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Streams = new();
     private static readonly ConcurrentDictionary<Type, VoidPlanRoot> VoidPlans = new();
+    private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), ResultPlanRoot> ResultPlans = new();
 
     /// <summary>Roots the void dispatch generics of a message type. Idempotent.</summary>
     public static void AddMessage<TMessage>() where TMessage : IMessage
@@ -59,9 +60,51 @@ public static class GeneratedDispatchRoots
         where THandler : class, IAsyncHandler<TMessage>
         => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>());
 
+    /// <summary>
+    /// Variant of <see cref="AddVoidPlan{TMessage, THandler}()"/> carrying a compile-time
+    /// construction path for the handler: the generator emits
+    /// <c>static () => new THandler()</c> for handlers with an accessible parameterless
+    /// constructor that are not disposable. The factory is advisory like the plan itself —
+    /// the executor uses it only after verifying at runtime that the handler's DI
+    /// registration is the module's own plain transient one (no user factory, no lifetime
+    /// override, not memoized), where container resolution and direct construction are
+    /// semantically identical. Idempotent.
+    /// </summary>
+    public static void AddVoidPlan<TMessage, THandler>(Func<THandler> directHandlerFactory)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>
+        => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>(directHandlerFactory));
+
     /// <summary>The void pipeline plan of the message type, or <c>null</c> when none was generated.</summary>
     public static VoidPlanRoot? FindVoidPlan(Type messageType)
         => VoidPlans.TryGetValue(messageType, out var root) ? root : null;
+
+    /// <summary>
+    /// Result-producing counterpart of <see cref="AddVoidPlan{TMessage, THandler}()"/>:
+    /// roots a compile-time pipeline plan for a message whose entire pipeline is a single
+    /// async result handler, so the dispatch executor invokes it devirtualized. The plan
+    /// is advisory and re-validated per registry version exactly like the void plan.
+    /// Idempotent.
+    /// </summary>
+    public static void AddResultPlan<TMessage, TResult, THandler>()
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>
+        => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>());
+
+    /// <summary>
+    /// Variant of <see cref="AddResultPlan{TMessage, TResult, THandler}()"/> carrying the
+    /// compile-time handler construction path; see
+    /// <see cref="AddVoidPlan{TMessage, THandler}(Func{THandler})"/> for the contract.
+    /// Idempotent.
+    /// </summary>
+    public static void AddResultPlan<TMessage, TResult, THandler>(Func<THandler> directHandlerFactory)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>
+        => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>(directHandlerFactory));
+
+    /// <summary>The result pipeline plan of the (message, result) pair, or <c>null</c> when none was generated.</summary>
+    public static ResultPlanRoot? FindResultPlan(Type messageType, Type resultType)
+        => ResultPlans.TryGetValue((messageType, resultType), out var root) ? root : null;
 }
 
 /// <summary>
@@ -125,6 +168,13 @@ public abstract class VoidPlanRoot
 {
     /// <summary>Invokes the visitor with this plan's message and handler types as the generic arguments.</summary>
     public abstract TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state);
+
+    /// <summary>
+    /// The compile-time handler construction path — a <c>Func&lt;THandler&gt;</c> carried
+    /// erased, cast back inside the executor's closed generic context — or <c>null</c>
+    /// when the generator emitted no factory for the handler.
+    /// </summary>
+    internal virtual object? DirectHandlerFactory => null;
 }
 
 /// <summary>The concrete closure of <see cref="VoidPlanRoot"/>; instantiated by generated code.</summary>
@@ -132,6 +182,18 @@ public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
+    private readonly Func<THandler>? _directHandlerFactory;
+
+    /// <summary>Creates a plan without a compile-time construction path.</summary>
+    public VoidPlanRoot()
+    {
+    }
+
+    internal VoidPlanRoot(Func<THandler> directHandlerFactory)
+        => _directHandlerFactory = directHandlerFactory;
+
+    internal override object? DirectHandlerFactory => _directHandlerFactory;
+
     /// <inheritdoc />
     public override TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state)
         => visitor.Visit<TMessage, THandler>(state);
@@ -144,4 +206,49 @@ public interface IVoidPlanRootVisitor<out TReturn, in TState>
     TReturn Visit<TMessage, THandler>(TState state)
         where TMessage : notnull, IMessage
         where THandler : class, IAsyncHandler<TMessage>;
+}
+
+/// <summary>
+/// A compile-time pipeline plan closed over a result-producing message, its result type
+/// and its sole async handler; the result-producing counterpart of
+/// <see cref="VoidPlanRoot"/>.
+/// </summary>
+public abstract class ResultPlanRoot
+{
+    /// <summary>Invokes the visitor with this plan's message, result and handler types as the generic arguments.</summary>
+    public abstract TReturn Accept<TReturn, TState>(IResultPlanRootVisitor<TReturn, TState> visitor, TState state);
+
+    /// <inheritdoc cref="VoidPlanRoot.DirectHandlerFactory"/>
+    internal virtual object? DirectHandlerFactory => null;
+}
+
+/// <summary>The concrete closure of <see cref="ResultPlanRoot"/>; instantiated by generated code.</summary>
+public sealed class ResultPlanRoot<TMessage, TResult, THandler> : ResultPlanRoot
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage, TResult>
+{
+    private readonly Func<THandler>? _directHandlerFactory;
+
+    /// <summary>Creates a plan without a compile-time construction path.</summary>
+    public ResultPlanRoot()
+    {
+    }
+
+    internal ResultPlanRoot(Func<THandler> directHandlerFactory)
+        => _directHandlerFactory = directHandlerFactory;
+
+    internal override object? DirectHandlerFactory => _directHandlerFactory;
+
+    /// <inheritdoc />
+    public override TReturn Accept<TReturn, TState>(IResultPlanRootVisitor<TReturn, TState> visitor, TState state)
+        => visitor.Visit<TMessage, TResult, THandler>(state);
+}
+
+/// <summary>Generic re-entry point for consumers of <see cref="ResultPlanRoot"/>.</summary>
+public interface IResultPlanRootVisitor<out TReturn, in TState>
+{
+    /// <summary>Called with the plan's message, result and handler types as the generic arguments.</summary>
+    TReturn Visit<TMessage, TResult, THandler>(TState state)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>;
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 
@@ -18,6 +19,7 @@ public static class GeneratedDispatchRoots
     private static readonly ConcurrentDictionary<Type, MessageRoot> Messages = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Results = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Streams = new();
+    private static readonly ConcurrentDictionary<Type, VoidPlanRoot> VoidPlans = new();
 
     /// <summary>Roots the void dispatch generics of a message type. Idempotent.</summary>
     public static void AddMessage<TMessage>() where TMessage : IMessage
@@ -42,6 +44,24 @@ public static class GeneratedDispatchRoots
     /// <summary>The stream dispatch root of the (message, result) pair, or <c>null</c> when none was generated.</summary>
     public static MessageResultRoot? FindStream(Type messageType, Type resultType)
         => Streams.TryGetValue((messageType, resultType), out var root) ? root : null;
+
+    /// <summary>
+    /// Roots a compile-time pipeline plan for a void message whose entire pipeline is a
+    /// single async handler: the dispatch executor closes over both the message and the
+    /// handler type, so the handler is invoked devirtualized — no contract pattern match.
+    /// The plan is advisory: the executor re-validates the actual pipeline against the
+    /// registry on every version change and falls back to the runtime dispatch shape
+    /// whenever the pipeline no longer matches (interceptors registered at runtime, a
+    /// different handler resolved, adapters configured). Idempotent.
+    /// </summary>
+    public static void AddVoidPlan<TMessage, THandler>()
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>
+        => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>());
+
+    /// <summary>The void pipeline plan of the message type, or <c>null</c> when none was generated.</summary>
+    public static VoidPlanRoot? FindVoidPlan(Type messageType)
+        => VoidPlans.TryGetValue(messageType, out var root) ? root : null;
 }
 
 /// <summary>
@@ -94,4 +114,34 @@ public interface IMessageResultRootVisitor<out TReturn, in TState>
 {
     /// <summary>Called with the root's message and result types as the generic arguments.</summary>
     TReturn Visit<TMessage, TResult>(TState state) where TMessage : IMessage;
+}
+
+/// <summary>
+/// A compile-time pipeline plan closed over a void message and its sole async handler;
+/// see <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}"/> and
+/// <see cref="MessageRoot"/> for the visitor re-entry pattern.
+/// </summary>
+public abstract class VoidPlanRoot
+{
+    /// <summary>Invokes the visitor with this plan's message and handler types as the generic arguments.</summary>
+    public abstract TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state);
+}
+
+/// <summary>The concrete closure of <see cref="VoidPlanRoot"/>; instantiated by generated code.</summary>
+public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage>
+{
+    /// <inheritdoc />
+    public override TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state)
+        => visitor.Visit<TMessage, THandler>(state);
+}
+
+/// <summary>Generic re-entry point for consumers of <see cref="VoidPlanRoot"/>.</summary>
+public interface IVoidPlanRootVisitor<out TReturn, in TState>
+{
+    /// <summary>Called with the plan's message and handler types as the generic arguments.</summary>
+    TReturn Visit<TMessage, THandler>(TState state)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>;
 }

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -89,23 +89,61 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
             RegisterHandlersFromDescriptor(descriptor, allHandlerTypes);
         }
 
-        // Capture the effective DI lifetime of every handler type (a user registration made
-        // before AddErgosfare wins over the TryAddTransient defaults above). Messages whose
-        // whole pipeline is singleton-registered keep the memoized fast path; the rest are
-        // resolved per scope so scoped/transient dependencies are honored.
-        var handlerLifetimes = new Dictionary<Type, ServiceLifetime>();
-        foreach (var serviceDescriptor in services)
-        {
-            if (allHandlerTypes.Contains(serviceDescriptor.ServiceType))
-            {
-                handlerLifetimes[serviceDescriptor.ServiceType] = serviceDescriptor.Lifetime;
-            }
-        }
-
-        services.TryAddSingleton(new HandlerLifetimeRegistry(handlerLifetimes));
+        // The lifetime registry is registered as a FACTORY so the capture runs at first
+        // resolution — after BuildServiceProvider, when the collection is final. A snapshot
+        // taken here (inside AddErgosfare) would miss registrations the user adds
+        // afterwards; for memoization that staleness only cost the fast path, but the
+        // plans' direct-construction gate must never claim a handler whose effective
+        // registration the user has overridden. The captured set of handler types keeps
+        // the scan bounded to pipeline participants.
+        var registeredHandlerTypes = allHandlerTypes;
+        services.TryAddSingleton(_ => CaptureHandlerLifetimes(services, registeredHandlerTypes));
     }
     
     
+    /// <summary>
+    /// Builds the lifetime registry from the finalized service collection: the effective
+    /// DI lifetime of every handler type (last registration wins, mirroring
+    /// <c>GetRequiredService</c>), and the subset whose effective registration is a plain
+    /// transient self-registration — the shape the module's own <c>TryAddTransient</c>
+    /// produces, and the only shape for which a generated plan may construct the handler
+    /// directly. Keyed descriptors throw on the implementation members, so they are
+    /// excluded up front.
+    /// </summary>
+    private static HandlerLifetimeRegistry CaptureHandlerLifetimes(
+        IServiceCollection services, HashSet<Type> handlerTypes)
+    {
+        var handlerLifetimes = new Dictionary<Type, ServiceLifetime>();
+        var plainTransientRegistrations = new HashSet<Type>();
+
+        foreach (var serviceDescriptor in services)
+        {
+            if (!handlerTypes.Contains(serviceDescriptor.ServiceType))
+            {
+                continue;
+            }
+
+            handlerLifetimes[serviceDescriptor.ServiceType] = serviceDescriptor.Lifetime;
+
+            var isPlain = !serviceDescriptor.IsKeyedService
+                          && serviceDescriptor.Lifetime == ServiceLifetime.Transient
+                          && serviceDescriptor.ImplementationType == serviceDescriptor.ServiceType
+                          && serviceDescriptor.ImplementationFactory is null
+                          && serviceDescriptor.ImplementationInstance is null;
+
+            if (isPlain)
+            {
+                plainTransientRegistrations.Add(serviceDescriptor.ServiceType);
+            }
+            else
+            {
+                plainTransientRegistrations.Remove(serviceDescriptor.ServiceType);
+            }
+        }
+
+        return new HandlerLifetimeRegistry(handlerLifetimes, plainTransientRegistrations);
+    }
+
     /// <summary>
     /// Collects and registers all handler types defined in the given message descriptor.
     /// </summary>

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -67,6 +67,12 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
         // insert that a fresh scope per dispatch would pay on every single dispatch.
         services.TryAddSingleton<IMessageDependenciesFactory, MessageDependenciesFactory>();
         services.TryAddSingleton<PipelineExecutorCache>();
+        // Factory registration because the engine's constructor is internal (the type is
+        // only meaningful wired to the executor cache); singleton, so the cost is paid once
+        // per container while every facade resolution ctor-injects it as a constant.
+        services.TryAddSingleton(static sp => new MessageDispatchEngine(
+            sp.GetRequiredService<PipelineExecutorCache>(),
+            sp.GetRequiredService<IMessageDependenciesFactory>()));
         services.TryAddTransient<IMessageMediator, MessageMediator>();
         services.TryAddSingleton<IDescriptorCacheStrategy, LruCacheStrategy>();
         services.TryAddSingleton<MessageDescriptorCache>();

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -61,11 +61,13 @@ public class ModuleRegistry(IServiceCollection services, IMessageRegistry messag
         }
         // The factory and its dependency graphs are provider-independent and cached
         // process-wide; handler instances resolve per invocation from the execution
-        // context's provider. The mediator stays scoped only to capture the calling
-        // scope's provider into that context — it is a thin, cheap wrapper.
+        // context's provider. The mediator exists only to capture the calling scope's
+        // provider — a transient does that too (DI hands it the resolving scope's
+        // provider), without the scoped-resolution lock and resolved-services dictionary
+        // insert that a fresh scope per dispatch would pay on every single dispatch.
         services.TryAddSingleton<IMessageDependenciesFactory, MessageDependenciesFactory>();
         services.TryAddSingleton<PipelineExecutorCache>();
-        services.TryAddScoped<IMessageMediator, MessageMediator>();
+        services.TryAddTransient<IMessageMediator, MessageMediator>();
         services.TryAddSingleton<IDescriptorCacheStrategy, LruCacheStrategy>();
         services.TryAddSingleton<MessageDescriptorCache>();
         services.TryAddSingleton<RootServiceProviderAccessor>();

--- a/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
@@ -22,6 +22,15 @@ internal sealed class ErgosfareExecutionContext(
     private IDictionary<object, object?>? _items = items;
 
     /// <summary>
+    /// Whether <see cref="_items"/> was created lazily by this context (owned) as opposed
+    /// to adopted from the caller (a settings object's dictionary). Owned dictionaries are
+    /// cleared and kept across pool reuses for their capacity; adopted ones are detached
+    /// untouched on <see cref="Clear"/> — the caller keeps whatever handlers wrote, and the
+    /// pool can never hand one dispatch's dictionary to the next.
+    /// </summary>
+    private bool _ownsItems;
+
+    /// <summary>
     /// Gets the <see cref="CancellationToken"/> associated with the current execution context.
     /// This token can be used to observe cancellation requests and propagate them to handlers or interceptors.
     /// </summary>
@@ -33,7 +42,19 @@ internal sealed class ErgosfareExecutionContext(
     /// The backing dictionary is created lazily on first access so dispatches that never
     /// touch shared items pay no allocation for it.
     /// </summary>
-    public IDictionary<object, object?> Items => _items ??= new Dictionary<object, object?>();
+    public IDictionary<object, object?> Items
+    {
+        get
+        {
+            if (_items is null)
+            {
+                _items = new Dictionary<object, object?>();
+                _ownsItems = true;
+            }
+
+            return _items;
+        }
+    }
 
     /// <summary>Re-initializes a pooled instance for a new dispatch.</summary>
     public void Reset(IDictionary<object, object?>? items, CancellationToken cancellationToken)
@@ -41,6 +62,7 @@ internal sealed class ErgosfareExecutionContext(
         if (items is not null)
         {
             _items = items;
+            _ownsItems = false;
         }
 
         CancellationToken = cancellationToken;
@@ -53,7 +75,23 @@ internal sealed class ErgosfareExecutionContext(
     /// </summary>
     public void Clear()
     {
-        _items?.Clear();
+        if (_items is not null)
+        {
+            if (_ownsItems)
+            {
+                // Lazily created here: clear and keep, so the capacity is reused.
+                _items.Clear();
+            }
+            else
+            {
+                // Adopted from the caller: detach without touching its contents — the
+                // caller reads results from it, and clearing it here would silently wipe
+                // their settings object (and retaining it would leak it into the next
+                // dispatch that rents this context).
+                _items = null;
+            }
+        }
+
         CancellationToken = default;
     }
 

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -31,6 +31,21 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
     private IServiceProvider? _memoizedGraphProvider;
     private bool _servicesResolved;
 
+    /// <summary>
+    /// The current registry version, or <see cref="int.MinValue"/> before the first
+    /// <see cref="Create"/> resolves the registry. Executors compare this against the
+    /// version their cached dependencies were built at and skip <see cref="Create"/>
+    /// entirely on a match.
+    /// </summary>
+    internal int CurrentRegistryVersion
+        => !_servicesResolved
+            ? int.MinValue
+            : _registry is null
+                ? int.MinValue
+                : _registry is MessageRegistry typedRegistry
+                    ? typedRegistry.Version
+                    : _registry.Count;
+
     public IMessageDependencies Create(Type messageType, IMessageDescriptor descriptor, IEnumerable<string> groups)
     {
         var cache = _cache ??= serviceProvider.GetRequiredService<MessageDescriptorCache>();

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -46,6 +46,16 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
                     ? typedRegistry.Version
                     : _registry.Count;
 
+    /// <summary>
+    /// Whether the handler type's effective DI registration is the module's own plain
+    /// transient shape, making container resolution and direct construction semantically
+    /// identical; see <see cref="HandlerLifetimeRegistry.IsPlainTransientRegistration"/>.
+    /// Always <c>false</c> before the first <see cref="Create"/> resolves the registry —
+    /// executors only consult this after building their dependencies.
+    /// </summary>
+    internal bool IsPlainTransientRegistration(Type handlerType)
+        => _servicesResolved && (_handlerLifetimes?.IsPlainTransientRegistration(handlerType) ?? false);
+
     public IMessageDependencies Create(Type messageType, IMessageDescriptor descriptor, IEnumerable<string> groups)
     {
         var cache = _cache ??= serviceProvider.GetRequiredService<MessageDescriptorCache>();

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
@@ -64,8 +64,10 @@ internal sealed class MessageDependencies : IMessageDependencies
     /// </param>
     public MessageDependencies(MessagePipelineShape shape, IServiceProvider? memoizedProvider)
     {
-        Handlers = Materialize<IHandler, IMainHandlerDescriptor>(shape.Handlers, memoizedProvider);
-        IndirectHandlers = Materialize<IHandler, IMainHandlerDescriptor>(shape.IndirectHandlers, memoizedProvider);
+        HandlerArray = Materialize<IHandler, IMainHandlerDescriptor>(shape.Handlers, memoizedProvider);
+        IndirectHandlerArray = Materialize<IHandler, IMainHandlerDescriptor>(shape.IndirectHandlers, memoizedProvider);
+        Handlers = HandlerArray;
+        IndirectHandlers = IndirectHandlerArray;
         PreInterceptors = Materialize<IPreInterceptor, IPreInterceptorDescriptor>(shape.PreInterceptors, memoizedProvider);
         PostInterceptors = Materialize<IPostInterceptor, IPostInterceptorDescriptor>(shape.PostInterceptors, memoizedProvider);
         ExceptionInterceptors = Materialize<IExceptionInterceptor, IExceptionInterceptorDescriptor>(shape.ExceptionInterceptors, memoizedProvider);
@@ -74,15 +76,28 @@ internal sealed class MessageDependencies : IMessageDependencies
         // Precomputed once per (message type, groups): the exact condition the single-handler
         // strategies use for their zero-interceptor fast path. Executors read this to invoke
         // the handler directly, without entering the strategy's async machinery.
-        FastSingleHandler =
-            Handlers.Count == 1
-            && PreInterceptors.Count == 0
+        HasNoInterceptors =
+            PreInterceptors.Count == 0
             && PostInterceptors.Count == 0
             && ExceptionInterceptors.Count == 0
-            && FinalInterceptors.Count == 0
-                ? Handlers[0]
-                : null;
+            && FinalInterceptors.Count == 0;
+
+        FastSingleHandler = HasNoInterceptors && Handlers.Count == 1 ? Handlers[0] : null;
     }
+
+    /// <summary>
+    /// The main-handler stages as concrete arrays, so hot loops index without interface
+    /// dispatch. Same instances the <see cref="Handlers"/>/<see cref="IndirectHandlers"/>
+    /// properties expose.
+    /// </summary>
+    internal IHandlerReference<IHandler, IMainHandlerDescriptor>[] HandlerArray { get; }
+    internal IHandlerReference<IHandler, IMainHandlerDescriptor>[] IndirectHandlerArray { get; }
+
+    /// <summary>
+    /// Whether all four interceptor stages are empty — the broadcast fast path's
+    /// eligibility condition, computed once at construction.
+    /// </summary>
+    internal bool HasNoInterceptors { get; }
 
     /// <summary>
     /// The sole main handler when the pipeline has exactly one handler and no interceptor

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
@@ -70,7 +70,25 @@ internal sealed class MessageDependencies : IMessageDependencies
         PostInterceptors = Materialize<IPostInterceptor, IPostInterceptorDescriptor>(shape.PostInterceptors, memoizedProvider);
         ExceptionInterceptors = Materialize<IExceptionInterceptor, IExceptionInterceptorDescriptor>(shape.ExceptionInterceptors, memoizedProvider);
         FinalInterceptors = Materialize<IFinalInterceptor, IFinalInterceptorDescriptor>(shape.FinalInterceptors, memoizedProvider);
+
+        // Precomputed once per (message type, groups): the exact condition the single-handler
+        // strategies use for their zero-interceptor fast path. Executors read this to invoke
+        // the handler directly, without entering the strategy's async machinery.
+        FastSingleHandler =
+            Handlers.Count == 1
+            && PreInterceptors.Count == 0
+            && PostInterceptors.Count == 0
+            && ExceptionInterceptors.Count == 0
+            && FinalInterceptors.Count == 0
+                ? Handlers[0]
+                : null;
     }
+
+    /// <summary>
+    /// The sole main handler when the pipeline has exactly one handler and no interceptor
+    /// stages; <c>null</c> otherwise. Computed once at construction.
+    /// </summary>
+    internal IHandlerReference<IHandler, IMainHandlerDescriptor>? FastSingleHandler { get; }
 
     /// <summary>
     /// Wraps the shape's planned handlers in resolvable references. Runs once per

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
@@ -83,6 +83,7 @@ internal sealed class MessageDependencies : IMessageDependencies
             && FinalInterceptors.Count == 0;
 
         FastSingleHandler = HasNoInterceptors && Handlers.Count == 1 ? Handlers[0] : null;
+        MemoizedInstances = memoizedProvider is not null;
     }
 
     /// <summary>
@@ -104,6 +105,13 @@ internal sealed class MessageDependencies : IMessageDependencies
     /// stages; <c>null</c> otherwise. Computed once at construction.
     /// </summary>
     internal IHandlerReference<IHandler, IMainHandlerDescriptor>? FastSingleHandler { get; }
+
+    /// <summary>
+    /// Whether references resolve once and cache the instance (memoized mode). Generated
+    /// plans must not construct handlers directly in this mode — the memoized instance is
+    /// the semantic contract.
+    /// </summary>
+    internal bool MemoizedInstances { get; }
 
     /// <summary>
     /// Wraps the shape's planned handlers in resolvable references. Runs once per

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -143,6 +143,17 @@ internal sealed class MessageMediator(
         return executor.Execute(message, context, _serviceProvider);
     }
 
+    /// <summary>
+    /// The provider of the scope this mediator was resolved from — the broadcast fast lane
+    /// (events assembly, via InternalsVisibleTo) dispatches strategies against it directly.
+    /// </summary>
+    internal IServiceProvider ScopeProvider => _serviceProvider;
+
+    /// <summary>
+    /// The dependencies factory backing this mediator; see <see cref="ScopeProvider"/>.
+    /// </summary>
+    internal IMessageDependenciesFactory DependenciesFactory => _messageDependenciesFactory;
+
     private PipelineExecutorCache RequireExecutorCache()
         => _executorCache ?? throw new InvalidOperationException(
             "Executor dispatch requires the PipelineExecutorCache; register Ergosfare through AddErgosfare or use Mediate with explicit options.");

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageMediator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
@@ -23,58 +22,16 @@ internal sealed class MessageMediator(
     IMessageRegistry messageRegistry,
     IMessageDependenciesFactory messageDependenciesFactory,
     IServiceProvider serviceProvider,
-    PipelineExecutorCache? executorCache = null)
+    PipelineExecutorCache? executorCache = null,
+    MessageDispatchEngine? engine = null)
     : IMessageMediator
 {
-    /// <summary>
-    /// Process-wide executor cache used by the <see cref="DispatchAsync(object,IDictionary{object,object?},CancellationToken,IEnumerable{string})"/>
-    /// path. Optional so directly-constructed mediators (tests) keep working; the DI
-    /// registration always supplies it.
-    /// </summary>
-    private readonly PipelineExecutorCache? _executorCache = executorCache;
-
     /// <inheritdoc />
     public ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var executor = RequireExecutorCache().GetVoidExecutor(message.GetType(), groups);
-        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
-        ValueTask task;
-
-        try
-        {
-            task = executor.Execute(message, context, _serviceProvider);
-        }
-        catch
-        {
-            ErgosfareExecutionContextPool.Return(context);
-            throw;
-        }
-
-        // Synchronously completed dispatches (the common case) return the context inline —
-        // no async state machine on the hot path. Only a genuinely suspended pipeline pays
-        // for the awaiting helper.
-        if (task.IsCompletedSuccessfully)
-        {
-            ErgosfareExecutionContextPool.Return(context);
-            return default;
-        }
-
-        return AwaitAndReturn(task, context);
-
-        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
-        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
-        {
-            try
-            {
-                await task;
-            }
-            finally
-            {
-                ErgosfareExecutionContextPool.Return(context);
-            }
-        }
+        return RequireEngine().DispatchAsync(message, _serviceProvider, items, cancellationToken, groups);
     }
 
     /// <inheritdoc />
@@ -82,41 +39,7 @@ internal sealed class MessageMediator(
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var executor = RequireExecutorCache().GetExecutor<TResult>(message.GetType(), groups);
-        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
-        ValueTask<TResult> task;
-
-        try
-        {
-            task = executor.Execute(message, context, _serviceProvider);
-        }
-        catch
-        {
-            ErgosfareExecutionContextPool.Return(context);
-            throw;
-        }
-
-        if (task.IsCompletedSuccessfully)
-        {
-            var result = task.Result;
-            ErgosfareExecutionContextPool.Return(context);
-            return new ValueTask<TResult>(result);
-        }
-
-        return AwaitAndReturn(task, context);
-
-        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
-        static async ValueTask<TResult> AwaitAndReturn(ValueTask<TResult> task, ErgosfareExecutionContext context)
-        {
-            try
-            {
-                return await task;
-            }
-            finally
-            {
-                ErgosfareExecutionContextPool.Return(context);
-            }
-        }
+        return RequireEngine().DispatchAsync<TResult>(message, _serviceProvider, items, cancellationToken, groups);
     }
 
     /// <inheritdoc />
@@ -125,11 +48,7 @@ internal sealed class MessageMediator(
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(context);
 
-        // Caller-owned context (typically a scope's child): the caller controls its
-        // lifetime, so nothing is rented or returned here.
-        var executor = RequireExecutorCache().GetVoidExecutor(message.GetType(), groups);
-
-        return executor.Execute(message, context, _serviceProvider);
+        return RequireEngine().DispatchAsync(message, context, _serviceProvider, groups);
     }
 
     /// <inheritdoc />
@@ -138,9 +57,7 @@ internal sealed class MessageMediator(
         ArgumentNullException.ThrowIfNull(message);
         ArgumentNullException.ThrowIfNull(context);
 
-        var executor = RequireExecutorCache().GetExecutor<TResult>(message.GetType(), groups);
-
-        return executor.Execute(message, context, _serviceProvider);
+        return RequireEngine().DispatchAsync<TResult>(message, context, _serviceProvider, groups);
     }
 
     /// <summary>
@@ -154,8 +71,8 @@ internal sealed class MessageMediator(
     /// </summary>
     internal IMessageDependenciesFactory DependenciesFactory => _messageDependenciesFactory;
 
-    private PipelineExecutorCache RequireExecutorCache()
-        => _executorCache ?? throw new InvalidOperationException(
+    private MessageDispatchEngine RequireEngine()
+        => _engine ?? throw new InvalidOperationException(
             "Executor dispatch requires the PipelineExecutorCache; register Ergosfare through AddErgosfare or use Mediate with explicit options.");
 
 
@@ -175,6 +92,16 @@ internal sealed class MessageMediator(
     /// strategy on each dispatch so handlers resolve against the calling scope.
     /// </summary>
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+    /// <summary>
+    /// The dispatch engine the executor overloads delegate to. DI injects the container's
+    /// singleton; directly-constructed mediators (tests) that supply only an executor cache
+    /// get a private engine wrapping it, preserving the original optional-cache contract.
+    /// Declared after the null-validated fields above so a null factory still fails their
+    /// argument checks first.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine =
+        engine ?? (executorCache is null ? null : new MessageDispatchEngine(executorCache, messageDependenciesFactory));
 
     
     /// <summary>

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -184,6 +184,23 @@ internal sealed class PipelineExecutorCache(
     private readonly ConcurrentDictionary<Type, IPipelineExecutor> _voidExecutorsByType = new();
     private readonly ConcurrentDictionary<(Type MessageType, Type ResultType), object> _resultExecutorsByType = new();
 
+    // Last-used result executor per message type: one Type-keyed lookup plus a reference
+    // equality check replaces the composite (message, result) key's tuple hashing on the
+    // result hot path — a message type practically has a single result type. A slot miss
+    // falls back to the composite store above, which stays authoritative so executor
+    // identity (and its dependency cache) is preserved even when result types alternate.
+    private readonly ConcurrentDictionary<Type, ResultExecutorSlot> _resultSlotsByType = new();
+
+    /// <summary>
+    /// Immutable (result type, executor) pair — immutability makes the racy slot refresh
+    /// safe: a reader that observes the reference sees both fields.
+    /// </summary>
+    private sealed class ResultExecutorSlot(Type resultType, object executor)
+    {
+        public readonly Type ResultType = resultType;
+        public readonly object Executor = executor;
+    }
+
     public IPipelineExecutor GetVoidExecutor(Type messageType, IEnumerable<string>? groups = null)
     {
         if (groups is null)
@@ -214,16 +231,16 @@ internal sealed class PipelineExecutorCache(
     {
         if (groups is null)
         {
-            if (_resultExecutorsByType.TryGetValue((messageType, typeof(TResult)), out var fast))
+            if (_resultSlotsByType.TryGetValue(messageType, out var slot)
+                && ReferenceEquals(slot.ResultType, typeof(TResult)))
             {
-                // Entries are only ever created as IPipelineExecutor<TResult> for their
-                // (message, result) key, so the interface cast can skip the runtime
+                // Slot entries are only ever created as IPipelineExecutor<TResult> for
+                // their recorded result type, so the interface cast can skip the runtime
                 // covariance check — a measurable cost on the hot path.
-                return Unsafe.As<IPipelineExecutor<TResult>>(fast);
+                return Unsafe.As<IPipelineExecutor<TResult>>(slot.Executor);
             }
 
-            return (IPipelineExecutor<TResult>)_resultExecutorsByType.GetOrAdd((messageType, typeof(TResult)),
-                static (k, cache) => cache.CreateResultExecutor(k.MessageType, k.ResultType, EmptyGroups), this);
+            return GetExecutorSlow<TResult>(messageType);
         }
 
         var materializedGroups = MaterializeGroups(groups);
@@ -237,6 +254,23 @@ internal sealed class PipelineExecutorCache(
         }
 
         return (IPipelineExecutor<TResult>)executor;
+    }
+
+    /// <summary>
+    /// Slot miss for the group-less result dispatch: resolve (or create) the executor in
+    /// the authoritative composite store, then refresh the message type's last-used slot.
+    /// Rare by construction — first dispatch per message type, or alternating result
+    /// types on one message type.
+    /// </summary>
+    private IPipelineExecutor<TResult> GetExecutorSlow<TResult>(Type messageType)
+    {
+        var executor = (IPipelineExecutor<TResult>)_resultExecutorsByType.GetOrAdd(
+            (messageType, typeof(TResult)),
+            static (k, cache) => cache.CreateResultExecutor(k.MessageType, k.ResultType, EmptyGroups), this);
+
+        _resultSlotsByType[messageType] = new ResultExecutorSlot(typeof(TResult), executor);
+
+        return executor;
     }
 
     private static string GroupsKey(string[] groups)

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -164,6 +164,90 @@ internal sealed class VoidPipelineExecutor<TMessage>(
 }
 
 /// <summary>
+/// Void pipeline closed over both the message and its compile-time-known sole handler —
+/// the executor a generated void plan constructs. The fast path resolves the handler
+/// reference exactly like <see cref="VoidPipelineExecutor{TMessage}"/> but invokes it
+/// through the closed <typeparamref name="THandler"/> type, so the call devirtualizes
+/// (and inlines for sealed handlers) instead of walking the contract pattern match. The
+/// plan is advisory: the same registry-version-guarded dependency cache re-validates the
+/// pipeline, and any mismatch — interceptors registered at runtime, a differently-typed
+/// handler instance, configured adapters — falls back to the runtime dispatch shape,
+/// preserving semantics exactly.
+/// </summary>
+internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups) : IPipelineExecutor
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage>
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);
+
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependencies? _cachedFastDependencies;
+    private int _cachedVersion = int.MinValue;
+
+    public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = GetDependencies();
+
+        if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
+            && !_foreignAdapters
+            && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
+        {
+            var handler = handlerReference.Resolve(serviceProvider);
+
+            // The compile-time plan's handler type: a devirtualized call, no pattern
+            // match. A runtime re-registration can put a differently-typed handler here;
+            // the contract switch below then dispatches it exactly as the runtime
+            // executor would.
+            if (handler is THandler planned)
+            {
+                return planned.HandleAsync((TMessage)message, context);
+            }
+
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, object> syncHandler:
+                    syncHandler.Handle((TMessage)message, context);
+                    return ValueTask.CompletedTask;
+            }
+        }
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            _cachedFastDependencies = dependencies as MessageDependencies;
+            _cachedDependencies = dependencies;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+    }
+}
+
+/// <summary>
 /// Process-wide cache of pipeline executors, one per (message runtime type, result type,
 /// group set). Executor construction closes the generic executor over the message's runtime
 /// type — one <see cref="Type.MakeGenericType"/> per message type, consistent with the
@@ -294,6 +378,17 @@ internal sealed class PipelineExecutorCache(
     {
         var descriptor = FindDescriptor(messageType);
 
+        // Generated void plan: closed over (message, handler) at compile time, so the
+        // fast path calls the handler devirtualized. Group-less pipelines only — a
+        // grouped pipeline may exclude the planned handler, and the plain executor
+        // serves that shape without the plan's permanently-missing fast check.
+        if (groups.Length == 0 && GeneratedDispatchRoots.FindVoidPlan(messageType) is { } plan)
+        {
+            return plan.Accept(
+                GeneratedVoidExecutorVisitor.Instance,
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups));
+        }
+
         // Generated dispatch roots close the executor generic at compile time; the
         // reflective path below only serves types without a root.
         if (GeneratedDispatchRoots.FindMessage(messageType) is { } root)
@@ -357,6 +452,22 @@ internal sealed class PipelineExecutorCache(
 
         public object Visit<TMessage, TResult>(ExecutorState state) where TMessage : IMessage
             => new ResultPipelineExecutor<TMessage, TResult>(
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups);
+    }
+
+    /// <summary>
+    /// Re-enters a generic context with a generated void plan's (message, handler) pair
+    /// and constructs the plan-closed executor there — no reflection, and the handler
+    /// call devirtualizes inside the closed generic.
+    /// </summary>
+    private sealed class GeneratedVoidExecutorVisitor : IVoidPlanRootVisitor<IPipelineExecutor, ExecutorState>
+    {
+        public static readonly GeneratedVoidExecutorVisitor Instance = new();
+
+        public IPipelineExecutor Visit<TMessage, THandler>(ExecutorState state)
+            where TMessage : notnull, IMessage
+            where THandler : class, IAsyncHandler<TMessage>
+            => new GeneratedVoidPipelineExecutor<TMessage, THandler>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups);
     }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
@@ -212,7 +213,10 @@ internal sealed class PipelineExecutorCache(
         {
             if (_resultExecutorsByType.TryGetValue((messageType, typeof(TResult)), out var fast))
             {
-                return (IPipelineExecutor<TResult>)fast;
+                // Entries are only ever created as IPipelineExecutor<TResult> for their
+                // (message, result) key, so the interface cast can skip the runtime
+                // covariance check — a measurable cost on the hot path.
+                return Unsafe.As<IPipelineExecutor<TResult>>(fast);
             }
 
             return (IPipelineExecutor<TResult>)_resultExecutorsByType.GetOrAdd((messageType, typeof(TResult)),

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -178,7 +178,8 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     IMessageDescriptor descriptor,
     IMessageDependenciesFactory dependenciesFactory,
     IResultAdapterService? resultAdapterService,
-    string[] groups) : IPipelineExecutor
+    string[] groups,
+    Func<THandler>? directHandlerFactory = null) : IPipelineExecutor
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
@@ -187,9 +188,23 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
+    // Compile-time construction path for the planned handler; discarded up front for
+    // disposable handlers — the container tracks transient disposables in the resolving
+    // scope, direct construction would not.
+    private readonly Func<THandler>? _directHandlerFactory =
+        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler))
+            ? null
+            : directHandlerFactory;
+
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
     private int _cachedVersion = int.MinValue;
+
+    // Re-validated with the dependency cache: true only while the registry's sole handler
+    // is the planned type, instances are not memoized, and the handler's effective DI
+    // registration is the module's own plain transient one — the exact conditions under
+    // which GetRequiredService is observably nothing but a constructor call.
+    private bool _useDirectConstruction;
 
     public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -199,7 +214,12 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             && !_foreignAdapters
             && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
         {
-            var handler = handlerReference.Resolve(serviceProvider);
+            // The handler-type re-check pins the racy flag to the reference actually in
+            // hand: a version transition observed halfway can only route back through the
+            // container, never construct a type the registry no longer plans.
+            IHandler handler = _useDirectConstruction && handlerReference.HandlerType == typeof(THandler)
+                ? _directHandlerFactory!()
+                : handlerReference.Resolve(serviceProvider);
 
             // The compile-time plan's handler type: a devirtualized call, no pattern
             // match. A runtime re-registration can put a differently-typed handler here;
@@ -237,15 +257,114 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             }
 
             var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
-            _cachedFastDependencies = dependencies as MessageDependencies;
+            var fastDependencies = dependencies as MessageDependencies;
+            _cachedFastDependencies = fastDependencies;
             _cachedDependencies = dependencies;
+            _useDirectConstruction = _directHandlerFactory is not null
+                && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
+                && plannedType == typeof(THandler)
+                && typedFactory.IsPlainTransientRegistration(typeof(THandler));
             _cachedVersion = typedFactory.CurrentRegistryVersion;
             return dependencies;
         }
 
+        _useDirectConstruction = false;
         return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }
+
+/// <summary>
+/// Result-producing counterpart of
+/// <see cref="GeneratedVoidPipelineExecutor{TMessage, THandler}"/>: closed over the
+/// message, its result and its compile-time-known sole async handler, so the handler call
+/// devirtualizes instead of walking the contract pattern match. The same advisory-plan
+/// contract applies — the registry-version-guarded dependency cache re-validates the
+/// pipeline and any mismatch falls back to the runtime dispatch shape.
+/// </summary>
+#pragma warning disable CS8714 // TResult is used as a pattern type argument; handler contracts declare notnull results
+internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups,
+    Func<THandler>? directHandlerFactory = null) : IPipelineExecutor<TResult>
+    where TMessage : notnull, IMessage
+    where THandler : class, IAsyncHandler<TMessage, TResult>
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);
+
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private readonly Func<THandler>? _directHandlerFactory =
+        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler))
+            ? null
+            : directHandlerFactory;
+
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependencies? _cachedFastDependencies;
+    private int _cachedVersion = int.MinValue;
+    private bool _useDirectConstruction;
+
+    public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = GetDependencies();
+
+        if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
+            && !_foreignAdapters
+            && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
+        {
+            IHandler handler = _useDirectConstruction && handlerReference.HandlerType == typeof(THandler)
+                ? _directHandlerFactory!()
+                : handlerReference.Resolve(serviceProvider);
+
+            if (handler is THandler planned)
+            {
+                return planned.HandleAsync((TMessage)message, context);
+            }
+
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage, TResult> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, TResult> syncHandler:
+                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+            }
+        }
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            var fastDependencies = dependencies as MessageDependencies;
+            _cachedFastDependencies = fastDependencies;
+            _cachedDependencies = dependencies;
+            _useDirectConstruction = _directHandlerFactory is not null
+                && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
+                && plannedType == typeof(THandler)
+                && typedFactory.IsPlainTransientRegistration(typeof(THandler));
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        _useDirectConstruction = false;
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+    }
+}
+#pragma warning restore CS8714
 
 /// <summary>
 /// Process-wide cache of pipeline executors, one per (message runtime type, result type,
@@ -285,6 +404,140 @@ internal sealed class PipelineExecutorCache(
         public readonly object Executor = executor;
     }
 
+    // Last-used grouped executor per message type: an ordinal element-wise compare of the
+    // caller's group sequence against the slot's snapshot replaces the per-dispatch group
+    // materialization and joined-string key of the composite stores — the overwhelmingly
+    // common grouped caller dispatches one message type with one stable group set. A slot
+    // miss falls back to the composite store, which stays authoritative so executor
+    // identity (and its dependency cache) is preserved when group sets alternate.
+    private readonly ConcurrentDictionary<Type, GroupedVoidExecutorSlot> _groupedVoidSlotsByType = new();
+    private readonly ConcurrentDictionary<Type, GroupedResultExecutorSlot> _groupedResultSlotsByType = new();
+
+    /// <summary>Immutable (groups, executor) pair; see <see cref="ResultExecutorSlot"/> for the refresh contract.</summary>
+    private sealed class GroupedVoidExecutorSlot(string[] groups, IPipelineExecutor executor)
+    {
+        public readonly string[] Groups = groups;
+        public readonly IPipelineExecutor Executor = executor;
+    }
+
+    /// <summary>Immutable (groups, result type, executor) triple; see <see cref="ResultExecutorSlot"/>.</summary>
+    private sealed class GroupedResultExecutorSlot(string[] groups, Type resultType, object executor)
+    {
+        public readonly string[] Groups = groups;
+        public readonly Type ResultType = resultType;
+        public readonly object Executor = executor;
+    }
+
+    /// <summary>
+    /// Ordinal element-wise comparison of the caller's group sequence against a cached
+    /// snapshot, allocation-free for the array and list shapes settings expose. Order is
+    /// significant, matching the joined composite key exactly.
+    /// </summary>
+    internal static bool GroupsMatch(IEnumerable<string> groups, string[] cached)
+    {
+        switch (groups)
+        {
+            case string[] array:
+            {
+                if (array.Length != cached.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < array.Length; i++)
+                {
+                    if (!string.Equals(array[i], cached[i], StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            case List<string> list:
+            {
+                if (list.Count != cached.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < cached.Length; i++)
+                {
+                    if (!string.Equals(list[i], cached[i], StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            default:
+            {
+                var index = 0;
+
+                foreach (var group in groups)
+                {
+                    if (index >= cached.Length || !string.Equals(group, cached[index], StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+
+                    index++;
+                }
+
+                return index == cached.Length;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Group-less void executor lookup for a compile-time-known message type: a
+    /// static-generic slot replaces the dictionary lookup with a field read and a cache
+    /// identity check. The slot is keyed by this cache instance, so containers stay
+    /// isolated — a foreign cache's executor is never served, and the authoritative
+    /// per-type dictionary below preserves executor identity across slot refreshes.
+    /// Callers must guard with <c>message.GetType() == typeof(TMessage)</c>; a base-typed
+    /// generic call must keep resolving by the runtime type.
+    /// </summary>
+    public IPipelineExecutor GetVoidExecutor<TMessage>() where TMessage : IMessage
+    {
+        var slot = VoidExecutorHolder<TMessage>.Slot;
+
+        if (slot is not null && ReferenceEquals(slot.Cache, this))
+        {
+            return slot.Executor;
+        }
+
+        var executor = GetVoidExecutor(typeof(TMessage));
+        VoidExecutorHolder<TMessage>.Slot = new VoidExecutorSlot(this, executor);
+
+        return executor;
+    }
+
+    /// <summary>
+    /// Immutable (cache, executor) pair — immutability makes the racy slot refresh safe:
+    /// a reader that observes the reference sees both fields.
+    /// </summary>
+    private sealed class VoidExecutorSlot(PipelineExecutorCache cache, IPipelineExecutor executor)
+    {
+        public readonly PipelineExecutorCache Cache = cache;
+        public readonly IPipelineExecutor Executor = executor;
+    }
+
+    /// <summary>
+    /// Per-message-type slot for the last cache instance that served a typed void lookup.
+    /// Multiple containers alternating over one message type refresh the slot each time —
+    /// correct either way, and the single-container case (every production process) reads
+    /// a stable field forever. The strong reference deliberately roots the last-serving
+    /// cache (and through it that container's executor graph) past container disposal:
+    /// at most one graph per message type, which in a single-container process is the
+    /// live one anyway — a WeakReference would tax every hot-path read instead.
+    /// </summary>
+    private static class VoidExecutorHolder<TMessage> where TMessage : IMessage
+    {
+        public static VoidExecutorSlot? Slot;
+    }
+
     public IPipelineExecutor GetVoidExecutor(Type messageType, IEnumerable<string>? groups = null)
     {
         if (groups is null)
@@ -298,6 +551,12 @@ internal sealed class PipelineExecutorCache(
                 static (t, cache) => cache.CreateVoidExecutor(t, EmptyGroups), this);
         }
 
+        if (_groupedVoidSlotsByType.TryGetValue(messageType, out var slot)
+            && GroupsMatch(groups, slot.Groups))
+        {
+            return slot.Executor;
+        }
+
         var materializedGroups = MaterializeGroups(groups);
         var key = (messageType, GroupsKey(materializedGroups));
 
@@ -307,6 +566,8 @@ internal sealed class PipelineExecutorCache(
                 static (k, state) => state.Cache.CreateVoidExecutor(k.MessageType, state.Groups),
                 (Cache: this, Groups: materializedGroups));
         }
+
+        _groupedVoidSlotsByType[messageType] = new GroupedVoidExecutorSlot(materializedGroups, executor);
 
         return executor;
     }
@@ -327,6 +588,15 @@ internal sealed class PipelineExecutorCache(
             return GetExecutorSlow<TResult>(messageType);
         }
 
+        if (_groupedResultSlotsByType.TryGetValue(messageType, out var groupedSlot)
+            && ReferenceEquals(groupedSlot.ResultType, typeof(TResult))
+            && GroupsMatch(groups, groupedSlot.Groups))
+        {
+            // Slot entries are only ever created as IPipelineExecutor<TResult> for their
+            // recorded result type; see the group-less slot above.
+            return Unsafe.As<IPipelineExecutor<TResult>>(groupedSlot.Executor);
+        }
+
         var materializedGroups = MaterializeGroups(groups);
         var key = (messageType, typeof(TResult), GroupsKey(materializedGroups));
 
@@ -336,6 +606,8 @@ internal sealed class PipelineExecutorCache(
                 static (k, state) => state.Cache.CreateResultExecutor(k.MessageType, k.ResultType, state.Groups),
                 (Cache: this, Groups: materializedGroups));
         }
+
+        _groupedResultSlotsByType[messageType] = new GroupedResultExecutorSlot(materializedGroups, typeof(TResult), executor);
 
         return (IPipelineExecutor<TResult>)executor;
     }
@@ -386,7 +658,8 @@ internal sealed class PipelineExecutorCache(
         {
             return plan.Accept(
                 GeneratedVoidExecutorVisitor.Instance,
-                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups));
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups,
+                    plan.DirectHandlerFactory));
         }
 
         // Generated dispatch roots close the executor generic at compile time; the
@@ -413,6 +686,17 @@ internal sealed class PipelineExecutorCache(
     {
         var descriptor = FindDescriptor(messageType);
 
+        // Generated result plan: closed over (message, result, handler) at compile time,
+        // so the fast path calls the handler devirtualized. Group-less pipelines only,
+        // mirroring the void plan above.
+        if (groups.Length == 0 && GeneratedDispatchRoots.FindResultPlan(messageType, resultType) is { } plan)
+        {
+            return plan.Accept(
+                GeneratedResultExecutorVisitor.Instance,
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups,
+                    plan.DirectHandlerFactory));
+        }
+
         if (GeneratedDispatchRoots.FindResult(messageType, resultType) is { } root)
         {
             return root.Accept(
@@ -425,12 +709,18 @@ internal sealed class PipelineExecutorCache(
         return Activator.CreateInstance(executorType, descriptor, dependenciesFactory, resultAdapterService, groups)!;
     }
 
-    /// <summary>Constructor arguments carried into the generic re-entry of a dispatch root.</summary>
+    /// <summary>
+    /// Constructor arguments carried into the generic re-entry of a dispatch root.
+    /// <paramref name="DirectHandlerFactory"/> is a plan's erased <c>Func&lt;THandler&gt;</c>
+    /// (cast back inside the closed generic), or <c>null</c> for plain roots and plans
+    /// without a construction path.
+    /// </summary>
     private readonly record struct ExecutorState(
         IMessageDescriptor Descriptor,
         IMessageDependenciesFactory DependenciesFactory,
         IResultAdapterService? ResultAdapterService,
-        string[] Groups);
+        string[] Groups,
+        object? DirectHandlerFactory = null);
 
     /// <summary>
     /// Re-enters a generic context with a root's message type and constructs the closed
@@ -468,7 +758,25 @@ internal sealed class PipelineExecutorCache(
             where TMessage : notnull, IMessage
             where THandler : class, IAsyncHandler<TMessage>
             => new GeneratedVoidPipelineExecutor<TMessage, THandler>(
-                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups);
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
+                state.DirectHandlerFactory as Func<THandler>);
+    }
+
+    /// <summary>
+    /// Re-enters a generic context with a generated result plan's (message, result,
+    /// handler) triple and constructs the plan-closed executor there; the result-producing
+    /// counterpart of <see cref="GeneratedVoidExecutorVisitor"/>.
+    /// </summary>
+    private sealed class GeneratedResultExecutorVisitor : IResultPlanRootVisitor<object, ExecutorState>
+    {
+        public static readonly GeneratedResultExecutorVisitor Instance = new();
+
+        public object Visit<TMessage, TResult, THandler>(ExecutorState state)
+            where TMessage : notnull, IMessage
+            where THandler : class, IAsyncHandler<TMessage, TResult>
+            => new GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
+                state.DirectHandlerFactory as Func<THandler>);
     }
 
     private IMessageDescriptor FindDescriptor(Type messageType)

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -4,7 +4,9 @@ using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Internal.Factories;
 
 namespace Stella.Ergosfare.Core.Internal.Mediator;
 
@@ -23,13 +25,70 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
 {
     private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);
 
+    // Adapter service split by shape: the concrete service can report emptiness cheaply,
+    // a foreign implementation always routes through the strategy (which consults it).
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    // Dependencies cached per executor (executors are already per message type + groups),
+    // re-validated against the registry version — turns the per-dispatch factory call and
+    // cache lookup into a single field read + version compare.
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependencies? _cachedFastDependencies;
+    private int _cachedVersion = int.MinValue;
+
     public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
-        // The factory caches per (message type, groups) and re-validates against the
-        // registry version, mirroring the Mediate path's per-dispatch behavior.
-        var dependencies = dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+        var dependencies = GetDependencies();
+
+        // Zero-interceptor, single-handler, no-adapter dispatch: invoke the handler's typed
+        // member directly and hand its ValueTask straight back — no async state machine,
+        // no interface-dispatched Count checks. Mirrors the strategy's fast path exactly.
+        if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
+            && !_foreignAdapters
+            && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
+        {
+            var handler = handlerReference.Resolve(serviceProvider);
+
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage, TResult> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, TResult> syncHandler:
+                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+            }
+
+            // Unsupported handler contract: fall through so the strategy raises its
+            // canonical NotSupportedException.
+        }
 
         return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            // Create runs the registry-version invalidation and rebuilds; races are benign —
+            // both writers publish equivalent, idempotent state.
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            _cachedFastDependencies = dependencies as MessageDependencies;
+            _cachedDependencies = dependencies;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        // Foreign factory implementations keep the original per-dispatch behavior.
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }
 
@@ -46,11 +105,57 @@ internal sealed class VoidPipelineExecutor<TMessage>(
 {
     private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);
 
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependencies? _cachedFastDependencies;
+    private int _cachedVersion = int.MinValue;
+
     public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
-        var dependencies = dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+        var dependencies = GetDependencies();
+
+        if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
+            && !_foreignAdapters
+            && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
+        {
+            var handler = handlerReference.Resolve(serviceProvider);
+
+            switch (handler)
+            {
+                case IAsyncHandler<TMessage> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, object> syncHandler:
+                    syncHandler.Handle((TMessage)message, context);
+                    return ValueTask.CompletedTask;
+            }
+        }
 
         return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            _cachedFastDependencies = dependencies as MessageDependencies;
+            _cachedDependencies = dependencies;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }
 
@@ -70,8 +175,24 @@ internal sealed class PipelineExecutorCache(
     private readonly ConcurrentDictionary<(Type MessageType, string GroupsKey), IPipelineExecutor> _voidExecutors = new();
     private readonly ConcurrentDictionary<(Type MessageType, Type ResultType, string GroupsKey), object> _resultExecutors = new();
 
+    // Group-less dispatch (the overwhelmingly common case) is keyed by message type alone:
+    // no group materialization, no composite-key hashing on the hot path.
+    private readonly ConcurrentDictionary<Type, IPipelineExecutor> _voidExecutorsByType = new();
+    private readonly ConcurrentDictionary<(Type MessageType, Type ResultType), object> _resultExecutorsByType = new();
+
     public IPipelineExecutor GetVoidExecutor(Type messageType, IEnumerable<string>? groups = null)
     {
+        if (groups is null)
+        {
+            if (_voidExecutorsByType.TryGetValue(messageType, out var fast))
+            {
+                return fast;
+            }
+
+            return _voidExecutorsByType.GetOrAdd(messageType,
+                static (t, cache) => cache.CreateVoidExecutor(t, EmptyGroups), this);
+        }
+
         var materializedGroups = MaterializeGroups(groups);
         var key = (messageType, GroupsKey(materializedGroups));
 
@@ -87,6 +208,17 @@ internal sealed class PipelineExecutorCache(
 
     public IPipelineExecutor<TResult> GetExecutor<TResult>(Type messageType, IEnumerable<string>? groups = null)
     {
+        if (groups is null)
+        {
+            if (_resultExecutorsByType.TryGetValue((messageType, typeof(TResult)), out var fast))
+            {
+                return (IPipelineExecutor<TResult>)fast;
+            }
+
+            return (IPipelineExecutor<TResult>)_resultExecutorsByType.GetOrAdd((messageType, typeof(TResult)),
+                static (k, cache) => cache.CreateResultExecutor(k.MessageType, k.ResultType, EmptyGroups), this);
+        }
+
         var materializedGroups = MaterializeGroups(groups);
         var key = (messageType, typeof(TResult), GroupsKey(materializedGroups));
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -17,6 +17,7 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 /// strategy's typed seam always hits — the handler is invoked through its typed member and
 /// its <see cref="ValueTask{TResult}"/> never crosses an object-typed bridge.
 /// </summary>
+#pragma warning disable CS8714 // TResult is used as a pattern type argument; handler contracts declare notnull results
 internal sealed class ResultPipelineExecutor<TMessage, TResult>(
     IMessageDescriptor descriptor,
     IMessageDependenciesFactory dependenciesFactory,
@@ -92,6 +93,8 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
         return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }
+
+#pragma warning restore CS8714
 
 /// <summary>
 /// Void pipeline closed over the concrete <typeparamref name="TMessage"/>; see

--- a/src/Stella.Ergosfare.Core/Internal/Registry/HandlerLifetimeRegistry.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/HandlerLifetimeRegistry.cs
@@ -10,8 +10,30 @@ namespace Stella.Ergosfare.Core.Internal.Registry;
 /// memoized fast path). Types with no known registration are treated as non-singleton,
 /// which routes them to the always-correct per-scope resolution path.
 /// </summary>
-internal sealed class HandlerLifetimeRegistry(IReadOnlyDictionary<Type, ServiceLifetime> lifetimes)
+/// <param name="lifetimes">Effective DI lifetime per handler type, captured at module initialization.</param>
+/// <param name="plainTransientRegistrations">
+/// Handler types whose effective registration is a plain transient self-registration
+/// (implementation type equals the service type, no factory, no instance, unkeyed) — the
+/// exact shape the module's own <c>TryAddTransient</c> produces. For these, container
+/// resolution and direct construction are semantically identical, which is what licenses
+/// a generated plan's <c>new()</c> fast path. Types not in the set — user factories,
+/// lifetime overrides, runtime-only registrations — always resolve through the container.
+/// </param>
+internal sealed class HandlerLifetimeRegistry(
+    IReadOnlyDictionary<Type, ServiceLifetime> lifetimes,
+    IReadOnlyCollection<Type>? plainTransientRegistrations = null)
 {
+    private readonly HashSet<Type> _plainTransients =
+        plainTransientRegistrations as HashSet<Type> ?? [.. plainTransientRegistrations ?? []];
+
+    /// <summary>
+    /// Whether the handler type's effective registration is the module's own plain
+    /// transient shape; see the constructor documentation. Captured at initialization —
+    /// the same capture window the lifetime dictionary (and with it the memoized fast
+    /// path) already relies on.
+    /// </summary>
+    public bool IsPlainTransientRegistration(Type handlerType) => _plainTransients.Contains(handlerType);
+
     private readonly ConcurrentDictionary<Type, bool> _allSingletonByMessageType = new();
     private int _version = -1;
 

--- a/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
+++ b/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
@@ -97,6 +97,74 @@ public sealed class MessageDispatchEngine
     }
 
     /// <summary>
+    /// Typed void dispatch: when the compile-time <typeparamref name="TMessage"/> is the
+    /// message's runtime type (the overwhelmingly common concrete-typed call), the
+    /// executor comes from a static-generic holder instead of the type-keyed dictionary —
+    /// the last lookup on the group-less hot path. A base-typed generic call falls back to
+    /// resolving by the runtime type, so dispatch semantics are identical to
+    /// <see cref="DispatchAsync(object, IServiceProvider, IDictionary{object, object?}?, CancellationToken, IEnumerable{string}?)"/>;
+    /// group-filtered dispatches stay on that overload.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT a <c>DispatchAsync</c> overload: a same-name generic would join
+    /// the candidate set of every explicit <c>DispatchAsync&lt;T&gt;(msg, ...)</c> call, and
+    /// whenever the message expression is convertible to the type argument (an echo-typed
+    /// result dispatch — legal since <c>ICommand&lt;TResult&gt; : ICommand : IMessage</c>) the
+    /// identity conversion would out-rank the result overload's <c>object</c> parameter,
+    /// silently rerouting a result dispatch through the void pipeline or breaking the
+    /// caller with a return-type mismatch. The distinct name keeps the typed fast path
+    /// out of that candidate set entirely.
+    /// </remarks>
+    /// <typeparam name="TMessage">The compile-time message type.</typeparam>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="serviceProvider">The scope provider handlers resolve against.</param>
+    /// <param name="items">Optional contextual items exposed to the pipeline.</param>
+    /// <param name="cancellationToken">Cancellation token for the dispatch.</param>
+    public ValueTask DispatchVoidAsync<TMessage>(TMessage message, IServiceProvider serviceProvider,
+        IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default)
+        where TMessage : notnull, IMessage
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = message.GetType() == typeof(TMessage)
+            ? _executorCache.GetVoidExecutor<TMessage>()
+            : _executorCache.GetVoidExecutor(message.GetType());
+        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
+        ValueTask task;
+
+        try
+        {
+            task = executor.Execute(message, context, serviceProvider);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
     /// Result-producing counterpart of
     /// <see cref="DispatchAsync(object, IServiceProvider, IDictionary{object, object?}?, CancellationToken, IEnumerable{string}?)"/>.
     /// </summary>

--- a/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
+++ b/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
@@ -1,0 +1,182 @@
+using System.Runtime.CompilerServices;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Factories;
+using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Core.Internal.Mediator;
+
+namespace Stella.Ergosfare.Core;
+
+/// <summary>
+/// The scope-free dispatch engine behind every mediator facade: the pipeline-executor
+/// lookup, pooled execution context, and completion handling of the
+/// <see cref="IMessageMediator"/> executor path, with the calling scope's provider supplied
+/// per call instead of being captured per instance. One process-wide singleton serves every
+/// scope, so resolving an engine-backed facade builds exactly one object per resolution.
+/// </summary>
+/// <remarks>
+/// Construction is internal: the engine only makes sense wired to the process-wide
+/// <see cref="PipelineExecutorCache"/> and dependencies factory that the DI registration
+/// supplies. Dispatch behavior matches <see cref="IMessageMediator"/>'s executor overloads
+/// exactly — the mediator delegates here, passing its own captured provider.
+/// </remarks>
+public sealed class MessageDispatchEngine
+{
+    /// <summary>
+    /// Process-wide executor cache; one closed executor per message (and result) type.
+    /// </summary>
+    private readonly PipelineExecutorCache _executorCache;
+
+    /// <summary>
+    /// The dependencies factory the executors build their pipeline plans against; exposed
+    /// internally so the broadcast fast lane (events assembly, via InternalsVisibleTo) can
+    /// key its cached plan by the same factory reference the executors use.
+    /// </summary>
+    private readonly IMessageDependenciesFactory _dependenciesFactory;
+
+    internal MessageDispatchEngine(PipelineExecutorCache executorCache, IMessageDependenciesFactory dependenciesFactory)
+    {
+        _executorCache = executorCache ?? throw new ArgumentNullException(nameof(executorCache));
+        _dependenciesFactory = dependenciesFactory ?? throw new ArgumentNullException(nameof(dependenciesFactory));
+    }
+
+    /// <inheritdoc cref="_dependenciesFactory"/>
+    internal IMessageDependenciesFactory DependenciesFactory => _dependenciesFactory;
+
+    /// <summary>
+    /// Dispatches a void message through its cached pipeline executor, resolving handlers
+    /// against <paramref name="serviceProvider"/> — the caller's scope.
+    /// </summary>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="serviceProvider">The scope provider handlers resolve against.</param>
+    /// <param name="items">Optional contextual items exposed to the pipeline.</param>
+    /// <param name="cancellationToken">Cancellation token for the dispatch.</param>
+    /// <param name="groups">Optional group filters applied to the pipeline.</param>
+    public ValueTask DispatchAsync(object message, IServiceProvider serviceProvider,
+        IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = _executorCache.GetVoidExecutor(message.GetType(), groups);
+        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
+        ValueTask task;
+
+        try
+        {
+            task = executor.Execute(message, context, serviceProvider);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        // Synchronously completed dispatches (the common case) return the context inline —
+        // no async state machine on the hot path. Only a genuinely suspended pipeline pays
+        // for the awaiting helper.
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Result-producing counterpart of
+    /// <see cref="DispatchAsync(object, IServiceProvider, IDictionary{object, object?}?, CancellationToken, IEnumerable{string}?)"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The expected result type of the message.</typeparam>
+    public ValueTask<TResult> DispatchAsync<TResult>(object message, IServiceProvider serviceProvider,
+        IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var executor = _executorCache.GetExecutor<TResult>(message.GetType(), groups);
+        var context = ErgosfareExecutionContextPool.Rent(items, cancellationToken);
+        ValueTask<TResult> task;
+
+        try
+        {
+            task = executor.Execute(message, context, serviceProvider);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            var result = task.Result;
+            ErgosfareExecutionContextPool.Return(context);
+            return new ValueTask<TResult>(result);
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        static async ValueTask<TResult> AwaitAndReturn(ValueTask<TResult> task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                return await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Dispatches a void message under a caller-owned execution context (typically a
+    /// scope's child): the caller controls the context's lifetime, so nothing is rented or
+    /// returned here.
+    /// </summary>
+    /// <param name="message">The message to dispatch.</param>
+    /// <param name="context">The externally owned execution context.</param>
+    /// <param name="serviceProvider">The scope provider handlers resolve against.</param>
+    /// <param name="groups">Optional group filters applied to the pipeline.</param>
+    public ValueTask DispatchAsync(object message, IExecutionContext context, IServiceProvider serviceProvider,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var executor = _executorCache.GetVoidExecutor(message.GetType(), groups);
+
+        return executor.Execute(message, context, serviceProvider);
+    }
+
+    /// <summary>
+    /// Result-producing counterpart of
+    /// <see cref="DispatchAsync(object, IExecutionContext, IServiceProvider, IEnumerable{string}?)"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The expected result type of the message.</typeparam>
+    public ValueTask<TResult> DispatchAsync<TResult>(object message, IExecutionContext context, IServiceProvider serviceProvider,
+        IEnumerable<string>? groups = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var executor = _executorCache.GetExecutor<TResult>(message.GetType(), groups);
+
+        return executor.Execute(message, context, serviceProvider);
+    }
+}

--- a/src/Stella.Ergosfare.Core/ResultAdapterService.cs
+++ b/src/Stella.Ergosfare.Core/ResultAdapterService.cs
@@ -33,6 +33,13 @@ public sealed class ResultAdapterService: IResultAdapterService
 
     
     public IEnumerable<IResultAdapter> GetAdapters() => _resultAdapters;
+
+    /// <summary>
+    /// Whether no adapters are registered — lets dispatch fast paths skip the lookup
+    /// entirely. Reads the live list count, so a late AddAdapter is observed.
+    /// </summary>
+    internal bool IsEmpty => _resultAdapters.Count == 0;
+
     /// <summary>
     /// Iterates over the registered adapters to find the first one that can handle
     /// the given <paramref name="result"/> and extract an exception.

--- a/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
+++ b/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
@@ -16,5 +16,7 @@
         <InternalsVisibleTo Include="Ergosfare.Core.Extensions.MicrosoftDependencyInjection" />
         <!-- The event broadcast invoker rents/returns pooled execution contexts directly. -->
         <InternalsVisibleTo Include="Stella.Ergosfare.Events" />
+        <!-- The query stream invoker's fast lane builds contexts and version-guarded plans directly. -->
+        <InternalsVisibleTo Include="Stella.Ergosfare.Queries" />
     </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
+++ b/src/Stella.Ergosfare.Core/Stella.Ergosfare.Core.csproj
@@ -14,5 +14,7 @@
      
     <ItemGroup>
         <InternalsVisibleTo Include="Ergosfare.Core.Extensions.MicrosoftDependencyInjection" />
+        <!-- The event broadcast invoker rents/returns pooled execution contexts directly. -->
+        <InternalsVisibleTo Include="Stella.Ergosfare.Events" />
     </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
@@ -33,6 +33,13 @@ public sealed class EventMediationSettings
     {
    
         /// <summary>
+        /// The canonical accept-everything predicate. Publish paths compare against this
+        /// instance by reference to recognize "no filtering requested" and skip the
+        /// per-handler predicate loop entirely.
+        /// </summary>
+        internal static readonly Func<Type, bool> AcceptAllHandlers = static _ => true;
+
+        /// <summary>
         /// Gets or sets the collection of group names used to filter event handlers.
         /// Only handlers belonging to these groups will receive the event.
         /// </summary>
@@ -43,6 +50,6 @@ public sealed class EventMediationSettings
         /// Gets or sets a predicate function to filter handlers by their type.
         /// By default, all handler types are included.
         /// </summary>
-        public Func<Type, bool> HandlerPredicate { get; set; } = _ => true;
+        public Func<Type, bool> HandlerPredicate { get; set; } = AcceptAllHandlers;
     }
 }

--- a/src/Stella.Ergosfare.Events.Abstractions/Stella.Ergosfare.Events.Abstractions.csproj
+++ b/src/Stella.Ergosfare.Events.Abstractions/Stella.Ergosfare.Events.Abstractions.csproj
@@ -8,4 +8,8 @@
       <ProjectReference Include="..\Stella.Ergosfare.Core.Abstractions\Stella.Ergosfare.Core.Abstractions.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- The broadcast fast lane reads the canonical accept-all predicate by reference. -->
+        <InternalsVisibleTo Include="Stella.Ergosfare.Events" />
+    </ItemGroup>
 </Project>

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EngineBackedEventMediator.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EngineBackedEventMediator.cs
@@ -1,0 +1,20 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+
+namespace Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+
+/// <summary>
+/// DI-facing shape of <see cref="EventMediator"/> with exactly one constructor, so
+/// container activation binds the engine-backed path deterministically — no
+/// multi-constructor ambiguity, and no per-resolution service lookup a factory
+/// registration would pay. Resolving <see cref="Stella.Ergosfare.Events.Abstractions.IEventMediator"/>
+/// or <see cref="Stella.Ergosfare.Events.Abstractions.IPublisher"/> builds this single
+/// object; the engine itself is a process-wide singleton.
+/// </summary>
+internal sealed class EngineBackedEventMediator(
+    MessageDispatchEngine engine,
+    IServiceProvider serviceProvider,
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+    IResultAdapterService? resultAdapterService)
+    : EventMediator(engine, serviceProvider, messageResolveStrategy, resultAdapterService);

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
@@ -32,8 +32,9 @@ internal class EventModule(Action<EventModuleBuilder> builder) : IModule
         // Transient, not scoped: the mediator is stateless and a transient service is handed
         // the resolving scope's provider all the same, so per-dispatch handler resolution
         // still binds to the calling scope. Scoped would add a scope lock and a
-        // resolved-services dictionary insert to every dispatch for no benefit.
-        configuration.Services.TryAddTransient<IEventMediator, EventMediator>();
-        configuration.Services.TryAddTransient<IPublisher, EventMediator>();
+        // resolved-services dictionary insert to every dispatch for no benefit. The
+        // engine-backed shape makes the facade the only object built per resolution.
+        configuration.Services.TryAddTransient<IEventMediator, EngineBackedEventMediator>();
+        configuration.Services.TryAddTransient<IPublisher, EngineBackedEventMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
@@ -29,8 +29,11 @@ internal class EventModule(Action<EventModuleBuilder> builder) : IModule
     {
         builder(new EventModuleBuilder(configuration.MessageRegistry));
 
-        // Scoped so per-dispatch handler resolution binds to the calling scope's provider.
-        configuration.Services.TryAddScoped<IEventMediator, EventMediator>();
-        configuration.Services.TryAddScoped<IPublisher, EventMediator>();
+        // Transient, not scoped: the mediator is stateless and a transient service is handed
+        // the resolving scope's provider all the same, so per-dispatch handler resolution
+        // still binds to the calling scope. Scoped would add a scope lock and a
+        // resolved-services dictionary insert to every dispatch for no benefit.
+        configuration.Services.TryAddTransient<IEventMediator, EventMediator>();
+        configuration.Services.TryAddTransient<IPublisher, EventMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -138,6 +138,14 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         IReadOnlyList<IHandlerReference<IHandler, IMainHandlerDescriptor>> handlers)
     {
         var predicate = settings.Filters.HandlerPredicate;
+
+        // The canonical accept-all predicate can be recognized by reference — no filtering
+        // requested, so skip the per-handler predicate loop entirely.
+        if (ReferenceEquals(predicate, EventMediationSettings.EventMediationFilters.AcceptAllHandlers))
+        {
+            return handlers;
+        }
+
         List<IHandlerReference<IHandler, IMainHandlerDescriptor>>? filtered = null;
 
         for (var i = 0; i < handlers.Count; i++)

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -70,20 +70,45 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         Exception? exception = null;
         try
         {
-            // events doesn't need result adapter, since events intended to not return a result
-            var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-            await preInvoker.Invoke(message, context);
-            await PublishSequentially(message, handlers, context, serviceProvider);
-            await PublishSequentially(message, indirectHandlers, context, serviceProvider);
+            // Empty stages are skipped before any invoker object exists — an invoker over an
+            // empty stage is a no-op, so the guards change allocations, not behavior.
+            if (messageDependencies.PreInterceptors.Count > 0)
+            {
+                // events doesn't need result adapter, since events intended to not return a result
+                var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
+                await preInvoker.Invoke(message, context);
+            }
 
-            // A ValueTask may be awaited only once — the completed ValueTask stands in as the
-            // (meaningless for events) result object flowing through the interceptor stages.
-            var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, null, serviceProvider);
-            await postInvoker.Invoke(message, CompletedResultBox.Instance, context);
+            if (handlers.Count > 0)
+            {
+                await PublishSequentially(message, handlers, context, serviceProvider);
+            }
+
+            if (indirectHandlers.Count > 0)
+            {
+                await PublishSequentially(message, indirectHandlers, context, serviceProvider);
+            }
+
+            if (messageDependencies.PostInterceptors.Count > 0)
+            {
+                // A ValueTask may be awaited only once — the completed ValueTask stands in as the
+                // (meaningless for events) result object flowing through the interceptor stages.
+                var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, null, serviceProvider);
+                await postInvoker.Invoke(message, CompletedResultBox.Instance, context);
+            }
         }
         catch (Exception e)
         {
             exception = e;
+
+            // Zero exception interceptors: rethrow directly — identical to the invoker's own
+            // empty-stage behavior (it rethrows via ExceptionDispatchInfo), minus the
+            // allocations. Final interceptors still run from the finally block.
+            if (messageDependencies.ExceptionInterceptors.Count == 0)
+            {
+                throw;
+            }
+
             var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
             await exceptionInvoker.Invoke(message, CompletedResultBox.Instance,
                 ExceptionDispatchInfo.Capture(e), context);
@@ -92,8 +117,11 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
 
         finally
         {
-            var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-            await finalInvoker.Invoke(message, CompletedResultBox.Instance, exception, context);
+            if (messageDependencies.FinalInterceptors.Count > 0)
+            {
+                var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
+                await finalInvoker.Invoke(message, CompletedResultBox.Instance, exception, context);
+            }
         }
     }
 

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -76,7 +76,11 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
             {
                 // events doesn't need result adapter, since events intended to not return a result
                 var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-                await preInvoker.Invoke(message, context);
+
+                // Pre-interceptors may transform the event — including returning a brand new
+                // instance — so the broadcast continues with the returned message, exactly as
+                // the single-handler strategies do.
+                message = (TMessage) await preInvoker.Invoke(message, context);
             }
 
             if (handlers.Count > 0)

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -403,6 +403,20 @@ internal static class EventBroadcastInvokerCache
 {
     private static readonly ConcurrentDictionary<Type, IEventBroadcastInvoker> Invokers = new();
 
+    /// <summary>
+    /// Static-generic view of the cache for callers that know the event's concrete type at
+    /// compile time: the invoker resolves once per closed type into a static readonly
+    /// field, so the typed publish overload skips the per-call dictionary lookup. Shares
+    /// the dictionary's instance, keeping the plan cache one-per-event-type (and
+    /// factory-keyed, so container isolation is unchanged). Callers must guard with
+    /// <c>@event.GetType() == typeof(TEvent)</c> — a base-typed generic call must keep
+    /// resolving by the runtime type.
+    /// </summary>
+    internal static class Holder<TEvent> where TEvent : notnull
+    {
+        public static readonly IEventBroadcastInvoker Instance = Get(typeof(TEvent));
+    }
+
     [UnconditionalSuppressMessage("Trimming", "IL2055",
         Justification = "The invoker generic is closed over a live event's runtime type; the event roots its type.")]
     [UnconditionalSuppressMessage("AOT", "IL3050",

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -149,6 +149,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     /// concurrent writers publish equivalent, idempotent state.
     /// </summary>
     private IMessageDependencies? _cachedDependencies;
+    private MessageDependenciesFactory? _cachedFactory;
     private int _cachedVersion = int.MinValue;
 
     private IMessageDependencies GetPlan(
@@ -159,13 +160,22 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         {
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            // The invoker is process-wide (one per event type) while factories are
+            // per-container — the factory reference is part of the cache key, so one
+            // container's plan (which may pin that container's root provider for
+            // memoized, all-singleton pipelines) is never served to another container.
+            // Multiple containers ping-ponging simply rebuild the single slot; the
+            // factory's own per-container cache keeps that cheap.
+            if (cached is not null
+                && ReferenceEquals(_cachedFactory, typedFactory)
+                && _cachedVersion == typedFactory.CurrentRegistryVersion)
             {
                 return cached;
             }
 
             var dependencies = BuildPlan(typedFactory, resolveStrategy);
             _cachedDependencies = dependencies;
+            _cachedFactory = typedFactory;
             _cachedVersion = typedFactory.CurrentRegistryVersion;
             return dependencies;
         }

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -83,7 +83,24 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 && mediator is MessageMediator concreteMediator)
             {
                 var dependencies = GetPlan(concreteMediator, resolveStrategy);
-                task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
+
+                // Straight-through broadcast: with no interceptor stages and no handler
+                // filtering requested, loop the handler arrays directly — synchronously
+                // while handlers complete synchronously, bailing to an awaiting helper on
+                // the first suspension. No strategy or per-stage async frames.
+                if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+                    && (settings is null
+                        || ReferenceEquals(settings.Filters.HandlerPredicate,
+                            EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
+                {
+                    task = PublishStraightThrough(
+                        (TEvent)@event, plan, context, concreteMediator.ScopeProvider,
+                        settings?.ThrowIfNoHandlerFound ?? false);
+                }
+                else
+                {
+                    task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
+                }
             }
             else
             {
@@ -154,6 +171,108 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         }
 
         return BuildPlan(mediator.DependenciesFactory, resolveStrategy);
+    }
+
+    /// <summary>
+    /// Broadcasts sequentially over the direct then indirect handler arrays without any
+    /// async machinery while handlers complete synchronously; the first suspension hands
+    /// the remainder to an awaiting helper, preserving strict sequential order. Semantics
+    /// match <see cref="AsyncBroadcastMediationStrategy{TMessage}"/> for the
+    /// zero-interceptor, unfiltered case: exceptions propagate raw, and an empty pipeline
+    /// throws only when <paramref name="throwIfNoHandlerFound"/> asks for it.
+    /// </summary>
+    private static ValueTask PublishStraightThrough(
+        TEvent @event,
+        MessageDependencies plan,
+        IExecutionContext context,
+        IServiceProvider serviceProvider,
+        bool throwIfNoHandlerFound)
+    {
+        var direct = plan.HandlerArray;
+        var indirect = plan.IndirectHandlerArray;
+
+        if (direct.Length == 0 && indirect.Length == 0)
+        {
+            return throwIfNoHandlerFound
+                ? ValueTask.FromException(new NoHandlerFoundException(typeof(TEvent)))
+                : default;
+        }
+
+        for (var i = 0; i < direct.Length; i++)
+        {
+            var pending = Invoke(direct[i], @event, context, serviceProvider);
+
+            if (!pending.IsCompletedSuccessfully)
+            {
+                return AwaitRemaining(pending, @event, plan, context, serviceProvider, i + 1, inIndirect: false);
+            }
+        }
+
+        for (var i = 0; i < indirect.Length; i++)
+        {
+            var pending = Invoke(indirect[i], @event, context, serviceProvider);
+
+            if (!pending.IsCompletedSuccessfully)
+            {
+                return AwaitRemaining(pending, @event, plan, context, serviceProvider, i + 1, inIndirect: true);
+            }
+        }
+
+        return default;
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitRemaining(
+            ValueTask pending, TEvent @event, MessageDependencies plan, IExecutionContext context,
+            IServiceProvider serviceProvider, int next, bool inIndirect)
+        {
+            await pending;
+
+            var direct = plan.HandlerArray;
+            var indirect = plan.IndirectHandlerArray;
+
+            if (!inIndirect)
+            {
+                for (var i = next; i < direct.Length; i++)
+                {
+                    await Invoke(direct[i], @event, context, serviceProvider);
+                }
+
+                next = 0;
+            }
+
+            for (var i = next; i < indirect.Length; i++)
+            {
+                await Invoke(indirect[i], @event, context, serviceProvider);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Invokes one handler through its typed contract — the same dispatch rules the
+    /// broadcast strategy applies.
+    /// </summary>
+    private static ValueTask Invoke(
+        Core.Abstractions.IHandlerReference<Core.Abstractions.Handlers.IHandler, Core.Abstractions.Registry.Descriptors.IMainHandlerDescriptor> reference,
+        TEvent @event,
+        IExecutionContext context,
+        IServiceProvider serviceProvider)
+    {
+        var handler = reference.Resolve(serviceProvider);
+
+        switch (handler)
+        {
+            case Core.Abstractions.Handlers.IAsyncHandler<TEvent> asyncHandler:
+                return asyncHandler.HandleAsync(@event, context);
+            case Core.Abstractions.Handlers.IHandler<TEvent, ValueTask> valueTaskShaped:
+                return valueTaskShaped.Handle(@event, context);
+            case Core.Abstractions.Handlers.IHandler<TEvent, object> syncHandler:
+                syncHandler.Handle(@event, context);
+                return ValueTask.CompletedTask;
+            default:
+                throw new NotSupportedException(
+                    $"'{handler.GetType()}' does not implement a supported handler contract for event '{typeof(TEvent)}'. " +
+                    "Interface-erased dispatch is not supported; publish with the concrete event type.");
+        }
     }
 
     private static IMessageDependencies BuildPlan(

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Internal.Contexts;
 using Stella.Ergosfare.Events.Abstractions;
 
 namespace Stella.Ergosfare.Events;
@@ -15,7 +17,7 @@ namespace Stella.Ergosfare.Events;
 /// </summary>
 internal interface IEventBroadcastInvoker
 {
-    ValueTask Publish(object @event, EventMediationSettings settings, CancellationToken cancellationToken,
+    ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null);
 }
@@ -25,21 +27,88 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 {
     private static readonly string[] EmptyGroups = [];
 
-    public ValueTask Publish(object @event, EventMediationSettings settings, CancellationToken cancellationToken,
+    /// <summary>
+    /// Shared strategy for publishes without caller-supplied settings. Safe to share: the
+    /// settings instance is private and never mutated, and the strategy keeps all
+    /// per-publish state in locals — one instance serves concurrent publishes.
+    /// </summary>
+    private static readonly EventMediationSettings DefaultSettings = new();
+    private static readonly AsyncBroadcastMediationStrategy<TEvent> DefaultStrategy = new(DefaultSettings);
+
+    public ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null)
     {
+        // Null settings (the common publish) reuse the cached default strategy — no
+        // EventMediationSettings, no Filters/List/Dictionary, no strategy allocation.
+        var strategy = settings is null
+            ? DefaultStrategy
+            : new AsyncBroadcastMediationStrategy<TEvent>(settings);
+
+        if (externalContext is not null)
+        {
+            // Caller-owned context (nested publish): the caller controls its lifetime —
+            // nothing is rented here, so nothing may be returned here.
+            return mediator.Mediate((TEvent)@event, new MediateOptions<TEvent, ValueTask>
+            {
+                MessageMediationStrategy = strategy,
+                MessageResolveStrategy = resolveStrategy,
+                CancellationToken = cancellationToken,
+                Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
+                ExternalContext = externalContext,
+            });
+        }
+
+        // Root publish: rent a pooled context and hand it to Mediate as an external
+        // context. This invoker is the completion observer — the broadcast strategy is a
+        // plain async ValueTask that awaits every handler and interceptor sequentially, so
+        // the returned task's completion really is the end of all context use.
+        // Adopting the settings' items dictionary keeps handler writes visible to the
+        // caller exactly as the unpooled path did; on return the context detaches the
+        // dictionary instead of wiping it.
+        var context = ErgosfareExecutionContextPool.Rent(settings?.Items, cancellationToken);
+
         var options = new MediateOptions<TEvent, ValueTask>
         {
-            MessageMediationStrategy = new AsyncBroadcastMediationStrategy<TEvent>(settings),
+            MessageMediationStrategy = strategy,
             MessageResolveStrategy = resolveStrategy,
             CancellationToken = cancellationToken,
-            Items = settings.Items,
-            Groups = settings.Filters.Groups,
-            ExternalContext = externalContext,
+            Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
+            ExternalContext = context,
         };
 
-        return mediator.Mediate((TEvent)@event, options);
+        ValueTask task;
+
+        try
+        {
+            task = mediator.Mediate((TEvent)@event, options);
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
     }
 }
 

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -87,15 +87,18 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
         try
         {
-            // Fast lane: for the group-less publish against the concrete mediator, run the
-            // broadcast strategy directly against the invoker-cached pipeline plan (the
-            // executors' registry-version-guarded pattern) — no MediateOptions, no
-            // per-publish descriptor lookup, no Mediate wrapper. Grouped publishes and
-            // foreign mediator implementations keep the original Mediate path.
-            if ((settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 })
-                && mediator is MessageMediator concreteMediator)
+            // Fast lane: against the concrete mediator, run the broadcast strategy
+            // directly against the invoker-cached pipeline plan (the executors'
+            // registry-version-guarded pattern) — no MediateOptions, no per-publish
+            // descriptor lookup, no Mediate wrapper. Grouped publishes resolve the same
+            // group-filtered dependencies the Mediate path would build, from the grouped
+            // plan slot; only foreign mediator implementations keep the original path.
+            if (mediator is MessageMediator concreteMediator)
             {
-                var dependencies = GetPlan(concreteMediator.DependenciesFactory, resolveStrategy);
+                var groups = settings?.Filters.Groups;
+                var dependencies = groups is null or List<string> { Count: 0 } or string[] { Length: 0 }
+                    ? GetPlan(concreteMediator.DependenciesFactory, resolveStrategy)
+                    : GetGroupedPlan(concreteMediator.DependenciesFactory, resolveStrategy, groups);
 
                 // Straight-through broadcast: with no interceptor stages and no handler
                 // filtering requested, loop the handler arrays directly — synchronously
@@ -168,8 +171,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null)
     {
-        if (externalContext is not null
-            || !(settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 }))
+        if (externalContext is not null)
         {
             return Publish(@event, settings, cancellationToken,
                 ResolveMediator(serviceProvider), resolveStrategy, resultAdapterService, externalContext);
@@ -181,7 +183,10 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
         try
         {
-            var dependencies = GetPlan(engine.DependenciesFactory, resolveStrategy);
+            var groups = settings?.Filters.Groups;
+            var dependencies = groups is null or List<string> { Count: 0 } or string[] { Length: 0 }
+                ? GetPlan(engine.DependenciesFactory, resolveStrategy)
+                : GetGroupedPlan(engine.DependenciesFactory, resolveStrategy, groups);
 
             if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
                 && (settings is null
@@ -269,14 +274,66 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 return cached;
             }
 
-            var dependencies = BuildPlan(typedFactory, resolveStrategy);
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
             _cachedDependencies = dependencies;
             _cachedFactory = typedFactory;
             _cachedVersion = typedFactory.CurrentRegistryVersion;
             return dependencies;
         }
 
-        return BuildPlan(dependenciesFactory, resolveStrategy);
+        return BuildPlan(dependenciesFactory, resolveStrategy, EmptyGroups);
+    }
+
+    /// <summary>
+    /// Grouped counterpart of <see cref="GetPlan"/>: a single last-used
+    /// (factory, group set) slot serves the overwhelmingly common shape — one stable
+    /// group set per event type — with an ordinal element-wise compare instead of a
+    /// per-publish key materialization. The dependencies come from the same factory call
+    /// the Mediate path would make, so the group-filtered pipeline is identical; a slot
+    /// miss (alternating group sets, another container, a registry change) only rebuilds
+    /// through the factory's own process-wide dependency cache. The slot snapshots the
+    /// caller's group sequence, so later caller-side mutation of a reused settings
+    /// instance is seen as a different group set, never as a stale hit.
+    /// </summary>
+    private GroupedPlanSlot? _cachedGroupedPlan;
+
+    private sealed class GroupedPlanSlot(
+        MessageDependenciesFactory factory,
+        string[] groups,
+        IMessageDependencies dependencies,
+        int version)
+    {
+        public readonly MessageDependenciesFactory Factory = factory;
+        public readonly string[] Groups = groups;
+        public readonly IMessageDependencies Dependencies = dependencies;
+        public readonly int Version = version;
+    }
+
+    private IMessageDependencies GetGroupedPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IEnumerable<string> groups)
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var slot = _cachedGroupedPlan;
+
+            if (slot is not null
+                && ReferenceEquals(slot.Factory, typedFactory)
+                && slot.Version == typedFactory.CurrentRegistryVersion
+                && PipelineExecutorCache.GroupsMatch(groups, slot.Groups))
+            {
+                return slot.Dependencies;
+            }
+
+            string[] materialized = [.. groups];
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
+            _cachedGroupedPlan = new GroupedPlanSlot(
+                typedFactory, materialized, dependencies, typedFactory.CurrentRegistryVersion);
+            return dependencies;
+        }
+
+        return BuildPlan(dependenciesFactory, resolveStrategy, [.. groups]);
     }
 
     /// <summary>
@@ -383,7 +440,8 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
     private static IMessageDependencies BuildPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory factory,
-        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        string[] groups)
     {
         // Mirrors MessageMediator.Mediate's descriptor handling for the options the old
         // path used: RegisterPlainMessagesOnSpot was never set for events, so an
@@ -391,7 +449,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         var descriptor = resolveStrategy.Find(typeof(TEvent))
                          ?? throw new NoHandlerFoundException(typeof(TEvent));
 
-        return factory.Create(typeof(TEvent), descriptor, EmptyGroups);
+        return factory.Create(typeof(TEvent), descriptor, groups);
     }
 }
 

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -2,8 +2,11 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Core.Internal.Factories;
+using Stella.Ergosfare.Core.Internal.Mediator;
 using Stella.Ergosfare.Events.Abstractions;
 
 namespace Stella.Ergosfare.Events;
@@ -59,29 +62,40 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             });
         }
 
-        // Root publish: rent a pooled context and hand it to Mediate as an external
-        // context. This invoker is the completion observer — the broadcast strategy is a
-        // plain async ValueTask that awaits every handler and interceptor sequentially, so
-        // the returned task's completion really is the end of all context use.
-        // Adopting the settings' items dictionary keeps handler writes visible to the
-        // caller exactly as the unpooled path did; on return the context detaches the
-        // dictionary instead of wiping it.
+        // Root publish: rent a pooled context; this invoker is the completion observer —
+        // the broadcast strategy is a plain async ValueTask that awaits every handler and
+        // interceptor sequentially, so the returned task's completion really is the end of
+        // all context use. Adopting the settings' items dictionary keeps handler writes
+        // visible to the caller exactly as the unpooled path did; on return the context
+        // detaches the dictionary instead of wiping it.
         var context = ErgosfareExecutionContextPool.Rent(settings?.Items, cancellationToken);
-
-        var options = new MediateOptions<TEvent, ValueTask>
-        {
-            MessageMediationStrategy = strategy,
-            MessageResolveStrategy = resolveStrategy,
-            CancellationToken = cancellationToken,
-            Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
-            ExternalContext = context,
-        };
 
         ValueTask task;
 
         try
         {
-            task = mediator.Mediate((TEvent)@event, options);
+            // Fast lane: for the group-less publish against the concrete mediator, run the
+            // broadcast strategy directly against the invoker-cached pipeline plan (the
+            // executors' registry-version-guarded pattern) — no MediateOptions, no
+            // per-publish descriptor lookup, no Mediate wrapper. Grouped publishes and
+            // foreign mediator implementations keep the original Mediate path.
+            if ((settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 })
+                && mediator is MessageMediator concreteMediator)
+            {
+                var dependencies = GetPlan(concreteMediator, resolveStrategy);
+                task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
+            }
+            else
+            {
+                task = mediator.Mediate((TEvent)@event, new MediateOptions<TEvent, ValueTask>
+                {
+                    MessageMediationStrategy = strategy,
+                    MessageResolveStrategy = resolveStrategy,
+                    CancellationToken = cancellationToken,
+                    Groups = settings is null ? EmptyGroups : settings.Filters.Groups,
+                    ExternalContext = context,
+                });
+            }
         }
         catch
         {
@@ -109,6 +123,50 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 ErgosfareExecutionContextPool.Return(context);
             }
         }
+    }
+
+    /// <summary>
+    /// The group-less pipeline plan for <typeparamref name="TEvent"/>, cached on the
+    /// invoker and re-validated against the registry version — runtime registrations
+    /// invalidate it exactly as they invalidate the executors' caches. Races are benign:
+    /// concurrent writers publish equivalent, idempotent state.
+    /// </summary>
+    private IMessageDependencies? _cachedDependencies;
+    private int _cachedVersion = int.MinValue;
+
+    private IMessageDependencies GetPlan(
+        MessageMediator mediator,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        if (mediator.DependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = BuildPlan(typedFactory, resolveStrategy);
+            _cachedDependencies = dependencies;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return BuildPlan(mediator.DependenciesFactory, resolveStrategy);
+    }
+
+    private static IMessageDependencies BuildPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory factory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        // Mirrors MessageMediator.Mediate's descriptor handling for the options the old
+        // path used: RegisterPlainMessagesOnSpot was never set for events, so an
+        // unregistered event type throws NoHandlerFoundException here as it did there.
+        var descriptor = resolveStrategy.Find(typeof(TEvent))
+                         ?? throw new NoHandlerFoundException(typeof(TEvent));
+
+        return factory.Create(typeof(TEvent), descriptor, EmptyGroups);
     }
 }
 

--- a/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
+++ b/src/Stella.Ergosfare.Events/BroadcastInvoker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
@@ -22,6 +23,18 @@ internal interface IEventBroadcastInvoker
 {
     ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null);
+
+    /// <summary>
+    /// Engine-backed publish: the concrete dispatch machinery is known by construction, so
+    /// the group-less publish takes the fast lane directly against the engine's plan and
+    /// the caller's scope provider. Non-fast shapes (grouped filters, external contexts)
+    /// resolve the scope's <see cref="IMessageMediator"/> on demand and run the original
+    /// overload — semantics unchanged.
+    /// </summary>
+    ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null);
 }
 
@@ -82,7 +95,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             if ((settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 })
                 && mediator is MessageMediator concreteMediator)
             {
-                var dependencies = GetPlan(concreteMediator, resolveStrategy);
+                var dependencies = GetPlan(concreteMediator.DependenciesFactory, resolveStrategy);
 
                 // Straight-through broadcast: with no interceptor stages and no handler
                 // filtering requested, loop the handler arrays directly — synchronously
@@ -143,6 +156,89 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     }
 
     /// <summary>
+    /// Engine-backed counterpart of the mediator overload: the engine is the concrete
+    /// dispatch machinery by construction, so the group-less publish runs the fast lane
+    /// directly against its plan and the caller's scope provider. Grouped publishes and
+    /// externally owned contexts resolve the scope's <see cref="IMessageMediator"/> on
+    /// demand and take the original overload, preserving the Mediate path's semantics
+    /// exactly.
+    /// </summary>
+    public ValueTask Publish(object @event, EventMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IResultAdapterService? resultAdapterService, IExecutionContext? externalContext = null)
+    {
+        if (externalContext is not null
+            || !(settings is null || settings.Filters.Groups is List<string> { Count: 0 } or string[] { Length: 0 }))
+        {
+            return Publish(@event, settings, cancellationToken,
+                ResolveMediator(serviceProvider), resolveStrategy, resultAdapterService, externalContext);
+        }
+
+        var context = ErgosfareExecutionContextPool.Rent(settings?.Items, cancellationToken);
+
+        ValueTask task;
+
+        try
+        {
+            var dependencies = GetPlan(engine.DependenciesFactory, resolveStrategy);
+
+            if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+                && (settings is null
+                    || ReferenceEquals(settings.Filters.HandlerPredicate,
+                        EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
+            {
+                task = PublishStraightThrough(
+                    (TEvent)@event, plan, context, serviceProvider,
+                    settings?.ThrowIfNoHandlerFound ?? false);
+            }
+            else
+            {
+                var strategy = settings is null
+                    ? DefaultStrategy
+                    : new AsyncBroadcastMediationStrategy<TEvent>(settings);
+
+                task = strategy.Mediate((TEvent)@event, dependencies, context, serviceProvider);
+            }
+        }
+        catch
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            throw;
+        }
+
+        if (task.IsCompletedSuccessfully)
+        {
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
+
+        return AwaitAndReturn(task, context);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        static async ValueTask AwaitAndReturn(ValueTask task, ErgosfareExecutionContext context)
+        {
+            try
+            {
+                await task;
+            }
+            finally
+            {
+                ErgosfareExecutionContextPool.Return(context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The scope's mediator registration, needed only for the non-fast shapes of the
+    /// engine overload — they run the Mediate path a mediator instance owns.
+    /// </summary>
+    private static IMessageMediator ResolveMediator(IServiceProvider serviceProvider)
+        => (IMessageMediator?)serviceProvider.GetService(typeof(IMessageMediator))
+           ?? throw new InvalidOperationException(
+               "Grouped or externally-scoped publishes resolve IMessageMediator from the scope; register Ergosfare through AddErgosfare.");
+
+    /// <summary>
     /// The group-less pipeline plan for <typeparamref name="TEvent"/>, cached on the
     /// invoker and re-validated against the registry version — runtime registrations
     /// invalidate it exactly as they invalidate the executors' caches. Races are benign:
@@ -153,10 +249,10 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     private int _cachedVersion = int.MinValue;
 
     private IMessageDependencies GetPlan(
-        MessageMediator mediator,
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
     {
-        if (mediator.DependenciesFactory is MessageDependenciesFactory typedFactory)
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
             var cached = _cachedDependencies;
 
@@ -180,7 +276,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             return dependencies;
         }
 
-        return BuildPlan(mediator.DependenciesFactory, resolveStrategy);
+        return BuildPlan(dependenciesFactory, resolveStrategy);
     }
 
     /// <summary>

--- a/src/Stella.Ergosfare.Events/EventMediator.cs
+++ b/src/Stella.Ergosfare.Events/EventMediator.cs
@@ -118,11 +118,19 @@ public class EventMediator : IPublisher
                                      EventMediationSettings? eventMediationSettings = null,
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
+        // When the runtime type is exactly TEvent (the overwhelmingly common typed
+        // publish), the static-generic holder hands back the invoker without a dictionary
+        // lookup. A base-typed generic call keeps resolving by the runtime type — the
+        // holder for a base TEvent would dispatch the wrong closed pipeline.
+        var invoker = @event.GetType() == typeof(TEvent)
+            ? EventBroadcastInvokerCache.Holder<TEvent>.Instance
+            : EventBroadcastInvokerCache.Get(@event.GetType());
+
         return _engine is not null
-            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+            ? invoker.Publish(
                 @event, eventMediationSettings, cancellationToken,
                 _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService)
-            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+            : invoker.Publish(
                 @event, eventMediationSettings, cancellationToken,
                 _messageMediator!, _messageResolveStrategy, _resultAdapterService);
     }

--- a/src/Stella.Ergosfare.Events/EventMediator.cs
+++ b/src/Stella.Ergosfare.Events/EventMediator.cs
@@ -1,3 +1,4 @@
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Events.Abstractions;
@@ -10,12 +11,80 @@ namespace Stella.Ergosfare.Events;
 /// handlers are always invoked through their typed members — including for the
 /// interface-erased <see cref="PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> overload.
 /// </summary>
+/// <remarks>
+/// Unsealed so the DI registration can bind the engine-backed constructor through a
+/// single-constructor derived shape; the facade carries no state a derived type could
+/// corrupt.
+/// </remarks>
 /// <inheritdoc cref="IEventMediator"/>
-public sealed class EventMediator(
-    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
-    IResultAdapterService? resultAdapterService,
-    IMessageMediator messageMediator) : IPublisher
+public class EventMediator : IPublisher
 {
+    /// <summary>
+    /// Resolve strategy handed to the broadcast invoker; identical on both construction
+    /// shapes.
+    /// </summary>
+    private readonly ActualTypeOrFirstAssignableTypeMessageResolveStrategy _messageResolveStrategy;
+
+    /// <summary>
+    /// Result adapters handed to the broadcast invoker; identical on both construction
+    /// shapes.
+    /// </summary>
+    private readonly IResultAdapterService? _resultAdapterService;
+
+    /// <summary>
+    /// The mediator backing the original construction shape; null when the facade is
+    /// engine-backed.
+    /// </summary>
+    private readonly IMessageMediator? _messageMediator;
+
+    /// <summary>
+    /// The singleton dispatch engine; null when the facade wraps an
+    /// <see cref="IMessageMediator"/>.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine;
+
+    /// <summary>
+    /// The scope provider handlers resolve against on the engine path.
+    /// </summary>
+    private readonly IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Wraps an existing <see cref="IMessageMediator"/> — the original construction shape,
+    /// kept for direct construction and foreign mediator implementations.
+    /// </summary>
+    public EventMediator(
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+        IResultAdapterService? resultAdapterService,
+        IMessageMediator messageMediator)
+    {
+        _messageResolveStrategy = messageResolveStrategy;
+        _resultAdapterService = resultAdapterService;
+        _messageMediator = messageMediator;
+    }
+
+    /// <summary>
+    /// Engine-backed construction: publishes go straight to the process-wide engine's
+    /// broadcast plan with <paramref name="serviceProvider"/> as the handler-resolution
+    /// scope, making the facade the only object built per resolution.
+    /// </summary>
+    /// <param name="engine">The singleton dispatch engine.</param>
+    /// <param name="serviceProvider">The provider of the scope this facade serves.</param>
+    /// <param name="messageResolveStrategy">Resolve strategy used to find broadcast pipelines.</param>
+    /// <param name="resultAdapterService">Result adapters applied by broadcast strategies.</param>
+    public EventMediator(
+        MessageDispatchEngine engine,
+        IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+        IResultAdapterService? resultAdapterService)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _engine = engine;
+        _serviceProvider = serviceProvider;
+        _messageResolveStrategy = messageResolveStrategy;
+        _resultAdapterService = resultAdapterService;
+    }
 
     /// <summary>
     /// Publishes a non-generic event asynchronously through the mediation pipeline.
@@ -28,9 +97,13 @@ public sealed class EventMediator(
                              EventMediationSettings? eventMediationSettings = null,
                              CancellationToken cancellationToken = default)
     {
-        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings, cancellationToken,
-            messageMediator, messageResolveStrategy, resultAdapterService);
+        return _engine is not null
+            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService)
+            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _messageMediator!, _messageResolveStrategy, _resultAdapterService);
     }
 
     /// <summary>
@@ -45,9 +118,13 @@ public sealed class EventMediator(
                                      EventMediationSettings? eventMediationSettings = null,
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
-        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings, cancellationToken,
-            messageMediator, messageResolveStrategy, resultAdapterService);
+        return _engine is not null
+            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService)
+            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, cancellationToken,
+                _messageMediator!, _messageResolveStrategy, _resultAdapterService);
     }
 
     /// <summary>
@@ -62,8 +139,12 @@ public sealed class EventMediator(
     public ValueTask PublishAsync(IEvent @event, IExecutionContext context,
                              EventMediationSettings? eventMediationSettings = null)
     {
-        return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings, context.CancellationToken,
-            messageMediator, messageResolveStrategy, resultAdapterService, context);
+        return _engine is not null
+            ? EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, context.CancellationToken,
+                _engine, _serviceProvider!, _messageResolveStrategy, _resultAdapterService, context)
+            : EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
+                @event, eventMediationSettings, context.CancellationToken,
+                _messageMediator!, _messageResolveStrategy, _resultAdapterService, context);
     }
 }

--- a/src/Stella.Ergosfare.Events/EventMediator.cs
+++ b/src/Stella.Ergosfare.Events/EventMediator.cs
@@ -29,7 +29,7 @@ public sealed class EventMediator(
                              CancellationToken cancellationToken = default)
     {
         return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings ?? new EventMediationSettings(), cancellationToken,
+            @event, eventMediationSettings, cancellationToken,
             messageMediator, messageResolveStrategy, resultAdapterService);
     }
 
@@ -46,7 +46,7 @@ public sealed class EventMediator(
                                      CancellationToken cancellationToken = default) where TEvent : notnull
     {
         return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings ?? new EventMediationSettings(), cancellationToken,
+            @event, eventMediationSettings, cancellationToken,
             messageMediator, messageResolveStrategy, resultAdapterService);
     }
 
@@ -63,7 +63,7 @@ public sealed class EventMediator(
                              EventMediationSettings? eventMediationSettings = null)
     {
         return EventBroadcastInvokerCache.Get(@event.GetType()).Publish(
-            @event, eventMediationSettings ?? new EventMediationSettings(), context.CancellationToken,
+            @event, eventMediationSettings, context.CancellationToken,
             messageMediator, messageResolveStrategy, resultAdapterService, context);
     }
 }

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/EngineBackedQueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/EngineBackedQueryMediator.cs
@@ -1,0 +1,18 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Queries;
+
+namespace Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+/// <summary>
+/// DI-facing shape of <see cref="QueryMediator"/> with exactly one constructor, so
+/// container activation binds the engine-backed path deterministically — no
+/// multi-constructor ambiguity, and no per-resolution service lookup a factory
+/// registration would pay. Resolving <see cref="Stella.Ergosfare.Queries.Abstractions.IQueryMediator"/>
+/// builds this single object; the engine itself is a process-wide singleton.
+/// </summary>
+internal sealed class EngineBackedQueryMediator(
+    MessageDispatchEngine engine,
+    IServiceProvider serviceProvider,
+    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy)
+    : QueryMediator(engine, serviceProvider, messageResolveStrategy);

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
@@ -26,7 +26,8 @@ internal class QueryModule(
         // Transient, not scoped: the mediator is stateless and a transient service is handed
         // the resolving scope's provider all the same, so per-dispatch handler resolution
         // still binds to the calling scope. Scoped would add a scope lock and a
-        // resolved-services dictionary insert to every dispatch for no benefit.
-        configuration.Services.TryAddTransient<IQueryMediator, QueryMediator>();
+        // resolved-services dictionary insert to every dispatch for no benefit. The
+        // engine-backed shape makes the facade the only object built per resolution.
+        configuration.Services.TryAddTransient<IQueryMediator, EngineBackedQueryMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
@@ -23,7 +23,10 @@ internal class QueryModule(
     public void Build(IModuleConfiguration configuration)
     {
         builder(new QueryModuleBuilder(configuration.MessageRegistry));
-        // Scoped so per-dispatch handler resolution binds to the calling scope's provider.
-        configuration.Services.TryAddScoped<IQueryMediator, QueryMediator>();
+        // Transient, not scoped: the mediator is stateless and a transient service is handed
+        // the resolving scope's provider all the same, so per-dispatch handler resolution
+        // still binds to the calling scope. Scoped would add a scope lock and a
+        // resolved-services dictionary insert to every dispatch for no benefit.
+        configuration.Services.TryAddTransient<IQueryMediator, QueryMediator>();
     }
 }

--- a/src/Stella.Ergosfare.Queries/QueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries/QueryMediator.cs
@@ -113,8 +113,14 @@ public class QueryMediator : IQueryMediator
     public IAsyncEnumerable<TResult> StreamAsync<TResult>(IStreamQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
-            query, queryMediationSettings, cancellationToken, RequireMessageMediator(), _messageResolveStrategy);
+        // Engine-backed facades stream against the invoker-cached pipeline plan — no
+        // per-call mediator resolution, MediateOptions or descriptor lookup; the wrapped
+        // shape keeps the original Mediate path for foreign mediator implementations.
+        return _engine is not null
+            ? QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
+                query, queryMediationSettings, cancellationToken, _engine, _serviceProvider!, _messageResolveStrategy)
+            : QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
+                query, queryMediationSettings, cancellationToken, RequireMessageMediator(), _messageResolveStrategy);
     }
 
     /// <summary>
@@ -138,9 +144,10 @@ public class QueryMediator : IQueryMediator
     }
 
     /// <summary>
-    /// The mediator the streaming path (untouched by the engine: it mediates through
-    /// <c>Mediate(options)</c>) runs against — the wrapped instance, or on the engine
-    /// shape the scope's own registration, resolved on demand.
+    /// The mediator the wrapped-shape streaming path (which mediates through
+    /// <c>Mediate(options)</c>) runs against — the wrapped instance, or the scope's own
+    /// registration resolved on demand. Engine-backed facades never call this: their
+    /// streams run the invoker's engine fast lane.
     /// </summary>
     private IMessageMediator RequireMessageMediator()
         => _messageMediator

--- a/src/Stella.Ergosfare.Queries/QueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries/QueryMediator.cs
@@ -1,4 +1,4 @@
-﻿using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Queries.Abstractions;
@@ -11,10 +11,64 @@ namespace Stella.Ergosfare.Queries;
 /// Handles both standard queries and streaming queries using the internal message mediation pipeline,
 /// supporting pre/post/final interceptors and result adapters.
 /// </summary>
-public class QueryMediator(
-    ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
-    IMessageMediator messageMediator): IQueryMediator
+public class QueryMediator : IQueryMediator
 {
+    /// <summary>
+    /// Resolve strategy handed to the streaming invoker; identical on both construction
+    /// shapes.
+    /// </summary>
+    private readonly ActualTypeOrFirstAssignableTypeMessageResolveStrategy _messageResolveStrategy;
+
+    /// <summary>
+    /// The mediator backing the original construction shape; null when the facade is
+    /// engine-backed.
+    /// </summary>
+    private readonly IMessageMediator? _messageMediator;
+
+    /// <summary>
+    /// The singleton dispatch engine; null when the facade wraps an
+    /// <see cref="IMessageMediator"/>.
+    /// </summary>
+    private readonly MessageDispatchEngine? _engine;
+
+    /// <summary>
+    /// The scope provider handlers resolve against on the engine path; the streaming path
+    /// also resolves its <see cref="IMessageMediator"/> from it on demand.
+    /// </summary>
+    private readonly IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// Wraps an existing <see cref="IMessageMediator"/> — the original construction shape,
+    /// kept for direct construction and foreign mediator implementations.
+    /// </summary>
+    public QueryMediator(
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy,
+        IMessageMediator messageMediator)
+    {
+        _messageResolveStrategy = messageResolveStrategy;
+        _messageMediator = messageMediator;
+    }
+
+    /// <summary>
+    /// Engine-backed construction: queries go straight to the process-wide engine with
+    /// <paramref name="serviceProvider"/> as the handler-resolution scope, making the
+    /// facade the only object built per resolution.
+    /// </summary>
+    /// <param name="engine">The singleton dispatch engine.</param>
+    /// <param name="serviceProvider">The provider of the scope this facade serves.</param>
+    /// <param name="messageResolveStrategy">Resolve strategy used by the streaming path.</param>
+    public QueryMediator(
+        MessageDispatchEngine engine,
+        IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy messageResolveStrategy)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        _engine = engine;
+        _serviceProvider = serviceProvider;
+        _messageResolveStrategy = messageResolveStrategy;
+    }
 
     /// <summary>
     /// Executes a query and returns a single result of type <typeparamref name="TResult"/>.
@@ -30,14 +84,21 @@ public class QueryMediator(
     public ValueTask<TResult> QueryAsync<TResult>(IQuery<TResult> query, QueryMediationSettings? queryMediationSettings = null,
         CancellationToken cancellationToken = default)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            query,
-            queryMediationSettings?.Items,
-            cancellationToken,
-            queryMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                query,
+                _serviceProvider!,
+                queryMediationSettings?.Items,
+                cancellationToken,
+                queryMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                query,
+                queryMediationSettings?.Items,
+                cancellationToken,
+                queryMediationSettings?.Filters.Groups);
     }
 
-    
+
     /// <summary>
     /// Executes a streaming query and returns an asynchronous enumerable of results.
     /// The query is processed through the streaming pipeline, supporting interceptors and result adapters.
@@ -53,7 +114,7 @@ public class QueryMediator(
         CancellationToken cancellationToken = default)
     {
         return QueryStreamInvokerCache.Get<TResult>(query.GetType()).Stream(
-            query, queryMediationSettings, cancellationToken, messageMediator, messageResolveStrategy);
+            query, queryMediationSettings, cancellationToken, RequireMessageMediator(), _messageResolveStrategy);
     }
 
     /// <summary>
@@ -64,9 +125,26 @@ public class QueryMediator(
     public ValueTask<TResult> QueryAsync<TResult>(IQuery<TResult> query, IExecutionContext context,
         QueryMediationSettings? queryMediationSettings = null)
     {
-        return messageMediator.DispatchAsync<TResult>(
-            query,
-            context,
-            queryMediationSettings?.Filters.Groups);
+        return _engine is not null
+            ? _engine.DispatchAsync<TResult>(
+                query,
+                context,
+                _serviceProvider!,
+                queryMediationSettings?.Filters.Groups)
+            : _messageMediator!.DispatchAsync<TResult>(
+                query,
+                context,
+                queryMediationSettings?.Filters.Groups);
     }
+
+    /// <summary>
+    /// The mediator the streaming path (untouched by the engine: it mediates through
+    /// <c>Mediate(options)</c>) runs against — the wrapped instance, or on the engine
+    /// shape the scope's own registration, resolved on demand.
+    /// </summary>
+    private IMessageMediator RequireMessageMediator()
+        => _messageMediator
+           ?? (IMessageMediator?)_serviceProvider!.GetService(typeof(IMessageMediator))
+           ?? throw new InvalidOperationException(
+               "Streaming dispatch resolves IMessageMediator from the scope; register Ergosfare through AddErgosfare.");
 }

--- a/src/Stella.Ergosfare.Queries/StreamInvoker.cs
+++ b/src/Stella.Ergosfare.Queries/StreamInvoker.cs
@@ -2,7 +2,10 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Core.Internal.Factories;
 using Stella.Ergosfare.Queries.Abstractions;
 
 namespace Stella.Ergosfare.Queries;
@@ -18,6 +21,17 @@ internal interface IQueryStreamInvoker<out TResult>
 {
     IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy);
+
+    /// <summary>
+    /// Engine-backed streaming: the concrete dispatch machinery is known by construction,
+    /// so the stream runs against the invoker-cached, registry-version-guarded pipeline
+    /// plan — no <c>MediateOptions</c>, no per-call descriptor lookup, no scope-resolved
+    /// mediator. Grouped streams resolve the same group-filtered dependencies the Mediate
+    /// path would build, from a last-used group-set slot.
+    /// </summary>
+    IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy);
 }
 
 internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<TResult>
@@ -25,12 +39,19 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
 {
     private static readonly string[] EmptyGroups = [];
 
+    /// <summary>
+    /// The stream path has always run against a fresh, empty adapter service (the facade
+    /// carries none); a single shared empty instance preserves that behavior without the
+    /// per-call allocation. Never exposed, so it cannot be mutated.
+    /// </summary>
+    private static readonly ResultAdapterService SharedEmptyAdapters = new();
+
     public IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
         IMessageMediator mediator, ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
     {
         var options = new MediateOptions<TQuery, IAsyncEnumerable<TResult>>
         {
-            MessageMediationStrategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(new ResultAdapterService(), cancellationToken),
+            MessageMediationStrategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(SharedEmptyAdapters, cancellationToken),
             MessageResolveStrategy = resolveStrategy,
             CancellationToken = cancellationToken,
             Items = settings?.Items,
@@ -38,6 +59,123 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
         };
 
         return mediator.Mediate((TQuery)query, options);
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
+        MessageDispatchEngine engine, IServiceProvider serviceProvider,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        var groups = settings?.Filters.Groups;
+        var dependencies = groups is null or List<string> { Count: 0 } or string[] { Length: 0 }
+            ? GetPlan(engine.DependenciesFactory, resolveStrategy)
+            : GetGroupedPlan(engine.DependenciesFactory, resolveStrategy, groups);
+
+        // Exactly the construction Mediate performs for streams: a fresh, unpooled
+        // context — enumeration happens after this call returns, so its completion is
+        // not observable here and the context cannot be pooled.
+        var context = new ErgosfareExecutionContext(settings?.Items, cancellationToken);
+        var strategy = new SingleStreamHandlerMediationStrategy<TQuery, TResult>(SharedEmptyAdapters, cancellationToken);
+
+        return strategy.Mediate((TQuery)query, dependencies, context, serviceProvider);
+    }
+
+    /// <summary>
+    /// The group-less pipeline plan for <typeparamref name="TQuery"/>, cached on the
+    /// invoker and re-validated against the registry version — the broadcast invoker's
+    /// pattern. The invoker is process-wide while factories are per-container, so the
+    /// factory reference is part of the cache key and one container's plan is never
+    /// served to another.
+    /// </summary>
+    private IMessageDependencies? _cachedDependencies;
+    private MessageDependenciesFactory? _cachedFactory;
+    private int _cachedVersion = int.MinValue;
+
+    private IMessageDependencies GetPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null
+                && ReferenceEquals(_cachedFactory, typedFactory)
+                && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
+            _cachedDependencies = dependencies;
+            _cachedFactory = typedFactory;
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        return BuildPlan(dependenciesFactory, resolveStrategy, EmptyGroups);
+    }
+
+    /// <summary>
+    /// Grouped counterpart of <see cref="GetPlan"/>: a single last-used
+    /// (factory, group set) slot with an ordinal element-wise compare, snapshotting the
+    /// caller's group sequence so later mutation of a reused settings instance reads as a
+    /// different group set. A slot miss only rebuilds through the factory's process-wide
+    /// dependency cache.
+    /// </summary>
+    private GroupedPlanSlot? _cachedGroupedPlan;
+
+    private sealed class GroupedPlanSlot(
+        MessageDependenciesFactory factory,
+        string[] groups,
+        IMessageDependencies dependencies,
+        int version)
+    {
+        public readonly MessageDependenciesFactory Factory = factory;
+        public readonly string[] Groups = groups;
+        public readonly IMessageDependencies Dependencies = dependencies;
+        public readonly int Version = version;
+    }
+
+    private IMessageDependencies GetGroupedPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        IEnumerable<string> groups)
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var slot = _cachedGroupedPlan;
+
+            if (slot is not null
+                && ReferenceEquals(slot.Factory, typedFactory)
+                && slot.Version == typedFactory.CurrentRegistryVersion
+                && Core.Internal.Mediator.PipelineExecutorCache.GroupsMatch(groups, slot.Groups))
+            {
+                return slot.Dependencies;
+            }
+
+            string[] materialized = [.. groups];
+            var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
+            _cachedGroupedPlan = new GroupedPlanSlot(
+                typedFactory, materialized, dependencies, typedFactory.CurrentRegistryVersion);
+            return dependencies;
+        }
+
+        return BuildPlan(dependenciesFactory, resolveStrategy, [.. groups]);
+    }
+
+    private static IMessageDependencies BuildPlan(
+        Core.Abstractions.Factories.IMessageDependenciesFactory factory,
+        ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
+        string[] groups)
+    {
+        // Mirrors MessageMediator.Mediate's descriptor handling for the options the
+        // original path used: RegisterPlainMessagesOnSpot was never set for streams, so
+        // an unregistered query type throws NoHandlerFoundException here as it did there.
+        var descriptor = resolveStrategy.Find(typeof(TQuery))
+                         ?? throw new NoHandlerFoundException(typeof(TQuery));
+
+        return factory.Create(typeof(TQuery), descriptor, groups);
     }
 }
 

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -105,7 +105,9 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 QueryBuilderHasRegisterDescriptors: HasRegisterDescriptors(queryBuilder),
                 EventBuilderHasRegisterDescriptors: HasRegisterDescriptors(eventBuilder),
                 HasDispatchRoots: dispatchRoots is not null,
-                DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty);
+                DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty,
+                DispatchRootsHasResultPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddResultPlan").IsEmpty,
+                DispatchRootsHasPlanFactories: dispatchRoots is not null && HasFactoryOverload(dispatchRoots));
         });
 
         // Reference scanning is default-on; consumers opt out per project through the
@@ -128,6 +130,71 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
 
     private static bool HasRegisterDescriptors(INamedTypeSymbol? builder)
         => builder is not null && !builder.GetMembers("RegisterDescriptors").IsEmpty;
+
+    /// <summary>
+    ///     Whether the referenced <c>GeneratedDispatchRoots</c> accepts a plan overload
+    ///     with a direct-construction factory parameter — the surface the
+    ///     <c>static () => new THandler()</c> emission requires.
+    /// </summary>
+    private static bool HasFactoryOverload(INamedTypeSymbol dispatchRoots)
+    {
+        foreach (var member in dispatchRoots.GetMembers("AddVoidPlan"))
+        {
+            if (member is IMethodSymbol { Parameters.Length: 1 })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Whether generated code can construct the type with <c>new()</c> and doing so
+    ///     is provably interchangeable with resolving its plain transient registration:
+    ///     a concrete, non-generic class whose ONLY instance constructor is public and
+    ///     parameterless (the container's greedy constructor selection would pick any
+    ///     richer constructor, and it only considers public ones), with no <c>required</c>
+    ///     members (a generated <c>new()</c> would fail compilation), implementing
+    ///     neither <c>IDisposable</c> nor <c>IAsyncDisposable</c> (the container tracks
+    ///     transient disposables; direct construction would not).
+    /// </summary>
+    private static bool IsDirectlyConstructible(INamedTypeSymbol symbol)
+    {
+        if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract || symbol.IsGenericType)
+        {
+            return false;
+        }
+
+        foreach (var iface in symbol.AllInterfaces)
+        {
+            if (iface is { Name: "IDisposable" or "IAsyncDisposable", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } })
+            {
+                return false;
+            }
+        }
+
+        // Required members anywhere in the hierarchy make an emitted `new()` a compile
+        // error (CS9035); the reflection-based container activation the plan replaces
+        // does not enforce them, so such types stay on the container path.
+        for (var type = symbol; type is not null; type = type.BaseType)
+        {
+            foreach (var member in type.GetMembers())
+            {
+                if (member is IPropertySymbol { IsRequired: true } or IFieldSymbol { IsRequired: true })
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Exactly one instance constructor, public and parameterless: with any richer
+        // constructor present (records' synthesized copy constructor included), the
+        // container's selection and `new()` can diverge — dropping dependencies the
+        // container would have injected.
+        return symbol.InstanceConstructors.Length == 1
+               && symbol.InstanceConstructors[0] is { Parameters.IsEmpty: true, DeclaredAccessibility: Accessibility.Public };
+    }
 
     /// <summary>
     ///     Projects a candidate type declaration to its registration model, or <c>null</c>
@@ -180,6 +247,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             DiscoveryKeys = GetDiscoveryKeys(symbol),
             IsDispatchableMessage = isDispatchable,
             DispatchResults = isDispatchable ? GetDispatchResults(symbol) : ImmutableArray<DispatchResultModel>.Empty,
+            IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
         };
     }
 
@@ -551,6 +619,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             DiscoveryKeys = GetDiscoveryKeys(symbol),
             IsDispatchableMessage = isDispatchable,
             DispatchResults = isDispatchable ? GetDispatchResults(symbol) : ImmutableArray<DispatchResultModel>.Empty,
+            IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
         };
     }
 
@@ -628,7 +697,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             ? ComputeVoidPlans(types)
             : (IReadOnlyList<VoidPlanModel>)Array.Empty<VoidPlanModel>();
 
-        var source = RegistrationEmitter.Emit(types, availability, voidPlans, GeneratorVersion);
+        var resultPlans = availability.DispatchRootsHasResultPlans
+            ? ComputeResultPlans(types)
+            : (IReadOnlyList<ResultPlanModel>)Array.Empty<ResultPlanModel>();
+
+        var source = RegistrationEmitter.Emit(types, availability, voidPlans, resultPlans, GeneratorVersion);
         context.AddSource("ErgosfareRegistrations.g.cs", SourceText.From(source, Encoding.UTF8));
     }
 
@@ -646,9 +719,102 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     /// </summary>
     private static List<VoidPlanModel> ComputeVoidPlans(List<RegistrableTypeModel> types)
     {
-        var handlerCounts = new Dictionary<string, int>(StringComparer.Ordinal);
-        var soleHandlers = new Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)>(StringComparer.Ordinal);
-        var interceptedMessages = new HashSet<string>(StringComparer.Ordinal);
+        CollectPipelineFacts(types, out var handlerCounts, out var soleHandlers, out var interceptedMessages);
+
+        var plans = new List<VoidPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || !type.IsCommand)
+            {
+                continue;
+            }
+
+            if (!TryGetSolePlannableHandler(type, handlerCounts, soleHandlers, interceptedMessages,
+                    out var handler, out var descriptor))
+            {
+                continue;
+            }
+
+            // The sole handler must be the async void contract.
+            if (descriptor.ResultTypeExpression != ValueTaskExpression)
+            {
+                continue;
+            }
+
+            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression, handler.IsDirectlyConstructible));
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    ///     Result-producing counterpart of <see cref="ComputeVoidPlans"/>: a dispatchable
+    ///     command/query with exactly one closed, non-stream result contract qualifies
+    ///     when its whole discovered pipeline is a single async handler producing exactly
+    ///     that result. Equally conservative and equally advisory — the runtime
+    ///     re-validates per registry version.
+    /// </summary>
+    private static List<ResultPlanModel> ComputeResultPlans(List<RegistrableTypeModel> types)
+    {
+        CollectPipelineFacts(types, out var handlerCounts, out var soleHandlers, out var interceptedMessages);
+
+        var plans = new List<ResultPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || (!type.IsCommand && !type.IsQuery))
+            {
+                continue;
+            }
+
+            // Exactly one closed result contract, and not a streaming one — a message
+            // with several result shapes is dispatched with executor-side result typing
+            // the plan cannot pin down.
+            if (type.DispatchResults.Length != 1 || type.DispatchResults[0].IsStream)
+            {
+                continue;
+            }
+
+            var dispatchResult = type.DispatchResults[0];
+
+            if (!TryGetSolePlannableHandler(type, handlerCounts, soleHandlers, interceptedMessages,
+                    out var handler, out var descriptor))
+            {
+                continue;
+            }
+
+            // The sole handler must be the async contract producing exactly the message's
+            // declared result (sync contracts carry the bare result type and fall out).
+            if (descriptor.ResultTypeExpression != ValueTaskExpression + "<" + dispatchResult.ResultTypeExpression + ">")
+            {
+                continue;
+            }
+
+            plans.Add(new ResultPlanModel(
+                type.TypeofExpression,
+                dispatchResult.ResultTypeExpression,
+                handler.TypeofExpression,
+                handler.IsDirectlyConstructible));
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    ///     Indexes the discovered descriptors by message type: main-handler counts, the
+    ///     (last-seen) sole handler per message, and the set of messages any interceptor
+    ///     targets directly — the shared facts both plan computations qualify against.
+    /// </summary>
+    private static void CollectPipelineFacts(
+        List<RegistrableTypeModel> types,
+        out Dictionary<string, int> handlerCounts,
+        out Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)> soleHandlers,
+        out HashSet<string> interceptedMessages)
+    {
+        handlerCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        soleHandlers = new Dictionary<string, (RegistrableTypeModel, DescriptorModel)>(StringComparer.Ordinal);
+        interceptedMessages = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var type in types)
         {
@@ -666,43 +832,41 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 }
             }
         }
+    }
 
-        var plans = new List<VoidPlanModel>();
+    /// <summary>
+    ///     The shared plan qualification: the message has exactly one discovered main
+    ///     handler, no interceptor targets it directly, and that handler is accessible
+    ///     and discoverable by default (an unkeyed, ungrouped registration — anything
+    ///     else may not be registered, or not in the default-group pipeline the plan
+    ///     serves).
+    /// </summary>
+    private static bool TryGetSolePlannableHandler(
+        RegistrableTypeModel type,
+        Dictionary<string, int> handlerCounts,
+        Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)> soleHandlers,
+        HashSet<string> interceptedMessages,
+        out RegistrableTypeModel handler,
+        out DescriptorModel descriptor)
+    {
+        handler = default;
+        descriptor = default;
 
-        foreach (var type in types)
+        if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
         {
-            if (!type.IsDispatchableMessage || !type.IsCommand)
-            {
-                continue;
-            }
-
-            if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
-            {
-                continue;
-            }
-
-            if (interceptedMessages.Contains(type.TypeofExpression))
-            {
-                continue;
-            }
-
-            var (handler, descriptor) = soleHandlers[type.TypeofExpression];
-
-            // The sole handler must be the async void contract, discoverable by default
-            // (an unkeyed, ungrouped registration — anything else may not be registered,
-            // or not in the default-group pipeline the plan serves).
-            if (descriptor.ResultTypeExpression != ValueTaskExpression
-                || !handler.IsAccessible
-                || !handler.DiscoveryKeys.IsEmpty
-                || handler.GroupsExpression is not null)
-            {
-                continue;
-            }
-
-            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression));
+            return false;
         }
 
-        return plans;
+        if (interceptedMessages.Contains(type.TypeofExpression))
+        {
+            return false;
+        }
+
+        (handler, descriptor) = soleHandlers[type.TypeofExpression];
+
+        return handler.IsAccessible
+               && handler.DiscoveryKeys.IsEmpty
+               && handler.GroupsExpression is null;
     }
 
     private static void AddModels(

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -93,6 +93,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             var commandBuilder = compilation.GetTypeByMetadataName(CommandBuilderMetadataName);
             var queryBuilder = compilation.GetTypeByMetadataName(QueryBuilderMetadataName);
             var eventBuilder = compilation.GetTypeByMetadataName(EventBuilderMetadataName);
+            var dispatchRoots = compilation.GetTypeByMetadataName(DispatchRootsMetadataName);
 
             return new ModuleBuilderAvailability(
                 HasMessageRegistry: compilation.GetTypeByMetadataName(MessageRegistryMetadataName) is not null,
@@ -103,7 +104,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 CommandBuilderHasRegisterDescriptors: HasRegisterDescriptors(commandBuilder),
                 QueryBuilderHasRegisterDescriptors: HasRegisterDescriptors(queryBuilder),
                 EventBuilderHasRegisterDescriptors: HasRegisterDescriptors(eventBuilder),
-                HasDispatchRoots: compilation.GetTypeByMetadataName(DispatchRootsMetadataName) is not null);
+                HasDispatchRoots: dispatchRoots is not null,
+                DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty);
         });
 
         // Reference scanning is default-on; consumers opt out per project through the
@@ -622,8 +624,85 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         // Deterministic output regardless of declaration/discovery order.
         types.Sort(static (x, y) => string.CompareOrdinal(x.TypeofExpression, y.TypeofExpression));
 
-        var source = RegistrationEmitter.Emit(types, availability, GeneratorVersion);
+        var voidPlans = availability.DispatchRootsHasVoidPlans
+            ? ComputeVoidPlans(types)
+            : (IReadOnlyList<VoidPlanModel>)Array.Empty<VoidPlanModel>();
+
+        var source = RegistrationEmitter.Emit(types, availability, voidPlans, GeneratorVersion);
         context.AddSource("ErgosfareRegistrations.g.cs", SourceText.From(source, Encoding.UTF8));
+    }
+
+    /// <summary>
+    ///     Computes the compile-time void pipeline plans: a dispatchable command message
+    ///     qualifies when the whole discovered pipeline for it is exactly one main-handler
+    ///     descriptor, that descriptor is the result-less async contract
+    ///     (<c>IAsyncHandler&lt;TMessage&gt;</c>), its handler participates in default
+    ///     discovery in the default group, and no discovered interceptor targets the
+    ///     message directly. The check is deliberately conservative and only ever costs
+    ///     the speedup when wrong: the runtime executor re-validates the actual pipeline
+    ///     per registry version and falls back to the runtime dispatch shape on any
+    ///     mismatch (covariant handlers or interceptors registered for base contracts,
+    ///     keyed selections, runtime registrations).
+    /// </summary>
+    private static List<VoidPlanModel> ComputeVoidPlans(List<RegistrableTypeModel> types)
+    {
+        var handlerCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var soleHandlers = new Dictionary<string, (RegistrableTypeModel Model, DescriptorModel Descriptor)>(StringComparer.Ordinal);
+        var interceptedMessages = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var type in types)
+        {
+            foreach (var descriptor in type.Descriptors)
+            {
+                if (descriptor.Kind == DescriptorKind.MainHandler)
+                {
+                    handlerCounts.TryGetValue(descriptor.MessageTypeExpression, out var count);
+                    handlerCounts[descriptor.MessageTypeExpression] = count + 1;
+                    soleHandlers[descriptor.MessageTypeExpression] = (type, descriptor);
+                }
+                else
+                {
+                    interceptedMessages.Add(descriptor.MessageTypeExpression);
+                }
+            }
+        }
+
+        var plans = new List<VoidPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || !type.IsCommand)
+            {
+                continue;
+            }
+
+            if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
+            {
+                continue;
+            }
+
+            if (interceptedMessages.Contains(type.TypeofExpression))
+            {
+                continue;
+            }
+
+            var (handler, descriptor) = soleHandlers[type.TypeofExpression];
+
+            // The sole handler must be the async void contract, discoverable by default
+            // (an unkeyed, ungrouped registration — anything else may not be registered,
+            // or not in the default-group pipeline the plan serves).
+            if (descriptor.ResultTypeExpression != ValueTaskExpression
+                || !handler.IsAccessible
+                || !handler.DiscoveryKeys.IsEmpty
+                || handler.GroupsExpression is not null)
+            {
+                continue;
+            }
+
+            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression));
+        }
+
+        return plans;
     }
 
     private static void AddModels(

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -17,6 +17,7 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// <param name="QueryBuilderHasRegisterDescriptors">Whether the query builder exposes <c>RegisterDescriptors</c>.</param>
 /// <param name="EventBuilderHasRegisterDescriptors">Whether the event builder exposes <c>RegisterDescriptors</c>.</param>
 /// <param name="HasDispatchRoots">Whether the <c>GeneratedDispatchRoots</c> store is resolvable.</param>
+/// <param name="DispatchRootsHasVoidPlans">Whether the store exposes <c>AddVoidPlan</c> (compile-time pipeline plans).</param>
 internal readonly record struct ModuleBuilderAvailability(
     bool HasMessageRegistry,
     bool HasCommandModuleBuilder,
@@ -26,4 +27,5 @@ internal readonly record struct ModuleBuilderAvailability(
     bool CommandBuilderHasRegisterDescriptors,
     bool QueryBuilderHasRegisterDescriptors,
     bool EventBuilderHasRegisterDescriptors,
-    bool HasDispatchRoots);
+    bool HasDispatchRoots,
+    bool DispatchRootsHasVoidPlans);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -18,6 +18,12 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// <param name="EventBuilderHasRegisterDescriptors">Whether the event builder exposes <c>RegisterDescriptors</c>.</param>
 /// <param name="HasDispatchRoots">Whether the <c>GeneratedDispatchRoots</c> store is resolvable.</param>
 /// <param name="DispatchRootsHasVoidPlans">Whether the store exposes <c>AddVoidPlan</c> (compile-time pipeline plans).</param>
+/// <param name="DispatchRootsHasResultPlans">Whether the store exposes <c>AddResultPlan</c> (result pipeline plans).</param>
+/// <param name="DispatchRootsHasPlanFactories">
+///     Whether the plan surface accepts direct-construction factories (the
+///     <c>Func&lt;THandler&gt;</c> overloads); older packages take only the parameterless
+///     form, and emission degrades accordingly.
+/// </param>
 internal readonly record struct ModuleBuilderAvailability(
     bool HasMessageRegistry,
     bool HasCommandModuleBuilder,
@@ -28,4 +34,6 @@ internal readonly record struct ModuleBuilderAvailability(
     bool QueryBuilderHasRegisterDescriptors,
     bool EventBuilderHasRegisterDescriptors,
     bool HasDispatchRoots,
-    bool DispatchRootsHasVoidPlans);
+    bool DispatchRootsHasVoidPlans,
+    bool DispatchRootsHasResultPlans,
+    bool DispatchRootsHasPlanFactories);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -93,6 +93,15 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
     /// </summary>
     public required ImmutableArray<DispatchResultModel> DispatchResults { get; init; }
 
+    /// <summary>
+    ///     Whether generated code can construct the type with <c>new()</c> and doing so is
+    ///     interchangeable with a plain transient container resolution: a concrete,
+    ///     non-generic class with an accessible parameterless constructor that is neither
+    ///     <c>IDisposable</c> nor <c>IAsyncDisposable</c>. Feeds the pipeline plans'
+    ///     direct-construction factories; meaningful for handler types only.
+    /// </summary>
+    public required bool IsDirectlyConstructible { get; init; }
+
     public bool Equals(RegistrableTypeModel other)
     {
         if (TypeofExpression != other.TypeofExpression
@@ -106,6 +115,7 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
             || GroupsExpression != other.GroupsExpression
             || ReferencedAssemblyName != other.ReferencedAssemblyName
             || IsDispatchableMessage != other.IsDispatchableMessage
+            || IsDirectlyConstructible != other.IsDirectlyConstructible
             || Descriptors.Length != other.Descriptors.Length
             || DiscoveryKeys.Length != other.DiscoveryKeys.Length
             || DispatchResults.Length != other.DispatchResults.Length)

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
@@ -1,0 +1,23 @@
+namespace Stella.Ergosfare.SourceGenerator.Models;
+
+/// <summary>
+///     A compile-time result pipeline plan: a dispatchable command/query message with a
+///     single closed result contract whose entire discovered pipeline is one
+///     default-discovery, default-group async result handler. Emitted as
+///     <c>GeneratedDispatchRoots.AddResultPlan&lt;TMessage, TResult, THandler&gt;()</c> so
+///     the runtime executor closes over all three types and calls the handler
+///     devirtualized. Advisory exactly like the void plan: the runtime re-validates the
+///     pipeline per registry version and a mismatched plan only loses the speedup.
+/// </summary>
+/// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
+/// <param name="ResultTypeExpression">Fully qualified expression of the closed result type.</param>
+/// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>
+/// <param name="HasDirectConstruction">
+///     Whether the handler qualifies for the plan's direct-construction factory; see
+///     <see cref="RegistrableTypeModel.IsDirectlyConstructible"/>.
+/// </param>
+internal readonly record struct ResultPlanModel(
+    string MessageTypeExpression,
+    string ResultTypeExpression,
+    string HandlerTypeExpression,
+    bool HasDirectConstruction);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
@@ -10,6 +10,12 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// </summary>
 /// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
 /// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>
+/// <param name="HasDirectConstruction">
+///     Whether the handler qualifies for the plan's direct-construction factory
+///     (<c>static () => new THandler()</c>); see
+///     <see cref="RegistrableTypeModel.IsDirectlyConstructible"/>.
+/// </param>
 internal readonly record struct VoidPlanModel(
     string MessageTypeExpression,
-    string HandlerTypeExpression);
+    string HandlerTypeExpression,
+    bool HasDirectConstruction);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
@@ -1,0 +1,15 @@
+namespace Stella.Ergosfare.SourceGenerator.Models;
+
+/// <summary>
+///     A compile-time void pipeline plan: a dispatchable command message whose entire
+///     discovered pipeline is a single default-discovery, default-group async handler.
+///     Emitted as <c>GeneratedDispatchRoots.AddVoidPlan&lt;TMessage, THandler&gt;()</c> so
+///     the runtime executor closes over both types and calls the handler devirtualized.
+///     The runtime re-validates the pipeline per registry version, so a plan that turns
+///     out not to match the actual registrations only loses the speedup, never behavior.
+/// </summary>
+/// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
+/// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>
+internal readonly record struct VoidPlanModel(
+    string MessageTypeExpression,
+    string HandlerTypeExpression);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -40,6 +40,7 @@ internal static class RegistrationEmitter
     public static string Emit(
         IReadOnlyList<RegistrableTypeModel> types,
         ModuleBuilderAvailability builders,
+        IReadOnlyList<VoidPlanModel> voidPlans,
         string generatorVersion)
     {
         var useDescriptors = builders.HasDescriptorFactory;
@@ -97,7 +98,7 @@ internal static class RegistrationEmitter
 
         if (emitDispatchRoots)
         {
-            EmitDispatchRoots(sb, ref wroteMember, types);
+            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans);
         }
 
         EmitMatchesHelper(sb, ref wroteMember);
@@ -241,7 +242,8 @@ internal static class RegistrationEmitter
     private static void EmitDispatchRoots(
         StringBuilder sb,
         ref bool wroteMember,
-        IReadOnlyList<RegistrableTypeModel> types)
+        IReadOnlyList<RegistrableTypeModel> types,
+        IReadOnlyList<VoidPlanModel> voidPlans)
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        private static void RootDispatchInstantiations()");
@@ -264,6 +266,17 @@ internal static class RegistrationEmitter
                   .Append(type.TypeofExpression).Append(", ").Append(result.ResultTypeExpression)
                   .AppendLine(">();");
             }
+        }
+
+        // Compile-time pipeline plans: the runtime re-validates each one against the
+        // registry per version, so a plan can only lose its speedup, never change
+        // behavior.
+        foreach (var plan in voidPlans)
+        {
+            sb.Append("            ").Append(DispatchRootsFullName)
+              .Append(".AddVoidPlan<").Append(plan.MessageTypeExpression)
+              .Append(", ").Append(plan.HandlerTypeExpression)
+              .AppendLine(">();");
         }
 
         sb.AppendLine("        }");

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -41,6 +41,7 @@ internal static class RegistrationEmitter
         IReadOnlyList<RegistrableTypeModel> types,
         ModuleBuilderAvailability builders,
         IReadOnlyList<VoidPlanModel> voidPlans,
+        IReadOnlyList<ResultPlanModel> resultPlans,
         string generatorVersion)
     {
         var useDescriptors = builders.HasDescriptorFactory;
@@ -98,7 +99,8 @@ internal static class RegistrationEmitter
 
         if (emitDispatchRoots)
         {
-            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans);
+            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans, resultPlans,
+                builders.DispatchRootsHasPlanFactories);
         }
 
         EmitMatchesHelper(sb, ref wroteMember);
@@ -243,7 +245,9 @@ internal static class RegistrationEmitter
         StringBuilder sb,
         ref bool wroteMember,
         IReadOnlyList<RegistrableTypeModel> types,
-        IReadOnlyList<VoidPlanModel> voidPlans)
+        IReadOnlyList<VoidPlanModel> voidPlans,
+        IReadOnlyList<ResultPlanModel> resultPlans,
+        bool emitPlanFactories)
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        private static void RootDispatchInstantiations()");
@@ -270,13 +274,38 @@ internal static class RegistrationEmitter
 
         // Compile-time pipeline plans: the runtime re-validates each one against the
         // registry per version, so a plan can only lose its speedup, never change
-        // behavior.
+        // behavior. Directly-constructible handlers additionally carry a construction
+        // factory, which the runtime uses only after verifying the handler's effective
+        // DI registration is the module's own plain transient one.
         foreach (var plan in voidPlans)
         {
             sb.Append("            ").Append(DispatchRootsFullName)
               .Append(".AddVoidPlan<").Append(plan.MessageTypeExpression)
               .Append(", ").Append(plan.HandlerTypeExpression)
-              .AppendLine(">();");
+              .Append(">(");
+
+            if (emitPlanFactories && plan.HasDirectConstruction)
+            {
+                sb.Append("static () => new ").Append(plan.HandlerTypeExpression).Append("()");
+            }
+
+            sb.AppendLine(");");
+        }
+
+        foreach (var plan in resultPlans)
+        {
+            sb.Append("            ").Append(DispatchRootsFullName)
+              .Append(".AddResultPlan<").Append(plan.MessageTypeExpression)
+              .Append(", ").Append(plan.ResultTypeExpression)
+              .Append(", ").Append(plan.HandlerTypeExpression)
+              .Append(">(");
+
+            if (emitPlanFactories && plan.HasDirectConstruction)
+            {
+                sb.Append("static () => new ").Append(plan.HandlerTypeExpression).Append("()");
+            }
+
+            sb.AppendLine(");");
         }
 
         sb.AppendLine("        }");

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -4,7 +4,9 @@ using BenchmarkDotNet.Running;
 using Microsoft.Extensions.DependencyInjection;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
@@ -53,6 +55,63 @@ public sealed class SecondPingEventHandler : IEventHandler<PingEvent>
     public ValueTask HandleAsync(PingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
+// Grouped variants on their own message types, so the grouped rows measure the grouped
+// lane without changing the default rows' pipelines (a second handler on VoidCommand
+// would suppress its compile-time plan, for instance).
+
+public sealed class GroupedCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+
+[Group("bench")]
+public sealed class GroupedCommandHandler : ICommandHandler<GroupedCommand>
+{
+    public ValueTask HandleAsync(GroupedCommand command, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+public sealed class GroupedPingEvent : IEvent { }
+
+[Group("bench")]
+public sealed class FirstGroupedPingEventHandler : IEventHandler<GroupedPingEvent>
+{
+    public ValueTask HandleAsync(GroupedPingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+[Group("bench")]
+public sealed class SecondGroupedPingEventHandler : IEventHandler<GroupedPingEvent>
+{
+    public ValueTask HandleAsync(GroupedPingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+// ---------------------------------------------------------------------------
+// Mediator (martinothamar/Mediator, source-generated) messages & handlers
+// ---------------------------------------------------------------------------
+
+public sealed class MediatorSgVoidCommand : Mediator.ICommand { }
+
+public sealed class MediatorSgVoidCommandHandler : Mediator.ICommandHandler<MediatorSgVoidCommand>
+{
+    public ValueTask<Mediator.Unit> Handle(MediatorSgVoidCommand command, CancellationToken cancellationToken)
+        => new(Mediator.Unit.Value);
+}
+
+public sealed class MediatorSgIntQuery : Mediator.IQuery<int> { }
+
+public sealed class MediatorSgIntQueryHandler : Mediator.IQueryHandler<MediatorSgIntQuery, int>
+{
+    public ValueTask<int> Handle(MediatorSgIntQuery query, CancellationToken cancellationToken) => new(7);
+}
+
+public sealed class MediatorSgPingNotification : Mediator.INotification { }
+
+public sealed class FirstMediatorSgPingHandler : Mediator.INotificationHandler<MediatorSgPingNotification>
+{
+    public ValueTask Handle(MediatorSgPingNotification notification, CancellationToken cancellationToken) => default;
+}
+
+public sealed class SecondMediatorSgPingHandler : Mediator.INotificationHandler<MediatorSgPingNotification>
+{
+    public ValueTask Handle(MediatorSgPingNotification notification, CancellationToken cancellationToken) => default;
+}
+
 // ---------------------------------------------------------------------------
 // MediatR requests & handlers
 // ---------------------------------------------------------------------------
@@ -93,7 +152,14 @@ public sealed class SecondMediatrPingHandler : INotificationHandler<MediatrPingN
 /// baseline — that is the floor the public facades add their convenience on top of, and
 /// the Ratio column reads as "what does the facade (or MediatR) cost relative to it".
 /// Within each category: a void dispatch, a result-returning dispatch, and a two-handler
-/// event publish, for Ergosfare and MediatR alike.
+/// event publish, for Ergosfare and the competitors alike.
+/// <para>Competitors run their out-of-the-box defaults: MediatR (reflection-based,
+/// transient handlers) as the ubiquitous baseline, and martinothamar/Mediator
+/// (source-generated dispatch, singleton lifetime by default) as the fastest widely-used
+/// alternative — the <c>MediatorSg_*</c> rows. Ergosfare's default rows resolve transient
+/// handlers per dispatch; the <c>Command_Void_Memoized</c> row shows the zero-allocation
+/// shape <c>ForceMemoizedHandlers()</c> (or plain singleton handler registration) yields,
+/// which is the apples-to-apples comparison against Mediator's singleton default.</para>
 /// </summary>
 [MemoryDiagnoser]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
@@ -102,21 +168,39 @@ public class MediationBenchmark
 {
     private ServiceProvider _ergosfare = null!;
     private ServiceProvider _ergosfareGenerated = null!;
+    private ServiceProvider _ergosfareMemoized = null!;
     private ServiceProvider _mediatr = null!;
+    private ServiceProvider _mediatorSg = null!;
 
     private IMessageMediator _engine = null!;
+    private MessageDispatchEngine _dispatchEngine = null!;
     private ICommandMediator _commands = null!;
     private ICommandMediator _generatedCommands = null!;
+    private ICommandMediator _memoizedCommands = null!;
     private IQueryMediator _queries = null!;
+    private IQueryMediator _generatedQueries = null!;
     private IEventMediator _events = null!;
     private IMediator _mediator = null!;
+    private Mediator.IMediator _martinMediator = null!;
 
     private readonly VoidCommand _voidCommand = new();
     private readonly IntQuery _intQuery = new();
     private readonly PingEvent _pingEvent = new();
+    private readonly GroupedCommand _groupedCommand = new();
+    private readonly GroupedPingEvent _groupedPingEvent = new();
+
+    private static readonly string[] BenchGroups = ["bench"];
+
+    // Reused across dispatches, mirroring a caller that keeps its settings: the grouped
+    // rows measure the grouped lane itself, not per-call settings construction.
+    private readonly CommandMediationSettings _groupedCommandSettings = new() { Filters = { Groups = BenchGroups } };
+    private readonly EventMediationSettings _groupedEventSettings = new() { Filters = { Groups = BenchGroups } };
     private readonly MediatrVoidRequest _mediatrVoid = new();
     private readonly MediatrIntRequest _mediatrInt = new();
     private readonly MediatrPingNotification _mediatrPing = new();
+    private readonly MediatorSgVoidCommand _mediatorSgVoid = new();
+    private readonly MediatorSgIntQuery _mediatorSgInt = new();
+    private readonly MediatorSgPingNotification _mediatorSgPing = new();
 
     [GlobalSetup]
     public void Setup()
@@ -124,17 +208,24 @@ public class MediationBenchmark
         _ergosfare = new ServiceCollection()
             .AddErgosfare(options =>
             {
-                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+                options.AddCommandModule(commands =>
+                {
+                    commands.Register<VoidCommandHandler>();
+                    commands.Register<GroupedCommandHandler>();
+                });
                 options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
                 options.AddEventModule(events =>
                 {
                     events.Register<FirstPingEventHandler>();
                     events.Register<SecondPingEventHandler>();
+                    events.Register<FirstGroupedPingEventHandler>();
+                    events.Register<SecondGroupedPingEventHandler>();
                 });
             })
             .BuildServiceProvider();
 
         _engine = _ergosfare.GetRequiredService<IMessageMediator>();
+        _dispatchEngine = _ergosfare.GetRequiredService<MessageDispatchEngine>();
         _commands = _ergosfare.GetRequiredService<ICommandMediator>();
         _queries = _ergosfare.GetRequiredService<IQueryMediator>();
         _events = _ergosfare.GetRequiredService<IEventMediator>();
@@ -144,6 +235,12 @@ public class MediationBenchmark
             .BuildServiceProvider();
 
         _mediator = _mediatr.GetRequiredService<IMediator>();
+
+        _mediatorSg = new ServiceCollection()
+            .AddMediator()
+            .BuildServiceProvider();
+
+        _martinMediator = _mediatorSg.GetRequiredService<Mediator.IMediator>();
     }
 
     [GlobalCleanup]
@@ -151,6 +248,7 @@ public class MediationBenchmark
     {
         _ergosfare.Dispose();
         _mediatr.Dispose();
+        _mediatorSg.Dispose();
     }
 
     /// <summary>
@@ -159,20 +257,52 @@ public class MediationBenchmark
     /// void pipeline plans process-wide, and the targeted setup keeps that installation
     /// away from the runtime-registration rows' processes so the comparison stays honest.
     /// </summary>
-    [GlobalSetup(Targets = [nameof(Command_Void_Generated)])]
+    [GlobalSetup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
     public void SetupGenerated()
     {
         _ergosfareGenerated = new ServiceCollection()
-            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated()))
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => commands.RegisterGenerated());
+                options.AddQueryModule(queries => queries.RegisterGenerated());
+            })
             .BuildServiceProvider();
 
         _generatedCommands = _ergosfareGenerated.GetRequiredService<ICommandMediator>();
+        _generatedQueries = _ergosfareGenerated.GetRequiredService<IQueryMediator>();
     }
 
-    [GlobalCleanup(Targets = [nameof(Command_Void_Generated)])]
+    [GlobalCleanup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
     public void CleanupGenerated()
     {
         _ergosfareGenerated.Dispose();
+    }
+
+    /// <summary>
+    /// Zero-allocation variant: <c>ForceMemoizedHandlers()</c> resolves each handler graph
+    /// once and reuses it for every dispatch, so the transient handler instance — the last
+    /// 24 B on the default root path — disappears. Plain singleton handler registration
+    /// reaches the same shape without the switch. Isolated to its own process via targets,
+    /// like the generated variant above.
+    /// </summary>
+    [GlobalSetup(Targets = [nameof(Command_Void_Memoized)])]
+    public void SetupMemoized()
+    {
+        _ergosfareMemoized = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.ForceMemoizedHandlers();
+                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+            })
+            .BuildServiceProvider();
+
+        _memoizedCommands = _ergosfareMemoized.GetRequiredService<ICommandMediator>();
+    }
+
+    [GlobalCleanup(Targets = [nameof(Command_Void_Memoized)])]
+    public void CleanupMemoized()
+    {
+        _ergosfareMemoized.Dispose();
     }
 
     // ------------------------------------------------------------------
@@ -182,6 +312,13 @@ public class MediationBenchmark
     [Benchmark(Baseline = true), BenchmarkCategory("Root")]
     public ValueTask Engine_Void() => _engine.DispatchAsync(_voidCommand);
 
+    /// <summary>
+    /// Typed engine dispatch: the compile-time message type resolves the executor from a
+    /// static-generic holder — no dictionary lookup on the hot path.
+    /// </summary>
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Engine_Void_Typed() => _dispatchEngine.DispatchVoidAsync(_voidCommand, _ergosfare);
+
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
 
@@ -189,10 +326,22 @@ public class MediationBenchmark
     public ValueTask Command_Void_Generated() => _generatedCommands.SendAsync(_voidCommand);
 
     [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Memoized() => _memoizedCommands.SendAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);
 
     [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> Query_Result_Generated() => _generatedQueries.QueryAsync(_intQuery);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Grouped() => _commands.SendAsync(_groupedCommand, _groupedCommandSettings);
+
+    [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Event_Publish() => _events.PublishAsync(_pingEvent);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Event_Publish_Grouped() => _events.PublishAsync(_groupedPingEvent, _groupedEventSettings);
 
     [Benchmark, BenchmarkCategory("Root")]
     public Task MediatR_Send_Void() => _mediator.Send(_mediatrVoid);
@@ -202,6 +351,15 @@ public class MediationBenchmark
 
     [Benchmark, BenchmarkCategory("Root")]
     public Task MediatR_Publish() => _mediator.Publish(_mediatrPing);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<Mediator.Unit> MediatorSg_Send_Void() => _martinMediator.Send(_mediatorSgVoid);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> MediatorSg_Send_Result() => _martinMediator.Send(_mediatorSgInt);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask MediatorSg_Publish() => _martinMediator.Publish(_mediatorSgPing);
 
     // ------------------------------------------------------------------
     // Scoped — a fresh DI scope and mediator resolution per dispatch
@@ -254,5 +412,26 @@ public class MediationBenchmark
     {
         using var scope = _mediatr.CreateScope();
         await scope.ServiceProvider.GetRequiredService<IMediator>().Publish(_mediatrPing);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatorSg_Send_Void_Scoped()
+    {
+        using var scope = _mediatorSg.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<Mediator.IMediator>().Send(_mediatorSgVoid);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task<int> MediatorSg_Send_Result_Scoped()
+    {
+        using var scope = _mediatorSg.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<Mediator.IMediator>().Send(_mediatorSgInt);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatorSg_Publish_Scoped()
+    {
+        using var scope = _mediatorSg.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<Mediator.IMediator>().Publish(_mediatorSgPing);
     }
 }

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -8,6 +8,7 @@ using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
 using Stella.Ergosfare.Queries.Abstractions;
 using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 using MediatR;
@@ -100,10 +101,12 @@ public sealed class SecondMediatrPingHandler : INotificationHandler<MediatrPingN
 public class MediationBenchmark
 {
     private ServiceProvider _ergosfare = null!;
+    private ServiceProvider _ergosfareGenerated = null!;
     private ServiceProvider _mediatr = null!;
 
     private IMessageMediator _engine = null!;
     private ICommandMediator _commands = null!;
+    private ICommandMediator _generatedCommands = null!;
     private IQueryMediator _queries = null!;
     private IEventMediator _events = null!;
     private IMediator _mediator = null!;
@@ -150,6 +153,28 @@ public class MediationBenchmark
         _mediatr.Dispose();
     }
 
+    /// <summary>
+    /// Source-generated registration variant, isolated to its own benchmark process via
+    /// targets: <c>RegisterGenerated()</c> installs the compile-time dispatch roots and
+    /// void pipeline plans process-wide, and the targeted setup keeps that installation
+    /// away from the runtime-registration rows' processes so the comparison stays honest.
+    /// </summary>
+    [GlobalSetup(Targets = [nameof(Command_Void_Generated)])]
+    public void SetupGenerated()
+    {
+        _ergosfareGenerated = new ServiceCollection()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated()))
+            .BuildServiceProvider();
+
+        _generatedCommands = _ergosfareGenerated.GetRequiredService<ICommandMediator>();
+    }
+
+    [GlobalCleanup(Targets = [nameof(Command_Void_Generated)])]
+    public void CleanupGenerated()
+    {
+        _ergosfareGenerated.Dispose();
+    }
+
     // ------------------------------------------------------------------
     // Root — mediators resolved once, no per-dispatch scope
     // ------------------------------------------------------------------
@@ -159,6 +184,9 @@ public class MediationBenchmark
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Generated() => _generatedCommands.SendAsync(_voidCommand);
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -1,19 +1,16 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Microsoft.Extensions.DependencyInjection;
-using Stella.Ergosfare;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.Handlers;
-using Stella.Ergosfare.Core.Abstractions.Registry;
-using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 using MediatR;
-using LiteBus.Commands;
-using LiteBus.Extensions.Microsoft.DependencyInjection;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace Stella.Ergosfare.Benchmarks;
 
@@ -25,146 +22,209 @@ public class Program
     }
 }
 
-public class StellaMessage : IMessage { }
-public class StellaHandler : IAsyncHandler<StellaMessage>
+// ---------------------------------------------------------------------------
+// Ergosfare messages & handlers
+// ---------------------------------------------------------------------------
+
+public sealed class VoidCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+
+public sealed class VoidCommandHandler : ICommandHandler<VoidCommand>
 {
-    public ValueTask HandleAsync(StellaMessage message, IExecutionContext context) => ValueTask.CompletedTask;
+    public ValueTask HandleAsync(VoidCommand command, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
-public class StellaCommand : ICommand { }
-public class StellaCommandHandler : ICommandHandler<StellaCommand>
+public sealed class IntQuery : IQuery<int> { }
+
+public sealed class IntQueryHandler : IQueryHandler<IntQuery, int>
 {
-    public ValueTask HandleAsync(StellaCommand message, IExecutionContext context) => ValueTask.CompletedTask;
+    public ValueTask<int> HandleAsync(IntQuery query, IExecutionContext context) => ValueTask.FromResult(7);
 }
 
-public class LiteBusCommand : LiteBus.Commands.Abstractions.ICommand { }
-public class LiteBusCommandHandler : LiteBus.Commands.Abstractions.ICommandHandler<LiteBusCommand>
+public sealed class PingEvent : IEvent { }
+
+public sealed class FirstPingEventHandler : IEventHandler<PingEvent>
 {
-    public Task HandleAsync(LiteBusCommand message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public ValueTask HandleAsync(PingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
-public class MediatrRequest : IRequest { }
-public class MediatrHandler : IRequestHandler<MediatrRequest>
+public sealed class SecondPingEventHandler : IEventHandler<PingEvent>
 {
-    public Task Handle(MediatrRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
+    public ValueTask HandleAsync(PingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
 }
 
+// ---------------------------------------------------------------------------
+// MediatR requests & handlers
+// ---------------------------------------------------------------------------
+
+public sealed class MediatrVoidRequest : IRequest { }
+
+public sealed class MediatrVoidRequestHandler : IRequestHandler<MediatrVoidRequest>
+{
+    public Task Handle(MediatrVoidRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+public sealed class MediatrIntRequest : IRequest<int> { }
+
+public sealed class MediatrIntRequestHandler : IRequestHandler<MediatrIntRequest, int>
+{
+    public Task<int> Handle(MediatrIntRequest request, CancellationToken cancellationToken) => Task.FromResult(7);
+}
+
+public sealed class MediatrPingNotification : INotification { }
+
+public sealed class FirstMediatrPingHandler : INotificationHandler<MediatrPingNotification>
+{
+    public Task Handle(MediatrPingNotification notification, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+public sealed class SecondMediatrPingHandler : INotificationHandler<MediatrPingNotification>
+{
+    public Task Handle(MediatrPingNotification notification, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Two scenarios, grouped as table categories:
+/// <para><b>Root</b> — mediators resolved once from the root provider (singleton-style
+/// usage: background workers, message-pump loops).</para>
+/// <para><b>Scoped</b> — a fresh DI scope per dispatch (the web-request shape; includes
+/// scope creation and mediator resolution in every measurement).</para>
+/// Each category carries the raw <see cref="IMessageMediator"/> engine dispatch as its
+/// baseline — that is the floor the public facades add their convenience on top of, and
+/// the Ratio column reads as "what does the facade (or MediatR) cost relative to it".
+/// Within each category: a void dispatch, a result-returning dispatch, and a two-handler
+/// event publish, for Ergosfare and MediatR alike.
+/// </summary>
 [MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
 public class MediationBenchmark
 {
-    private IServiceProvider _stellaProvider = null!;
-    private IMessageMediator _stellaMediator = null!;
-    private ICommandMediator _stellaCommandMediator = null!;
-    private StellaMessage _stellaMessage = null!;
-    private StellaCommand _stellaCommand = null!;
-    private MediateOptions<StellaMessage, ValueTask> _stellaOptions = null!;
+    private ServiceProvider _ergosfare = null!;
+    private ServiceProvider _mediatr = null!;
 
-    private IServiceProvider _mediatrProvider = null!;
-    private IMediator _mediatrMediator = null!;
-    private MediatrRequest _mediatrRequest = null!;
+    private IMessageMediator _engine = null!;
+    private ICommandMediator _commands = null!;
+    private IQueryMediator _queries = null!;
+    private IEventMediator _events = null!;
+    private IMediator _mediator = null!;
 
-    private IServiceProvider _liteBusProvider = null!;
-    private LiteBus.Commands.Abstractions.ICommandMediator _liteBusCommandMediator = null!;
-    private LiteBusCommand _liteBusCommand = null!;
+    private readonly VoidCommand _voidCommand = new();
+    private readonly IntQuery _intQuery = new();
+    private readonly PingEvent _pingEvent = new();
+    private readonly MediatrVoidRequest _mediatrVoid = new();
+    private readonly MediatrIntRequest _mediatrInt = new();
+    private readonly MediatrPingNotification _mediatrPing = new();
 
     [GlobalSetup]
     public void Setup()
     {
-        // Stella Setup
-        var stellaServices = new ServiceCollection();
-        stellaServices.AddErgosfare(options => {
-            options.AddCoreModule(module => {
-                module.Register<StellaHandler>();
-            });
-            options.AddCommandModule(module => {
-                module.Register<StellaCommandHandler>();
-            });
-        });
-        _stellaProvider = stellaServices.BuildServiceProvider();
-        _stellaMediator = _stellaProvider.GetRequiredService<IMessageMediator>();
-        _stellaCommandMediator = _stellaProvider.GetRequiredService<ICommandMediator>();
-        _stellaMessage = new StellaMessage();
-        _stellaCommand = new StellaCommand();
+        _ergosfare = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+                options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
+                options.AddEventModule(events =>
+                {
+                    events.Register<FirstPingEventHandler>();
+                    events.Register<SecondPingEventHandler>();
+                });
+            })
+            .BuildServiceProvider();
 
-        _stellaOptions = new MediateOptions<StellaMessage, ValueTask>
-        {
-            CancellationToken = CancellationToken.None,
-            Groups = [],
-            MessageMediationStrategy = new SingleAsyncHandlerMediationStrategy<StellaMessage>(null),
-            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(_stellaProvider.GetRequiredService<IMessageRegistry>())
-        };
+        _engine = _ergosfare.GetRequiredService<IMessageMediator>();
+        _commands = _ergosfare.GetRequiredService<ICommandMediator>();
+        _queries = _ergosfare.GetRequiredService<IQueryMediator>();
+        _events = _ergosfare.GetRequiredService<IEventMediator>();
 
-        // MediatR Setup
-        var mediatrServices = new ServiceCollection();
-        mediatrServices.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(MediationBenchmark).Assembly));
-        _mediatrProvider = mediatrServices.BuildServiceProvider();
-        _mediatrMediator = _mediatrProvider.GetRequiredService<IMediator>();
-        _mediatrRequest = new MediatrRequest();
+        _mediatr = new ServiceCollection()
+            .AddMediatR(configuration => configuration.RegisterServicesFromAssembly(typeof(MediationBenchmark).Assembly))
+            .BuildServiceProvider();
 
-        // LiteBus Setup
-        var liteBusServices = new ServiceCollection();
-        liteBusServices.AddLiteBus(builder => {
-            builder.AddCommandModule(module => {
-                module.Register<LiteBusCommandHandler>();
-            });
-        });
-        _liteBusProvider = liteBusServices.BuildServiceProvider();
-        _liteBusCommandMediator = _liteBusProvider.GetRequiredService<LiteBus.Commands.Abstractions.ICommandMediator>();
-        _liteBusCommand = new LiteBusCommand();
+        _mediator = _mediatr.GetRequiredService<IMediator>();
     }
 
-    [Benchmark]
-    public async Task StellaErgosfare()
+    [GlobalCleanup]
+    public void Cleanup()
     {
-
-        for (var i = 0; i < 100000; i++)
-            await _stellaMediator.Mediate(_stellaMessage, _stellaOptions);
+        _ergosfare.Dispose();
+        _mediatr.Dispose();
     }
 
-    // Full public API path (settings/options/strategy handling included),
-    // symmetric with the MediatR benchmark which also uses its public Send.
-    [Benchmark]
-    public async Task StellaErgosfare_PublicApi()
+    // ------------------------------------------------------------------
+    // Root — mediators resolved once, no per-dispatch scope
+    // ------------------------------------------------------------------
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Root")]
+    public ValueTask Engine_Void() => _engine.DispatchAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Event_Publish() => _events.PublishAsync(_pingEvent);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public Task MediatR_Send_Void() => _mediator.Send(_mediatrVoid);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public Task<int> MediatR_Send_Result() => _mediator.Send(_mediatrInt);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public Task MediatR_Publish() => _mediator.Publish(_mediatrPing);
+
+    // ------------------------------------------------------------------
+    // Scoped — a fresh DI scope and mediator resolution per dispatch
+    // ------------------------------------------------------------------
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Scoped")]
+    public async Task Engine_Void_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-            await _stellaCommandMediator.SendAsync(_stellaCommand);
+        using var scope = _ergosfare.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMessageMediator>().DispatchAsync(_voidCommand);
     }
 
-    [Benchmark]
-    public async Task MediatR()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task Command_Void_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-            await _mediatrMediator.Send(_mediatrRequest);
+        using var scope = _ergosfare.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<ICommandMediator>().SendAsync(_voidCommand);
     }
 
-    // Ergosfare is an independent implementation whose design (API surface, naming) was
-    // heavily inspired by LiteBus, so LiteBus is included as a reference point.
-    [Benchmark]
-    public async Task LiteBus_PublicApi()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task<int> Query_Result_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-            await _liteBusCommandMediator.SendAsync(_liteBusCommand);
+        using var scope = _ergosfare.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<IQueryMediator>().QueryAsync(_intQuery);
     }
 
-    // Fresh DI scope per dispatch — the realistic per-request shape where
-    // lifetime-aware (scoped) handler resolution actually pays its cost.
-    [Benchmark]
-    public async Task StellaErgosfare_PublicApi_ScopePerDispatch()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task Event_Publish_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-        {
-            using var scope = _stellaProvider.CreateScope();
-            await scope.ServiceProvider.GetRequiredService<ICommandMediator>().SendAsync(_stellaCommand);
-        }
+        using var scope = _ergosfare.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IEventMediator>().PublishAsync(_pingEvent);
     }
 
-    [Benchmark]
-    public async Task MediatR_ScopePerDispatch()
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatR_Send_Void_Scoped()
     {
-        for (var i = 0; i < 100000; i++)
-        {
-            using var scope = _mediatrProvider.CreateScope();
-            await scope.ServiceProvider.GetRequiredService<IMediator>().Send(_mediatrRequest);
-        }
+        using var scope = _mediatr.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMediator>().Send(_mediatrVoid);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task<int> MediatR_Send_Result_Scoped()
+    {
+        using var scope = _mediatr.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<IMediator>().Send(_mediatrInt);
+    }
+
+    [Benchmark, BenchmarkCategory("Scoped")]
+    public async Task MediatR_Publish_Scoped()
+    {
+        using var scope = _mediatr.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMediator>().Publish(_mediatrPing);
     }
 }

--- a/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
+++ b/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
@@ -6,7 +6,6 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageReference Include="MediatR" Version="12.4.1" />
-        <PackageReference Include="LiteBus.Commands.Extensions.Microsoft.DependencyInjection" Version="4.3.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     </ItemGroup>
     <PropertyGroup>

--- a/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
+++ b/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <ProjectReference Include="..\..\src\Stella.Ergosfare\Stella.Ergosfare.csproj" />
+        <ProjectReference Include="..\..\src\Stella.Ergosfare.SourceGenerator\Stella.Ergosfare.SourceGenerator.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
+++ b/test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj
@@ -9,6 +9,11 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageReference Include="MediatR" Version="12.4.1" />
+        <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+        <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     </ItemGroup>
     <PropertyGroup>

--- a/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
@@ -1,6 +1,7 @@
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,6 +80,12 @@ public class DispatchItemsAndInvalidationTests
             => ValueTask.CompletedTask;
     }
 
+    /// <summary>
+    /// Excluded from discovery: the fact below registers this type at runtime to observe
+    /// the version bump — another test's assembly scan (the registry is process-wide)
+    /// must not slip it into the pipeline before the warm dispatches run.
+    /// </summary>
+    [ExcludeFromDiscovery]
     public sealed class LateRegisteredInterceptor : ICommandPreInterceptor<LateInterceptedCommand>
     {
         public ValueTask<LateInterceptedCommand> HandleAsync(LateInterceptedCommand command, IExecutionContext context)

--- a/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
@@ -1,0 +1,147 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Covers the dispatch fast path's interaction with caller-supplied settings items —
+/// the pooled context adopts the caller's dictionary for the dispatch and detaches it
+/// untouched on return — and the executor-level plan cache's registry-version
+/// invalidation for runtime registrations.
+/// </summary>
+public class DispatchItemsAndInvalidationTests
+{
+    public sealed class ItemsCommand : ICommand { }
+
+    public sealed class ItemsCommandHandler : ICommandHandler<ItemsCommand>
+    {
+        public ValueTask HandleAsync(ItemsCommand command, IExecutionContext context)
+        {
+            context.Set("writtenByHandler", "yes");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ShouldNotWipeCallerSettingsItems_AndShouldExposeHandlerWrites()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ItemsCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        settings.Items["keep"] = "me";
+
+        await mediator.SendAsync(new ItemsCommand(), settings);
+
+        Assert.Equal("me", settings.Items["keep"]);
+        Assert.Equal("yes", settings.Items["writtenByHandler"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ShouldNotLeakOneDispatchesItems_IntoTheNext()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ItemsCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new CommandMediationSettings();
+        first.Items["secret"] = "data";
+        await mediator.SendAsync(new ItemsCommand(), first);
+
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new ItemsCommand(), second);
+
+        // The second dispatch's pooled context must not surface the first caller's items,
+        // and writing during the second dispatch must not reach the first caller.
+        Assert.False(second.Items.ContainsKey("secret"));
+        Assert.Equal("data", first.Items["secret"]);
+    }
+
+    public sealed class LateInterceptedCommand : ICommand { }
+
+    public sealed class LateInterceptedCommandHandler : ICommandHandler<LateInterceptedCommand>
+    {
+        public ValueTask HandleAsync(LateInterceptedCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    public sealed class LateRegisteredInterceptor : ICommandPreInterceptor<LateInterceptedCommand>
+    {
+        public ValueTask<LateInterceptedCommand> HandleAsync(LateInterceptedCommand command, IExecutionContext context)
+        {
+            context.Set("lateInterceptorRan", true);
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ShouldPickUpRuntimeRegistrations_AfterWarmingTheExecutorCache()
+    {
+        var provider = new ServiceCollection()
+            .AddTransient<LateRegisteredInterceptor>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<LateInterceptedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // Warm the executor's cached plan on the zero-interceptor fast path.
+        var warm = new CommandMediationSettings();
+        await mediator.SendAsync(new LateInterceptedCommand(), warm);
+        await mediator.SendAsync(new LateInterceptedCommand(), warm);
+        Assert.False(warm.Items.ContainsKey("lateInterceptorRan"));
+
+        // A runtime registration bumps the registry version; the cached plan must rebuild
+        // and the dispatch must leave the fast path for the full pipeline.
+        registry.Register(typeof(LateRegisteredInterceptor));
+
+        var probe = new CommandMediationSettings();
+        await mediator.SendAsync(new LateInterceptedCommand(), probe);
+
+        Assert.Equal(true, probe.Items["lateInterceptorRan"]);
+    }
+
+    public sealed class ResultCommand : ICommand<int> { }
+
+    public sealed class ResultCommandHandler : ICommandHandler<ResultCommand, int>
+    {
+        public ValueTask<int> HandleAsync(ResultCommand command, IExecutionContext context)
+            => ValueTask.FromResult(42);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Send_ResultCommand_ShouldFlowThroughTheResultFastPath()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ResultCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Repeated sends exercise the cached result-executor lookup.
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(42, await mediator.SendAsync(new ResultCommand()));
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/EngineBackedFacadeTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/EngineBackedFacadeTests.cs
@@ -1,0 +1,133 @@
+using Stella.Ergosfare.Commands;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Covers the engine-backed facade shape: DI resolves a single-object facade bound to the
+/// process-wide <see cref="MessageDispatchEngine"/>, handler resolution still binds to the
+/// calling scope (verified under <c>ValidateScopes</c>), and the facade's two public
+/// constructors dispatch identically.
+/// </summary>
+public class EngineBackedFacadeTests
+{
+    public sealed class ScopedProbe
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    public sealed class ProbeCommand : ICommand { }
+
+    public sealed class ProbeCommandHandler(ScopedProbe probe) : ICommandHandler<ProbeCommand>
+    {
+        public ValueTask HandleAsync(ProbeCommand command, IExecutionContext context)
+        {
+            context.Set("probeId", probe.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class EchoCommand : ICommand<string>
+    {
+        public string Payload { get; init; } = string.Empty;
+    }
+
+    public sealed class EchoCommandHandler : ICommandHandler<EchoCommand, string>
+    {
+        public ValueTask<string> HandleAsync(EchoCommand command, IExecutionContext context)
+        {
+            context.Set("sawPayload", command.Payload);
+            return ValueTask.FromResult(command.Payload + "!");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_IsTheEngineBackedShape()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<EchoCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The DI shape derives from the public facade (compat for callers typed to it) but
+        // is not the bare facade — it must be the single-constructor engine-backed type.
+        Assert.IsAssignableFrom<CommandMediator>(mediator);
+        Assert.NotEqual(typeof(CommandMediator), mediator.GetType());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_WithValidateScopes_BindsHandlerResolutionToTheCallingScope()
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<ScopedProbe>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ProbeCommandHandler>()))
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        await using var _ = provider;
+
+        Guid first, second, third;
+
+        using (var scope = provider.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<ICommandMediator>();
+
+            var firstSettings = new CommandMediationSettings();
+            await mediator.SendAsync(new ProbeCommand(), firstSettings);
+            first = Assert.IsType<Guid>(firstSettings.Items["probeId"]);
+
+            var secondSettings = new CommandMediationSettings();
+            await mediator.SendAsync(new ProbeCommand(), secondSettings);
+            second = Assert.IsType<Guid>(secondSettings.Items["probeId"]);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<ICommandMediator>();
+
+            var thirdSettings = new CommandMediationSettings();
+            await mediator.SendAsync(new ProbeCommand(), thirdSettings);
+            third = Assert.IsType<Guid>(thirdSettings.Items["probeId"]);
+        }
+
+        // Within one scope the scoped dependency is one instance; a fresh scope gets its own.
+        Assert.Equal(first, second);
+        Assert.NotEqual(first, third);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task BothConstructors_DispatchIdentically()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<EchoCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var engineBacked = new CommandMediator(
+            provider.GetRequiredService<MessageDispatchEngine>(), provider);
+        var mediatorBacked = new CommandMediator(
+            provider.GetRequiredService<IMessageMediator>());
+
+        foreach (var mediator in new[] { engineBacked, mediatorBacked })
+        {
+            var settings = new CommandMediationSettings();
+
+            var result = await mediator.SendAsync<string>(
+                new EchoCommand { Payload = "hi" }, settings);
+
+            Assert.Equal("hi!", result);
+            Assert.Equal("hi", settings.Items["sawPayload"]);
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/GeneratedPlanDirectConstructionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedPlanDirectConstructionTests.cs
@@ -1,0 +1,233 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime gating of the plans' direct-construction factories: the factory is used only
+/// while the handler's effective DI registration is the module's own plain transient one,
+/// and any user customization — a factory registration, a lifetime override, forced
+/// memoization — routes the dispatch back through the container. The tests install plans
+/// whose factories construct marked instances, which generated code never does, precisely
+/// so the chosen construction path is observable. Helper types are excluded from discovery
+/// so assembly scans (the registry is process-wide) cannot alter these pipelines.
+/// </summary>
+public class GeneratedPlanDirectConstructionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class ConstructedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class ConstructedCommandHandler : ICommandHandler<ConstructedCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public bool ViaPlanFactory { get; init; }
+
+        public ValueTask HandleAsync(ConstructedCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            context.Set("viaPlanFactory", ViaPlanFactory);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static async Task<(Guid Id, bool ViaPlanFactory)> DispatchAndProbe(ICommandMediator mediator)
+    {
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new ConstructedCommand(), settings);
+        return (Assert.IsType<Guid>(settings.Items["handlerId"]),
+            Assert.IsType<bool>(settings.Items["viaPlanFactory"]));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlainTransientRegistration_ConstructsThroughThePlanFactory()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<ConstructedCommand, ConstructedCommandHandler>(
+            static () => new ConstructedCommandHandler { ViaPlanFactory = true });
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ConstructedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The module's own plain transient registration: the factory constructs, and
+        // transient semantics stay — a fresh instance per dispatch.
+        var first = await DispatchAndProbe(mediator);
+        var second = await DispatchAndProbe(mediator);
+
+        Assert.True(first.ViaPlanFactory);
+        Assert.True(second.ViaPlanFactory);
+        Assert.NotEqual(first.Id, second.Id);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class UserFactoryCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class UserFactoryCommandHandler : ICommandHandler<UserFactoryCommand>
+    {
+        public bool ViaUserFactory { get; init; }
+
+        public ValueTask HandleAsync(UserFactoryCommand command, IExecutionContext context)
+        {
+            context.Set("viaUserFactory", ViaUserFactory);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task UserFactoryRegistration_KeepsResolvingThroughTheContainer()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<UserFactoryCommand, UserFactoryCommandHandler>(
+            static () => new UserFactoryCommandHandler());
+
+        // The user's factory registration (made before AddErgosfare, so the module's
+        // TryAddTransient defers to it) customizes construction — the plan factory would
+        // skip that customization and must therefore stay unused.
+        var provider = new ServiceCollection()
+            .AddTransient(_ => new UserFactoryCommandHandler { ViaUserFactory = true })
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<UserFactoryCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new UserFactoryCommand(), settings);
+
+        Assert.Equal(true, settings.Items["viaUserFactory"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class LateOverrideCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class LateOverrideCommandHandler : ICommandHandler<LateOverrideCommand>
+    {
+        public bool ViaUser { get; init; }
+
+        public ValueTask HandleAsync(LateOverrideCommand command, IExecutionContext context)
+        {
+            context.Set("viaUser", ViaUser);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task RegistrationAfterAddErgosfare_KeepsResolvingThroughTheContainer()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<LateOverrideCommand, LateOverrideCommandHandler>(
+            static () => new LateOverrideCommandHandler());
+
+        // The override lands AFTER AddErgosfare but before BuildServiceProvider — the
+        // window a snapshot taken inside AddErgosfare would miss. The lifetime capture
+        // runs at first resolution, so the user's instance must win over the plan factory
+        // exactly as it wins over GetRequiredService.
+        var services = new ServiceCollection();
+        services.AddErgosfare(x => x.AddCommandModule(c => c.Register<LateOverrideCommandHandler>()));
+        services.AddSingleton(new LateOverrideCommandHandler { ViaUser = true });
+
+        await using var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new LateOverrideCommand(), settings);
+
+        Assert.Equal(true, settings.Items["viaUser"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class SingletonCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class SingletonCommandHandler : ICommandHandler<SingletonCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(SingletonCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task SingletonLifetimeOverride_KeepsTheSharedInstance()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<SingletonCommand, SingletonCommandHandler>(
+            static () => new SingletonCommandHandler());
+
+        var provider = new ServiceCollection()
+            .AddSingleton<SingletonCommandHandler>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<SingletonCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // A plan-factory construction would hand out fresh instances; the user's
+        // singleton override must keep sharing one.
+        var first = new CommandMediationSettings();
+        await mediator.SendAsync(new SingletonCommand(), first);
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new SingletonCommand(), second);
+
+        Assert.Equal(first.Items["handlerId"], second.Items["handlerId"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedPlanCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedPlanCommandHandler : ICommandHandler<MemoizedPlanCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(MemoizedPlanCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ForceMemoizedHandlers_KeepsTheMemoizedInstance()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<MemoizedPlanCommand, MemoizedPlanCommandHandler>(
+            static () => new MemoizedPlanCommandHandler());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x =>
+            {
+                x.ForceMemoizedHandlers();
+                x.AddCommandModule(c => c.Register<MemoizedPlanCommandHandler>());
+            })
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new CommandMediationSettings();
+        await mediator.SendAsync(new MemoizedPlanCommand(), first);
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new MemoizedPlanCommand(), second);
+
+        Assert.Equal(first.Items["handlerId"], second.Items["handlerId"]);
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/GeneratedResultPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedResultPlanExecutionTests.cs
@@ -1,0 +1,100 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime behavior of generated result pipeline plans, installed through the public
+/// <see cref="GeneratedDispatchRoots.AddResultPlan{TMessage, TResult, THandler}()"/>
+/// surface exactly as generated code would — the result-producing counterpart of
+/// <see cref="GeneratedVoidPlanExecutionTests"/>. Helper types are excluded from discovery
+/// so assembly scans (the registry is process-wide) cannot alter these pipelines.
+/// </summary>
+public class GeneratedResultPlanExecutionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class PlannedEcho : ICommand<string>
+    {
+        public string Payload { get; init; } = string.Empty;
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class PlannedEchoHandler : ICommandHandler<PlannedEcho, string>
+    {
+        public bool ViaPlanFactory { get; init; }
+
+        public ValueTask<string> HandleAsync(PlannedEcho command, IExecutionContext context)
+        {
+            context.Set("viaPlanFactory", ViaPlanFactory);
+            return ValueTask.FromResult(command.Payload + "!");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlannedResultDispatch_ReturnsTheResult_AndConstructsThroughTheFactory()
+    {
+        GeneratedDispatchRoots.AddResultPlan<PlannedEcho, string, PlannedEchoHandler>(
+            static () => new PlannedEchoHandler { ViaPlanFactory = true });
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<PlannedEchoHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+
+        var result = await mediator.SendAsync(new PlannedEcho { Payload = "hi" }, settings);
+
+        Assert.Equal("hi!", result);
+        Assert.Equal(true, settings.Items["viaPlanFactory"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedEcho : ICommand<string> { }
+
+    /// <summary>Registered handler — not the type the plan claims.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ActualMismatchedEchoHandler : ICommandHandler<MismatchedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(MismatchedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("actual");
+    }
+
+    /// <summary>The plan's claimed handler; never registered anywhere.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ClaimedMismatchedEchoHandler : ICommandHandler<MismatchedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(MismatchedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("claimed");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ResultPlanClaimingTheWrongHandler_StillDispatchesTheRegisteredOne()
+    {
+        GeneratedDispatchRoots.AddResultPlan<MismatchedEcho, string, ClaimedMismatchedEchoHandler>(
+            static () => new ClaimedMismatchedEchoHandler());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ActualMismatchedEchoHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The plan claims a handler the registry never saw: the factory must stay unused
+        // (its type differs from the registered reference) and the registered handler
+        // must run, exactly as the runtime executor would dispatch it.
+        var result = await mediator.SendAsync(new MismatchedEcho());
+
+        Assert.Equal("actual", result);
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
@@ -1,0 +1,150 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime behavior of generated void pipeline plans, installed here through the public
+/// <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}"/> surface exactly as
+/// generated code would: the plan-closed executor dispatches the handler, runtime
+/// registrations still invalidate the cached pipeline, and a plan whose handler type does
+/// not match the actual registration falls back to the runtime dispatch shape without any
+/// behavioral difference. Helper types are excluded from discovery so assembly scans (the
+/// registry is process-wide) cannot alter the pipelines these facts construct.
+/// </summary>
+public class GeneratedVoidPlanExecutionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class PlannedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class PlannedCommandHandler : ICommandHandler<PlannedCommand>
+    {
+        public ValueTask HandleAsync(PlannedCommand command, IExecutionContext context)
+        {
+            context.Set("plannedRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlannedDispatch_RunsTheHandler_WithCallerVisibleItems()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<PlannedCommand, PlannedCommandHandler>();
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<PlannedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        settings.Items["keep"] = "me";
+
+        await mediator.SendAsync(new PlannedCommand(), settings);
+
+        Assert.Equal("me", settings.Items["keep"]);
+        Assert.Equal(true, settings.Items["plannedRan"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class LatePlannedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class LatePlannedCommandHandler : ICommandHandler<LatePlannedCommand>
+    {
+        public ValueTask HandleAsync(LatePlannedCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class LatePlannedInterceptor : ICommandPreInterceptor<LatePlannedCommand>
+    {
+        public ValueTask<LatePlannedCommand> HandleAsync(LatePlannedCommand command, IExecutionContext context)
+        {
+            context.Set("lateInterceptorRan", true);
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlannedDispatch_StillPicksUpRuntimeRegistrations()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<LatePlannedCommand, LatePlannedCommandHandler>();
+
+        var provider = new ServiceCollection()
+            .AddTransient<LatePlannedInterceptor>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<LatePlannedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // Warm the plan-closed executor on its devirtualized fast path.
+        var warm = new CommandMediationSettings();
+        await mediator.SendAsync(new LatePlannedCommand(), warm);
+        await mediator.SendAsync(new LatePlannedCommand(), warm);
+        Assert.False(warm.Items.ContainsKey("lateInterceptorRan"));
+
+        // A runtime registration bumps the registry version; the plan's cached pipeline
+        // must rebuild and leave the fast path for the full interceptor pipeline.
+        registry.Register(typeof(LatePlannedInterceptor));
+
+        var probe = new CommandMediationSettings();
+        await mediator.SendAsync(new LatePlannedCommand(), probe);
+
+        Assert.Equal(true, probe.Items["lateInterceptorRan"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedCommand : ICommand { }
+
+    /// <summary>Registered handler — not the type the plan claims.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ActualMismatchedHandler : ICommandHandler<MismatchedCommand>
+    {
+        public ValueTask HandleAsync(MismatchedCommand command, IExecutionContext context)
+        {
+            context.Set("actualRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>The plan's claimed handler; never registered anywhere.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class ClaimedMismatchedHandler : ICommandHandler<MismatchedCommand>
+    {
+        public ValueTask HandleAsync(MismatchedCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlanClaimingTheWrongHandler_StillDispatchesTheRegisteredOne()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<MismatchedCommand, ClaimedMismatchedHandler>();
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ActualMismatchedHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+
+        await mediator.SendAsync(new MismatchedCommand(), settings);
+
+        Assert.Equal(true, settings.Items["actualRan"]);
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/GroupedExecutorSlotTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GroupedExecutorSlotTests.cs
@@ -1,0 +1,114 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// The grouped executor lookup's last-used slot: alternating group sets on one message
+/// type must always dispatch the requested group's executor (the composite store stays
+/// authoritative on a slot miss), for the void and the result shape alike. Helper types
+/// are excluded from discovery so assembly scans cannot alter these pipelines.
+/// </summary>
+public class GroupedExecutorSlotTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class RoutedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    [Group("east")]
+    public sealed class EastHandler : ICommandHandler<RoutedCommand>
+    {
+        public ValueTask HandleAsync(RoutedCommand command, IExecutionContext context)
+        {
+            context.Set("ran", "east");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("west")]
+    public sealed class WestHandler : ICommandHandler<RoutedCommand>
+    {
+        public ValueTask HandleAsync(RoutedCommand command, IExecutionContext context)
+        {
+            context.Set("ran", "west");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task AlternatingGroupSets_DispatchTheRequestedGroupsExecutor()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<EastHandler>();
+                c.Register<WestHandler>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+        Assert.Equal("west", await Dispatch(mediator, "west"));
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+
+        static async Task<string> Dispatch(ICommandMediator mediator, params string[] groups)
+        {
+            var settings = new CommandMediationSettings { Filters = { Groups = groups } };
+            await mediator.SendAsync(new RoutedCommand(), settings);
+            return Assert.IsType<string>(settings.Items["ran"]);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class RoutedEcho : ICommand<string> { }
+
+    [ExcludeFromDiscovery]
+    [Group("east")]
+    public sealed class EastEchoHandler : ICommandHandler<RoutedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(RoutedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("east");
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("west")]
+    public sealed class WestEchoHandler : ICommandHandler<RoutedEcho, string>
+    {
+        public ValueTask<string> HandleAsync(RoutedEcho command, IExecutionContext context)
+            => ValueTask.FromResult("west");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task AlternatingGroupSets_DispatchTheRequestedGroupsResultExecutor()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<EastEchoHandler>();
+                c.Register<WestEchoHandler>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+        Assert.Equal("west", await Dispatch(mediator, "west"));
+        Assert.Equal("east", await Dispatch(mediator, "east"));
+
+        static async Task<string> Dispatch(ICommandMediator mediator, params string[] groups)
+        {
+            var settings = new CommandMediationSettings { Filters = { Groups = groups } };
+            return await mediator.SendAsync(new RoutedEcho(), settings);
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Command.Test/TypedEngineDispatchTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/TypedEngineDispatchTests.cs
@@ -1,0 +1,156 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Covers the typed void dispatch overload on <see cref="MessageDispatchEngine"/>: the
+/// static-generic executor holder serves the exact-typed call, base-typed generic calls
+/// keep resolving by the message's runtime type, and the holder's cache-identity guard
+/// keeps containers isolated from each other's cached executors.
+/// </summary>
+public class TypedEngineDispatchTests
+{
+    public sealed class TypedProbeCommand : ICommand { }
+
+    public sealed class TypedProbeCommandHandler : ICommandHandler<TypedProbeCommand>
+    {
+        public ValueTask HandleAsync(TypedProbeCommand command, IExecutionContext context)
+        {
+            context.Set("typedProbe", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class UnregisteredCommand : ICommand { }
+
+    public sealed class IdentityProbeCommand : ICommand { }
+
+    public sealed class IdentityProbeCommandHandler : ICommandHandler<IdentityProbeCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(IdentityProbeCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider BuildProvider()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<TypedProbeCommandHandler>()))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_RunsThePipeline_AndRepeatsThroughTheHolder()
+    {
+        await using var provider = BuildProvider();
+        var engine = provider.GetRequiredService<MessageDispatchEngine>();
+
+        // First call populates the static-generic slot, second call is served from it;
+        // both must run the full pipeline.
+        for (var i = 0; i < 2; i++)
+        {
+            var items = new Dictionary<object, object?>();
+
+            await engine.DispatchVoidAsync(new TypedProbeCommand(), provider, items);
+
+            Assert.Equal(true, items["typedProbe"]);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_BaseTypedGenericCall_ResolvesByRuntimeType()
+    {
+        await using var provider = BuildProvider();
+        var engine = provider.GetRequiredService<MessageDispatchEngine>();
+
+        // TMessage closes over ICommand here, so the holder guard must reject the slot
+        // and resolve the executor by the runtime type — the concrete pipeline still runs.
+        ICommand baseTyped = new TypedProbeCommand();
+        var items = new Dictionary<object, object?>();
+
+        await engine.DispatchVoidAsync(baseTyped, provider, items);
+
+        Assert.Equal(true, items["typedProbe"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_DoesNotServeAnotherContainersExecutor()
+    {
+        // The message registry is process-wide, so a second container can dispatch the
+        // same message type. What must not leak between containers is the executor: it
+        // carries the container's dependencies factory — and with it the container's
+        // lifetime semantics, made observable here via ForceMemoizedHandlers.
+        await using var transientContainer = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<IdentityProbeCommandHandler>()))
+            .BuildServiceProvider();
+        var transientEngine = transientContainer.GetRequiredService<MessageDispatchEngine>();
+
+        // Populate the static-generic slot from the transient container: every dispatch
+        // resolves a fresh handler instance.
+        var first = await DispatchAndReadId(transientEngine, transientContainer);
+        var second = await DispatchAndReadId(transientEngine, transientContainer);
+        Assert.NotEqual(first, second);
+
+        await using var memoizedContainer = new ServiceCollection()
+            .AddErgosfare(x =>
+            {
+                x.ForceMemoizedHandlers();
+                x.AddCommandModule(c => c.Register<IdentityProbeCommandHandler>());
+            })
+            .BuildServiceProvider();
+        var memoizedEngine = memoizedContainer.GetRequiredService<MessageDispatchEngine>();
+
+        // Served through its own executor the memoized container reuses one handler
+        // instance; the transient container's cached executor would hand out fresh ones.
+        var memoizedFirst = await DispatchAndReadId(memoizedEngine, memoizedContainer);
+        var memoizedSecond = await DispatchAndReadId(memoizedEngine, memoizedContainer);
+        Assert.Equal(memoizedFirst, memoizedSecond);
+
+        // And after the slot moved on, the original container still dispatches through
+        // its own transient-resolving executor.
+        var third = await DispatchAndReadId(transientEngine, transientContainer);
+        Assert.NotEqual(memoizedFirst, third);
+
+        static async Task<Guid> DispatchAndReadId(MessageDispatchEngine engine, IServiceProvider provider)
+        {
+            var items = new Dictionary<object, object?>();
+            await engine.DispatchVoidAsync(new IdentityProbeCommand(), provider, items);
+            return Assert.IsType<Guid>(items["handlerId"]);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedDispatch_UnregisteredMessage_FailsLikeErasedDispatch()
+    {
+        await using var provider = BuildProvider();
+        var engine = provider.GetRequiredService<MessageDispatchEngine>();
+
+        // The registry is process-wide, so suites running in parallel may add assignable
+        // descriptors (say, an interceptor-only base-interface pipeline) that change WHICH
+        // exception an unhandled message produces. The contract under test is exception
+        // parity: the typed overload fails exactly like the erased one.
+        var erased = await Record.ExceptionAsync(async () =>
+            await engine.DispatchAsync((object)new UnregisteredCommand(), provider));
+        var typed = await Record.ExceptionAsync(async () =>
+            await engine.DispatchVoidAsync(new UnregisteredCommand(), provider));
+
+        Assert.NotNull(erased);
+        Assert.NotNull(typed);
+        Assert.IsType(erased.GetType(), typed);
+    }
+}

--- a/test/Stella.Ergosfare.Core.Test/ExecutionContextItemsOwnershipTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/ExecutionContextItemsOwnershipTests.cs
@@ -1,0 +1,91 @@
+using Stella.Ergosfare.Core.Internal.Contexts;
+
+namespace Stella.Ergosfare.Core.Test;
+
+/// <summary>
+/// Unit tests for the items-dictionary ownership rules of
+/// <see cref="ErgosfareExecutionContext"/>: a dictionary adopted from the caller (a
+/// settings object) must survive the context's return to the pool untouched, while the
+/// lazily created (owned) dictionary is cleared and kept for capacity reuse — and one
+/// dispatch's items must never leak into the next dispatch that rents the same context.
+/// </summary>
+public class ExecutionContextItemsOwnershipTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Return_ShouldDetachAdoptedDictionary_WithoutClearingIt()
+    {
+        var callerItems = new Dictionary<object, object?> { ["seed"] = "value" };
+
+        var context = ErgosfareExecutionContextPool.Rent(callerItems, CancellationToken.None);
+        context.Set("writtenByHandler", 42);
+
+        ErgosfareExecutionContextPool.Return(context);
+
+        // The caller keeps both its own seed and what handlers wrote during the dispatch.
+        Assert.Equal("value", callerItems["seed"]);
+        Assert.Equal(42, callerItems["writtenByHandler"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Rent_AfterAdoptedDispatch_ShouldNotExposePreviousCallersItems()
+    {
+        var callerItems = new Dictionary<object, object?> { ["secret"] = "data" };
+
+        var first = ErgosfareExecutionContextPool.Rent(callerItems, CancellationToken.None);
+        ErgosfareExecutionContextPool.Return(first);
+
+        // The same pooled instance comes back on this thread; it must not carry the
+        // previous caller's dictionary.
+        var second = ErgosfareExecutionContextPool.Rent(items: null, CancellationToken.None);
+
+        Assert.False(second.Has("secret"));
+
+        ErgosfareExecutionContextPool.Return(second);
+
+        // And writing through the second context must never reach the first caller.
+        Assert.False(callerItems.ContainsKey("lateWrite"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Return_ShouldClearOwnedDictionary_AndReuseItAcrossRents()
+    {
+        var first = ErgosfareExecutionContextPool.Rent(items: null, CancellationToken.None);
+        first.Set("transient", "state");
+        ErgosfareExecutionContextPool.Return(first);
+
+        var second = ErgosfareExecutionContextPool.Rent(items: null, CancellationToken.None);
+
+        Assert.False(second.Has("transient"));
+
+        ErgosfareExecutionContextPool.Return(second);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Reset_WithNewAdoptedDictionary_ShouldReplaceDetachedOne()
+    {
+        var firstCaller = new Dictionary<object, object?> { ["a"] = 1 };
+        var secondCaller = new Dictionary<object, object?> { ["b"] = 2 };
+
+        var context = ErgosfareExecutionContextPool.Rent(firstCaller, CancellationToken.None);
+        ErgosfareExecutionContextPool.Return(context);
+
+        var reused = ErgosfareExecutionContextPool.Rent(secondCaller, CancellationToken.None);
+
+        Assert.False(reused.Has("a"));
+        Assert.True(reused.Has("b"));
+
+        reused.Set("c", 3);
+        ErgosfareExecutionContextPool.Return(reused);
+
+        Assert.False(firstCaller.ContainsKey("c"));
+        Assert.Equal(3, secondCaller["c"]);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -1,4 +1,5 @@
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
@@ -264,6 +265,12 @@ public class BroadcastFastLaneTests
 
     public sealed class LateEvent : IEvent { }
 
+    /// <summary>
+    /// Excluded from discovery: the fact below registers this type at runtime to observe
+    /// the version bump — another test's assembly scan (the registry is process-wide)
+    /// must not slip it into the pipeline before the warm publishes run.
+    /// </summary>
+    [ExcludeFromDiscovery]
     public sealed class LateEventHandler : IEventHandler<LateEvent>
     {
         public ValueTask HandleAsync(LateEvent @event, IExecutionContext context)

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -343,6 +343,51 @@ public class BroadcastFastLaneTests
         }
     }
 
+    public sealed class IsolatedEvent : IEvent { }
+
+    public sealed class IsolatedEventHandler : IEventHandler<IsolatedEvent>
+    {
+        public ValueTask HandleAsync(IsolatedEvent @event, IExecutionContext context)
+        {
+            context.Set("handlerInstance", this);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithMemoizedPipeline_ShouldNeverServeAnotherContainersPlan()
+    {
+        // Singleton-registered handler => memoized pipeline, whose plan pins the creating
+        // container's root provider. The process-wide invoker must key its cached plan by
+        // factory, so two containers publishing the same event type each hit their own
+        // handler instance.
+        static ServiceProvider BuildContainer() => new ServiceCollection()
+            .AddSingleton<IsolatedEventHandler>()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<IsolatedEventHandler>()))
+            .BuildServiceProvider();
+
+        await using var first = BuildContainer();
+        await using var second = BuildContainer();
+
+        var firstInstance = first.GetRequiredService<IsolatedEventHandler>();
+        var secondInstance = second.GetRequiredService<IsolatedEventHandler>();
+        Assert.NotSame(firstInstance, secondInstance);
+
+        var settings = new EventMediationSettings();
+        await first.GetRequiredService<IEventMediator>().PublishAsync(new IsolatedEvent(), settings);
+        Assert.Same(firstInstance, settings.Items["handlerInstance"]);
+
+        settings = new EventMediationSettings();
+        await second.GetRequiredService<IEventMediator>().PublishAsync(new IsolatedEvent(), settings);
+        Assert.Same(secondInstance, settings.Items["handlerInstance"]);
+
+        settings = new EventMediationSettings();
+        await first.GetRequiredService<IEventMediator>().PublishAsync(new IsolatedEvent(), settings);
+        Assert.Same(firstInstance, settings.Items["handlerInstance"]);
+    }
+
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -1,0 +1,366 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Covers the broadcast fast lane: pooled execution contexts with caller-owned items
+/// semantics, the cached default-settings strategy, the invoker-cached pipeline plan and
+/// its registry-version invalidation, and the pre-interceptor message transformation.
+/// </summary>
+public class BroadcastFastLaneTests
+{
+    private static ServiceProvider Build(Action<EventModuleBuilder>? extra = null)
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<FastLaneEventHandler>();
+                e.Register<FastLaneSecondHandler>();
+                extra?.Invoke(e);
+            }))
+            .BuildServiceProvider();
+
+    public sealed class FastLaneEvent : IEvent { public string? Tag { get; init; } }
+
+    public sealed class FastLaneEventHandler : IEventHandler<FastLaneEvent>
+    {
+        public ValueTask HandleAsync(FastLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("writtenByHandler", @event.Tag ?? "-");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class FastLaneSecondHandler : IEventHandler<FastLaneEvent>
+    {
+        public ValueTask HandleAsync(FastLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("secondHandlerRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldMakeHandlerWrites_VisibleInCallerSettingsItems()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new FastLaneEvent { Tag = "t1" }, settings);
+
+        Assert.Equal("t1", settings.Items["writtenByHandler"]);
+        Assert.Equal(true, settings.Items["secondHandlerRan"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldKeepCallerSeededItems_AndSurviveTheDispatch()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+        settings.Items["seed"] = "hello";
+
+        await mediator.PublishAsync(new FastLaneEvent(), settings);
+
+        // The dictionary is adopted for the dispatch and detached on return — never wiped.
+        Assert.Equal("hello", settings.Items["seed"]);
+        Assert.True(settings.Items.ContainsKey("writtenByHandler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithDefaultSettings_ShouldStartFromACleanPooledContext()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // First publish seeds a caller dictionary through the pooled context.
+        var settings = new EventMediationSettings();
+        settings.Items["seed"] = "hello";
+        await mediator.PublishAsync(new FastLaneEvent(), settings);
+
+        // A default-settings publish right after must not observe any of it, and must not
+        // pollute the earlier caller's dictionary either.
+        var probe = new EventMediationSettings();
+        await mediator.PublishAsync(new FastLaneEvent { Tag = "probe" }, probe);
+
+        Assert.False(probe.Items.ContainsKey("seed"));
+        Assert.Equal("probe", probe.Items["writtenByHandler"]);
+        Assert.Equal("hello", settings.Items["seed"]);
+        Assert.NotEqual("probe", settings.Items["writtenByHandler"]);
+    }
+
+    public sealed class RewrittenEvent : IEvent { public string Payload { get; init; } = "original"; }
+
+    public sealed class RewritingPreInterceptor : IEventPreInterceptor<RewrittenEvent>
+    {
+        public ValueTask<RewrittenEvent> HandleAsync(RewrittenEvent @event, IExecutionContext context)
+            => ValueTask.FromResult(new RewrittenEvent { Payload = @event.Payload + "+rewritten" });
+    }
+
+    public sealed class RewrittenEventHandler : IEventHandler<RewrittenEvent>
+    {
+        public ValueTask HandleAsync(RewrittenEvent @event, IExecutionContext context)
+        {
+            context.Set("observedPayload", @event.Payload);
+            context.Set("observedInstance", @event);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldContinueWithThePreInterceptorsReturnedEvent()
+    {
+        await using var provider = Build(e =>
+        {
+            e.Register<RewritingPreInterceptor>();
+            e.Register<RewrittenEventHandler>();
+        });
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+        var original = new RewrittenEvent();
+
+        await mediator.PublishAsync(original, settings);
+
+        // The handler received the brand-new instance the pre-interceptor returned.
+        Assert.Equal("original+rewritten", settings.Items["observedPayload"]);
+        Assert.NotSame(original, settings.Items["observedInstance"]);
+    }
+
+    public sealed class ThrowingEvent : IEvent { }
+
+    public sealed class ThrowingEventHandler : IEventHandler<ThrowingEvent>
+    {
+        public ValueTask HandleAsync(ThrowingEvent @event, IExecutionContext context)
+            => throw new InvalidOperationException("evt-boom");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldPropagateHandlerException_WhenNoExceptionInterceptorsExist()
+    {
+        await using var provider = Build(e => e.Register<ThrowingEventHandler>());
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.PublishAsync(new ThrowingEvent()));
+
+        Assert.Equal("evt-boom", exception.Message);
+    }
+
+    public sealed class HandlerlessEvent : IEvent { }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldHonorThrowIfNoHandlerFound()
+    {
+        await using var provider = Build(e => e.Register<HandlerlessEvent>());
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // Default: silent.
+        await mediator.PublishAsync(new HandlerlessEvent());
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(async () =>
+            await mediator.PublishAsync(
+                new HandlerlessEvent(),
+                new EventMediationSettings { ThrowIfNoHandlerFound = true }));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldApplyHandlerPredicateFilter()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+        settings.Filters.HandlerPredicate = type => type != typeof(FastLaneSecondHandler);
+
+        await mediator.PublishAsync(new FastLaneEvent { Tag = "filtered" }, settings);
+
+        Assert.Equal("filtered", settings.Items["writtenByHandler"]);
+        Assert.False(settings.Items.ContainsKey("secondHandlerRan"));
+    }
+
+    public sealed class SlowEvent : IEvent { }
+
+    public sealed class SlowEventHandler : IEventHandler<SlowEvent>
+    {
+        public async ValueTask HandleAsync(SlowEvent @event, IExecutionContext context)
+        {
+            await Task.Delay(10);
+            context.Set("afterAwait", 42);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithGenuinelyAsyncHandler_ShouldCompleteAndExposeItems()
+    {
+        await using var provider = Build(e => e.Register<SlowEventHandler>());
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new SlowEvent(), settings);
+
+        Assert.Equal(42, settings.Items["afterAwait"]);
+    }
+
+    public sealed class OuterEvent : IEvent { }
+    public sealed class InnerEvent : IEvent { }
+
+    public sealed class InnerEventHandler : IEventHandler<InnerEvent>
+    {
+        public ValueTask HandleAsync(InnerEvent @event, IExecutionContext context)
+        {
+            context.Set("innerRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class OuterEventHandler(IEventMediator events) : IEventHandler<OuterEvent>
+    {
+        public async ValueTask HandleAsync(OuterEvent @event, IExecutionContext context)
+        {
+            using var scope = context.CreateScope();
+            await events.PublishAsync(new InnerEvent(), scope.Context);
+            context.Set("outerSawInner", scope.Context.Has("innerRan"));
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_Nested_ShouldRunUnderTheCallerOwnedChildContext()
+    {
+        await using var provider = Build(e =>
+        {
+            e.Register<OuterEventHandler>();
+            e.Register<InnerEventHandler>();
+        });
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new OuterEvent(), settings);
+
+        Assert.Equal(true, settings.Items["outerSawInner"]);
+    }
+
+    public sealed class LateEvent : IEvent { }
+
+    public sealed class LateEventHandler : IEventHandler<LateEvent>
+    {
+        public ValueTask HandleAsync(LateEvent @event, IExecutionContext context)
+        {
+            context.Set("lateHandlerRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldPickUpRuntimeRegistrations_AfterWarmingTheInvokerPlan()
+    {
+        var provider = new ServiceCollection()
+            .AddTransient<LateEventHandler>()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<LateEvent>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // Warm the invoker-cached plan with zero handlers (silent publishes).
+        var warm = new EventMediationSettings();
+        await mediator.PublishAsync(new LateEvent(), warm);
+        await mediator.PublishAsync(new LateEvent(), warm);
+        Assert.False(warm.Items.ContainsKey("lateHandlerRan"));
+
+        // A runtime registration bumps the registry version; the cached plan must rebuild.
+        registry.Register(typeof(LateEventHandler));
+
+        var probe = new EventMediationSettings();
+        await mediator.PublishAsync(new LateEvent(), probe);
+
+        Assert.Equal(true, probe.Items["lateHandlerRan"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_InParallel_ShouldNeverMixPerPublishItems()
+    {
+        await using var provider = Build();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var mismatches = 0;
+
+        await Task.WhenAll(Enumerable.Range(0, 4).Select(lane => Task.Run(async () =>
+        {
+            for (var i = 0; i < 2_000; i++)
+            {
+                var settings = new EventMediationSettings();
+                var tag = $"{lane}:{i}";
+
+                await mediator.PublishAsync(new FastLaneEvent { Tag = tag }, settings);
+
+                if (!Equals(settings.Items["writtenByHandler"], tag))
+                {
+                    Interlocked.Increment(ref mismatches);
+                }
+            }
+        })));
+
+        Assert.Equal(0, mismatches);
+    }
+
+    public sealed class ScopedProbe { }
+
+    public sealed class ScopedEvent : IEvent { }
+
+    public sealed class ScopedEventHandler(ScopedProbe probe) : IEventHandler<ScopedEvent>
+    {
+        public ValueTask HandleAsync(ScopedEvent @event, IExecutionContext context)
+        {
+            context.Set("probe", probe);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_FromAScope_ShouldResolveHandlersAgainstThatScope()
+    {
+        var provider = new ServiceCollection()
+            .AddScoped<ScopedProbe>()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<ScopedEventHandler>()))
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        await using var _ = provider;
+
+        using var scope = provider.CreateScope();
+        var expected = scope.ServiceProvider.GetRequiredService<ScopedProbe>();
+        var settings = new EventMediationSettings();
+
+        await scope.ServiceProvider.GetRequiredService<IEventMediator>()
+            .PublishAsync(new ScopedEvent(), settings);
+
+        Assert.Same(expected, settings.Items["probe"]);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
@@ -76,7 +76,7 @@ public class EngineBackedEventFacadeTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task Publish_WithGroups_TakesTheMediateFallback_AndFiltersHandlers()
+    public async Task Publish_WithGroups_FiltersHandlers()
     {
         var provider = Build();
         await using var _ = provider;
@@ -88,7 +88,8 @@ public class EngineBackedEventFacadeTests
 
         await mediator.PublishAsync(new GroupedEvent(), settings);
 
-        // The grouped publish leaves the fast lane; only the requested group's handler runs.
+        // The grouped publish runs the group-filtered plan; only the requested group's
+        // handler runs.
         Assert.Equal(true, settings.Items["auditRan"]);
         Assert.False(settings.Items.ContainsKey("defaultRan"));
     }

--- a/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
@@ -1,0 +1,122 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Covers the engine-backed facade shape for events: DI resolves a single-object facade
+/// bound to the process-wide <see cref="MessageDispatchEngine"/>, both public constructors
+/// publish identically, and grouped publishes leave the fast lane for the original
+/// Mediate path with its handler-group filtering intact.
+/// </summary>
+public class EngineBackedEventFacadeTests
+{
+    public sealed class GroupedEvent : IEvent { }
+
+    /// <summary>
+    /// Excluded from discovery so another test's assembly scan (the registry is
+    /// process-wide) cannot register it into a group set this class does not control.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    [Group("audit")]
+    public sealed class AuditGroupHandler : IEventHandler<GroupedEvent>
+    {
+        public ValueTask HandleAsync(GroupedEvent @event, IExecutionContext context)
+        {
+            context.Set("auditRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class DefaultGroupHandler : IEventHandler<GroupedEvent>
+    {
+        public ValueTask HandleAsync(GroupedEvent @event, IExecutionContext context)
+        {
+            context.Set("defaultRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider Build()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<AuditGroupHandler>();
+                e.Register<DefaultGroupHandler>();
+            }))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_IsTheEngineBackedShape_AndPublishes()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        Assert.IsAssignableFrom<EventMediator>(mediator);
+        Assert.NotEqual(typeof(EventMediator), mediator.GetType());
+
+        var settings = new EventMediationSettings();
+        await mediator.PublishAsync(new GroupedEvent(), settings);
+
+        // A group-less publish serves the default group only.
+        Assert.Equal(true, settings.Items["defaultRan"]);
+        Assert.False(settings.Items.ContainsKey("auditRan"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_WithGroups_TakesTheMediateFallback_AndFiltersHandlers()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = ["audit"];
+
+        await mediator.PublishAsync(new GroupedEvent(), settings);
+
+        // The grouped publish leaves the fast lane; only the requested group's handler runs.
+        Assert.Equal(true, settings.Items["auditRan"]);
+        Assert.False(settings.Items.ContainsKey("defaultRan"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task BothConstructors_PublishIdentically()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var strategy = provider.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>();
+        var adapters = provider.GetRequiredService<IResultAdapterService>();
+
+        var engineBacked = new EventMediator(
+            provider.GetRequiredService<MessageDispatchEngine>(), provider, strategy, adapters);
+        var mediatorBacked = new EventMediator(
+            strategy, adapters, provider.GetRequiredService<IMessageMediator>());
+
+        foreach (var mediator in new EventMediator[] { engineBacked, mediatorBacked })
+        {
+            var settings = new EventMediationSettings();
+
+            await mediator.PublishAsync(new GroupedEvent(), settings);
+
+            Assert.Equal(true, settings.Items["defaultRan"]);
+            Assert.False(settings.Items.ContainsKey("auditRan"));
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/GroupedBroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/GroupedBroadcastFastLaneTests.cs
@@ -1,0 +1,173 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// The grouped broadcast fast lane: grouped publishes resolve the same group-filtered
+/// pipeline the Mediate path built, served from a last-used (factory, group set) plan
+/// slot. The tests stress the slot's weak spots — alternating group sets, a reused
+/// settings instance whose group list is mutated in place, and a grouped pipeline that
+/// carries an interceptor (which must keep the strategy path, not the straight-through
+/// loop).
+/// </summary>
+public class GroupedBroadcastFastLaneTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class LaneEvent : IEvent { }
+
+    [ExcludeFromDiscovery]
+    [Group("alpha")]
+    public sealed class AlphaHandler : IEventHandler<LaneEvent>
+    {
+        public ValueTask HandleAsync(LaneEvent @event, IExecutionContext context)
+        {
+            context.Set("alphaRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("beta")]
+    public sealed class BetaHandler : IEventHandler<LaneEvent>
+    {
+        public ValueTask HandleAsync(LaneEvent @event, IExecutionContext context)
+        {
+            context.Set("betaRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider Build()
+        => new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<AlphaHandler>();
+                e.Register<BetaHandler>();
+            }))
+            .BuildServiceProvider();
+
+    private static async Task<IDictionary<object, object?>> Publish(IEventMediator mediator, params string[] groups)
+    {
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = groups;
+
+        await mediator.PublishAsync(new LaneEvent(), settings);
+
+        return settings.Items;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task AlternatingGroupSets_AlwaysRunTheRequestedGroup()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // alpha populates the slot, beta must not be served alpha's plan, and alpha
+        // again must survive the slot having moved on.
+        var first = await Publish(mediator, "alpha");
+        Assert.Equal(true, first["alphaRan"]);
+        Assert.False(first.ContainsKey("betaRan"));
+
+        var second = await Publish(mediator, "beta");
+        Assert.Equal(true, second["betaRan"]);
+        Assert.False(second.ContainsKey("alphaRan"));
+
+        var third = await Publish(mediator, "alpha");
+        Assert.Equal(true, third["alphaRan"]);
+        Assert.False(third.ContainsKey("betaRan"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task MutatedReusedGroupList_IsSeenAsANewGroupSet()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // One settings instance, one List instance — mutated between publishes. The slot
+        // snapshots group contents, so the second publish must re-resolve, not replay
+        // alpha's plan.
+        var groups = new List<string> { "alpha" };
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = groups;
+
+        await mediator.PublishAsync(new LaneEvent(), settings);
+        Assert.Equal(true, settings.Items["alphaRan"]);
+
+        groups.Clear();
+        groups.Add("beta");
+        settings.Items.Clear();
+
+        await mediator.PublishAsync(new LaneEvent(), settings);
+        Assert.Equal(true, settings.Items["betaRan"]);
+        Assert.False(settings.Items.ContainsKey("alphaRan"));
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedLaneEvent : IEvent { }
+
+    [ExcludeFromDiscovery]
+    [Group("guarded")]
+    public sealed class GuardedHandler : IEventHandler<InterceptedLaneEvent>
+    {
+        public ValueTask HandleAsync(InterceptedLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("guardedRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("guarded")]
+    public sealed class GuardedInterceptor : IEventPreInterceptor<InterceptedLaneEvent>
+    {
+        public ValueTask<InterceptedLaneEvent> HandleAsync(InterceptedLaneEvent @event, IExecutionContext context)
+        {
+            context.Set("guardedInterceptorRan", true);
+            return ValueTask.FromResult(@event);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task GroupedPipelineWithInterceptor_RunsTheFullStrategy()
+    {
+        var provider = Build();
+        await using var _ = provider;
+
+        // Register the intercepted pipeline in its own container to keep the fixture
+        // handlers' pipelines interceptor-free.
+        await using var guarded = new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e =>
+            {
+                e.Register<GuardedHandler>();
+                e.Register<GuardedInterceptor>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = guarded.GetRequiredService<IEventMediator>();
+
+        var settings = new EventMediationSettings();
+        settings.Filters.Groups = ["guarded"];
+
+        await mediator.PublishAsync(new InterceptedLaneEvent(), settings);
+
+        // A grouped pipeline that carries an interceptor must leave the straight-through
+        // loop to the strategy, which runs the interceptor before the handler.
+        Assert.Equal(true, settings.Items["guardedInterceptorRan"]);
+        Assert.Equal(true, settings.Items["guardedRan"]);
+    }
+}

--- a/test/Stella.Ergosfare.Events.Test/TypedPublishHolderTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/TypedPublishHolderTests.cs
@@ -1,0 +1,81 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Covers the static-generic invoker holder behind the typed publish overload: it must be
+/// the same instance the runtime-type cache serves (one plan cache per event type), and a
+/// generic call made through a base-typed variable must keep dispatching by the event's
+/// runtime type.
+/// </summary>
+public class TypedPublishHolderTests
+{
+    public class BaseEvent : IEvent { }
+
+    public sealed class DerivedEvent : BaseEvent { }
+
+    public sealed class DerivedEventHandler : IEventHandler<DerivedEvent>
+    {
+        public ValueTask HandleAsync(DerivedEvent @event, IExecutionContext context)
+        {
+            context.Set("derivedRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void Holder_ServesTheSameInstance_AsTheRuntimeTypeCache()
+    {
+        var fromHolder = EventBroadcastInvokerCache.Holder<DerivedEvent>.Instance;
+        var fromCache = EventBroadcastInvokerCache.Get(typeof(DerivedEvent));
+
+        Assert.Same(fromCache, fromHolder);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ThroughABaseTypedVariable_DispatchesByRuntimeType()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<DerivedEventHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // The variable's static type closes the generic overload over BaseEvent; the
+        // holder guard must reject it and resolve the DerivedEvent pipeline instead.
+        BaseEvent @event = new DerivedEvent();
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(@event, settings);
+
+        Assert.Equal(true, settings.Items["derivedRan"]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ThroughTheConcreteType_TakesTheHolderAndDispatches()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddEventModule(e => e.Register<DerivedEventHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        var settings = new EventMediationSettings();
+
+        await mediator.PublishAsync(new DerivedEvent(), settings);
+
+        Assert.Equal(true, settings.Items["derivedRan"]);
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
@@ -37,7 +37,7 @@ public class EngineBackedQueryFacadeTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task DiResolvedFacade_Streams_ResolvingTheScopesMediatorOnDemand()
+    public async Task DiResolvedFacade_Streams_ThroughTheEngineFastLane()
     {
         var provider = new ServiceCollection()
             .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStreamStringResultQueryHandler>()))

--- a/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/EngineBackedQueryFacadeTests.cs
@@ -1,0 +1,82 @@
+using Stella.Ergosfare.Core;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Test.__stubs__;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Queries.Test;
+
+/// <summary>
+/// Covers the engine-backed facade shape for queries: DI resolves a single-object facade
+/// bound to the process-wide <see cref="MessageDispatchEngine"/>, both public constructors
+/// query identically, and the streaming path — which stays on the mediator's
+/// <c>Mediate(options)</c> machinery — resolves the scope's mediator on demand.
+/// </summary>
+public class EngineBackedQueryFacadeTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_IsTheEngineBackedShape_AndQueries()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStringResultQueryHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        Assert.IsAssignableFrom<QueryMediator>(mediator);
+        Assert.NotEqual(typeof(QueryMediator), mediator.GetType());
+        Assert.Equal(string.Empty, await mediator.QueryAsync(new StubNonGenericStringResultQuery()));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task DiResolvedFacade_Streams_ResolvingTheScopesMediatorOnDemand()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStreamStringResultQueryHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IQueryMediator>();
+
+        var result = new List<string>();
+
+        await foreach (var item in mediator.StreamAsync(new StubNonGenericStreamStringResultQuery()))
+        {
+            result.Add(item);
+        }
+
+        Assert.Equal(["Foo", "Bar", "Baz"], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task BothConstructors_QueryIdentically()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<StubNonGenericStringResultQueryHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var strategy = provider.GetRequiredService<ActualTypeOrFirstAssignableTypeMessageResolveStrategy>();
+
+        var engineBacked = new QueryMediator(
+            provider.GetRequiredService<MessageDispatchEngine>(), provider, strategy);
+        var mediatorBacked = new QueryMediator(
+            strategy, provider.GetRequiredService<IMessageMediator>());
+
+        foreach (var mediator in new[] { engineBacked, mediatorBacked })
+        {
+            Assert.Equal(string.Empty, await mediator.QueryAsync(new StubNonGenericStringResultQuery()));
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
@@ -1,0 +1,141 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Queries.Test;
+
+/// <summary>
+/// The engine-backed streaming fast lane: streams run against the invoker-cached,
+/// registry-version-guarded pipeline plan instead of the per-call Mediate options path.
+/// Covers plan reuse across streams, grouped streams alternating group sets on the
+/// last-used slot, caller-visible items, and the unregistered-query failure parity.
+/// Helper types are excluded from discovery so assembly scans (the registry is
+/// process-wide) cannot alter these pipelines.
+/// </summary>
+public class StreamFastLaneTests
+{
+    [ExcludeFromDiscovery]
+    public sealed record NumberStream : IStreamQuery<int>;
+
+    [ExcludeFromDiscovery]
+    public sealed class NumberStreamHandler : IStreamQueryHandler<NumberStream, int>
+    {
+        public async IAsyncEnumerable<int> StreamAsync(NumberStream query, IExecutionContext context)
+        {
+            context.Set("streamRan", true);
+            yield return 1;
+            await Task.Yield();
+            yield return 2;
+            yield return 3;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task RepeatedStreams_ServeThePlan_AndFlowItemsToTheCaller()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q => q.Register<NumberStreamHandler>()))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        // First stream builds the invoker's plan, second is served from it; both must
+        // yield the full sequence and surface handler writes through the settings items.
+        for (var i = 0; i < 2; i++)
+        {
+            var settings = new QueryMediationSettings();
+            var items = new List<int>();
+
+            await foreach (var item in mediator.StreamAsync(new NumberStream(), settings))
+            {
+                items.Add(item);
+            }
+
+            Assert.Equal([1, 2, 3], items);
+            Assert.Equal(true, settings.Items["streamRan"]);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed record RoutedStream : IStreamQuery<string>;
+
+    [ExcludeFromDiscovery]
+    [Group("east")]
+    public sealed class EastStreamHandler : IStreamQueryHandler<RoutedStream, string>
+    {
+        public async IAsyncEnumerable<string> StreamAsync(RoutedStream query, IExecutionContext context)
+        {
+            await Task.Yield();
+            yield return "east";
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    [Group("west")]
+    public sealed class WestStreamHandler : IStreamQueryHandler<RoutedStream, string>
+    {
+        public async IAsyncEnumerable<string> StreamAsync(RoutedStream query, IExecutionContext context)
+        {
+            await Task.Yield();
+            yield return "west";
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task GroupedStreams_AlternatingGroupSets_RunTheRequestedGroup()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q =>
+            {
+                q.Register<EastStreamHandler>();
+                q.Register<WestStreamHandler>();
+            }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        Assert.Equal("east", await StreamOne(mediator, "east"));
+        Assert.Equal("west", await StreamOne(mediator, "west"));
+        Assert.Equal("east", await StreamOne(mediator, "east"));
+
+        static async Task<string> StreamOne(IQueryMediator mediator, params string[] groups)
+        {
+            var settings = new QueryMediationSettings { Filters = { Groups = groups } };
+
+            await foreach (var item in mediator.StreamAsync(new RoutedStream(), settings))
+            {
+                return item;
+            }
+
+            throw new InvalidOperationException("stream yielded nothing");
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed record UnhandledStream : IStreamQuery<int>;
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task UnregisteredStreamQuery_ThrowsAtCallTime_LikeTheMediatePath()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(_ => { }))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        // The Mediate path threw from the StreamAsync call itself (descriptor resolution
+        // precedes enumeration); the fast lane must keep that timing.
+        Assert.Throws<NoHandlerFoundException>(() => mediator.StreamAsync(new UnhandledStream()));
+        await Task.CompletedTask;
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
@@ -1,0 +1,153 @@
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+/// Compile-time void pipeline plan emission: a dispatchable command whose whole discovered
+/// pipeline is a single default-discovery, default-group async handler gets an
+/// <c>AddVoidPlan</c> root; any ambiguity — a second handler, an interceptor, a keyed or
+/// grouped handler, a result contract — keeps the type on the plain dispatch roots only.
+/// </summary>
+public class VoidPlanEmissionTests
+{
+    [Fact]
+    public void SoloAsyncHandler_EmitsTheVoidPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record SoloPing : ICommand;
+
+                public sealed class SoloPingHandler : ICommandHandler<SoloPing>
+                {
+                    public ValueTask HandleAsync(SoloPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.SoloPing, global::TestApp.SoloPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void SecondHandler_SuppressesThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record DuoPing : ICommand;
+
+                public sealed class FirstDuoPingHandler : ICommandHandler<DuoPing>
+                {
+                    public ValueTask HandleAsync(DuoPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class SecondDuoPingHandler : ICommandHandler<DuoPing>
+                {
+                    public ValueTask HandleAsync(DuoPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+        Assert.Contains("AddMessage<global::TestApp.DuoPing>", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void DiscoveredInterceptor_SuppressesThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record GuardedPing : ICommand;
+
+                public sealed class GuardedPingHandler : ICommandHandler<GuardedPing>
+                {
+                    public ValueTask HandleAsync(GuardedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class GuardedPingInterceptor : ICommandPreInterceptor<GuardedPing>
+                {
+                    public ValueTask<GuardedPing> HandleAsync(GuardedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void KeyedOrGroupedHandler_SuppressesThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record KeyedPing : ICommand;
+
+                [DiscoveryKey("plans.keyed")]
+                public sealed class KeyedPingHandler : ICommandHandler<KeyedPing>
+                {
+                    public ValueTask HandleAsync(KeyedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed record GroupedPing : ICommand;
+
+                [Group("reporting")]
+                public sealed class GroupedPingHandler : ICommandHandler<GroupedPing>
+                {
+                    public ValueTask HandleAsync(GroupedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ResultContract_DoesNotProduceAVoidPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record TypedPing : ICommand<string>;
+
+                public sealed class TypedPingHandler : ICommandHandler<TypedPing, string>
+                {
+                    public ValueTask<string> HandleAsync(TypedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(string.Empty);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
+        Assert.Contains("AddResult<global::TestApp.TypedPing, string>", result.GeneratedSource);
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
@@ -29,8 +29,127 @@ public class VoidPlanEmissionTests
 
         Assert.Empty(result.GeneratorDiagnostics);
         Assert.Empty(result.CompilationErrors);
+
+        // The handler has an accessible parameterless constructor and is not disposable,
+        // so the plan carries the direct-construction factory.
         Assert.Contains(
-            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.SoloPing, global::TestApp.SoloPingHandler>();",
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.SoloPing, global::TestApp.SoloPingHandler>(static () => new global::TestApp.SoloPingHandler());",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ConstructorDependency_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record NeedyPing : ICommand;
+
+                public sealed class NeedyPingHandler : ICommandHandler<NeedyPing>
+                {
+                    public NeedyPingHandler(string dependency) { }
+
+                    public ValueTask HandleAsync(NeedyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.NeedyPing, global::TestApp.NeedyPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void AdditionalConstructor_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record PickyPing : ICommand;
+
+                public sealed class PickyPingHandler : ICommandHandler<PickyPing>
+                {
+                    public PickyPingHandler() { }
+
+                    public PickyPingHandler(string dependency) { }
+
+                    public ValueTask HandleAsync(PickyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // The container's greedy constructor selection would pick the richer constructor;
+        // a `new()` factory would silently drop that dependency — plan only, no factory.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.PickyPing, global::TestApp.PickyPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void RequiredMember_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record NamedPing : ICommand;
+
+                public sealed class NamedPingHandler : ICommandHandler<NamedPing>
+                {
+                    public required string Name { get; init; }
+
+                    public ValueTask HandleAsync(NamedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // An emitted `new()` would fail compilation with CS9035 — plan only, no factory.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.NamedPing, global::TestApp.NamedPingHandler>();",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void DisposableHandler_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record LeakyPing : ICommand;
+
+                public sealed class LeakyPingHandler : ICommandHandler<LeakyPing>, IDisposable
+                {
+                    public ValueTask HandleAsync(LeakyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+
+                    public void Dispose() { }
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.LeakyPing, global::TestApp.LeakyPingHandler>();",
             result.GeneratedSource);
     }
 
@@ -149,5 +268,64 @@ public class VoidPlanEmissionTests
         Assert.Empty(result.CompilationErrors);
         Assert.DoesNotContain("AddVoidPlan<", result.GeneratedSource);
         Assert.Contains("AddResult<global::TestApp.TypedPing, string>", result.GeneratedSource);
+
+        // The same solo-async-handler shape on the result side produces the result plan
+        // instead, factory included.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddResultPlan<global::TestApp.TypedPing, string, global::TestApp.TypedPingHandler>(static () => new global::TestApp.TypedPingHandler());",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void DiscoveredInterceptor_SuppressesTheResultPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record GuardedTypedPing : ICommand<string>;
+
+                public sealed class GuardedTypedPingHandler : ICommandHandler<GuardedTypedPing, string>
+                {
+                    public ValueTask<string> HandleAsync(GuardedTypedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(string.Empty);
+                }
+
+                public sealed class GuardedTypedPingInterceptor : ICommandPreInterceptor<GuardedTypedPing>
+                {
+                    public ValueTask<GuardedTypedPing> HandleAsync(GuardedTypedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddResultPlan<", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void StreamContract_DoesNotProduceAResultPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Queries.Abstractions;
+            using System.Collections.Generic;
+
+            namespace TestApp
+            {
+                public sealed record NumberStream : IStreamQuery<int>;
+
+                public sealed class NumberStreamHandler : IStreamQueryHandler<NumberStream, int>
+                {
+                    public IAsyncEnumerable<int> StreamAsync(NumberStream message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => throw new System.NotImplementedException();
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddResultPlan<", result.GeneratedSource);
+        Assert.Contains("AddStream<global::TestApp.NumberStream, int>", result.GeneratedSource);
     }
 }


### PR DESCRIPTION
Promotes everything on `preview` since v2.0.0 to the stable line as **v2.1.0**:

- the v2.2.0-preview dispatch fast path (executor-level dependency caches, sync fast path, transient facades),
- the v2.3.0-preview engine work (single-object facades over `MessageDispatchEngine`, broadcast fast lane, first compile-time void plans, typed publish holder),
- the v2.4.0-preview sweep (result plans + direct handler construction, grouped and streaming fast lanes, `DispatchVoidAsync`, martinothamar/Mediator benchmark rows, NativeAOT smoke CI).

The shared CHANGELOG already carries the `v2.1.0 – '2026-08-07'` stable entry (landed on preview via #110, so this merge is conflict-free). The only commit on top of `preview` here flips the readme back to its stable flavor: `nuget/v` badge, `branch=main` tests badge, the stable-line callout, plain (non-`--prerelease`) install commands.

After merge: push the stable `v2.1.0` tag on `main` (the release workflows' ancestry check passes there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)