### PR TITLE
perf: precomputed descriptor catalog — manual Register<T>() drops its reflection

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDescriptorCatalog.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDescriptorCatalog.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+
+namespace Stella.Ergosfare.Core.Abstractions;
+
+/// <summary>
+/// Process-wide lookup of compile-time-computed handler descriptors, populated by
+/// source-generated module initializers: one factory per handler type the generator saw
+/// in a compilation. Runtime registration (<c>Register&lt;THandler&gt;()</c> /
+/// <c>Register(Type)</c>) consults the catalog first and only falls back to the
+/// reflection-based descriptor builders for types no generator modeled — runtime-loaded
+/// plugin types, open generics registered manually, foreign assemblies without the
+/// analyzer. The generator's descriptor computation mirrors the runtime builders exactly
+/// (the contract its test suite pins), so the two paths are interchangeable; the catalog
+/// only removes the reflection.
+/// </summary>
+public static class GeneratedDescriptorCatalog
+{
+    private static readonly ConcurrentDictionary<Type, Func<IReadOnlyList<IHandlerDescriptor>>> Factories = new();
+
+    /// <summary>
+    /// Contributes the descriptor factory of a handler type. Idempotent — the first
+    /// contribution for a type wins, which is immaterial because every generator computes
+    /// identical descriptors for the same type.
+    /// </summary>
+    /// <param name="handlerType">The handler type the factory describes.</param>
+    /// <param name="descriptorsFactory">Factory producing the type's full descriptor set.</param>
+    public static void Add(Type handlerType, Func<IReadOnlyList<IHandlerDescriptor>> descriptorsFactory)
+    {
+        ArgumentNullException.ThrowIfNull(handlerType);
+        ArgumentNullException.ThrowIfNull(descriptorsFactory);
+
+        Factories.TryAdd(handlerType, descriptorsFactory);
+    }
+
+    /// <summary>
+    /// Materializes the precomputed descriptors of a type, or reports that no generator
+    /// modeled it (route to the reflective builders).
+    /// </summary>
+    internal static bool TryCreateDescriptors(Type type, out IReadOnlyList<IHandlerDescriptor>? descriptors)
+    {
+        if (Factories.TryGetValue(type, out var factory))
+        {
+            descriptors = factory();
+            return true;
+        }
+
+        descriptors = null;
+        return false;
+    }
+}

--- a/src/Stella.Ergosfare.Core/Internal/Registry/MessageRegistry.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/MessageRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Internal.Factories;
@@ -159,10 +160,14 @@ internal sealed class MessageRegistry(
                 return;
             }
 
-            // Use builders to create handler descriptors for the given type
-            // <see cref="MessageDescriptorBuilderFactory" />
-
-            var newDescriptors = handlerDescriptorBuilderFactory.BuildDescriptors(type);
+            // Compile-time-computed descriptors first (the generator's module initializer
+            // populated the catalog for every type it modeled — identical values to what
+            // the builders would derive); the reflection-based builders remain the
+            // fallback for types no generator saw.
+            IReadOnlyList<IHandlerDescriptor> newDescriptors =
+                GeneratedDescriptorCatalog.TryCreateDescriptors(type, out var precomputed)
+                    ? precomputed!
+                    : handlerDescriptorBuilderFactory.BuildDescriptors(type);
 
 
             // If no handlers were created, assume the type is a message type and register it

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -63,6 +63,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private const string EventBuilderMetadataName = "Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection.EventModuleBuilder";
 
     private const string ValueTaskExpression = "global::System.Threading.Tasks.ValueTask";
+    private const string DescriptorCatalogMetadataName = "Stella.Ergosfare.Core.Abstractions.GeneratedDescriptorCatalog";
 
     private const string ScanReferencesBuildProperty = "build_property.ErgosfareSourceGeneratorScanReferences";
     private const string ErgosfareAssemblyNamePrefix = "Stella.Ergosfare";
@@ -107,7 +108,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 HasDispatchRoots: dispatchRoots is not null,
                 DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty,
                 DispatchRootsHasResultPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddResultPlan").IsEmpty,
-                DispatchRootsHasPlanFactories: dispatchRoots is not null && HasFactoryOverload(dispatchRoots));
+                DispatchRootsHasPlanFactories: dispatchRoots is not null && HasFactoryOverload(dispatchRoots),
+                HasDescriptorCatalog: compilation.GetTypeByMetadataName(DescriptorCatalogMetadataName) is not null);
         });
 
         // Reference scanning is default-on; consumers opt out per project through the

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -24,6 +24,11 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     <c>Func&lt;THandler&gt;</c> overloads); older packages take only the parameterless
 ///     form, and emission degrades accordingly.
 /// </param>
+/// <param name="HasDescriptorCatalog">
+///     Whether <c>GeneratedDescriptorCatalog</c> is resolvable — the lookup that makes
+///     runtime <c>Register&lt;THandler&gt;()</c> reflection-free for generator-modeled
+///     types; older packages simply skip the module-initializer emission.
+/// </param>
 internal readonly record struct ModuleBuilderAvailability(
     bool HasMessageRegistry,
     bool HasCommandModuleBuilder,
@@ -36,4 +41,5 @@ internal readonly record struct ModuleBuilderAvailability(
     bool HasDispatchRoots,
     bool DispatchRootsHasVoidPlans,
     bool DispatchRootsHasResultPlans,
-    bool DispatchRootsHasPlanFactories);
+    bool DispatchRootsHasPlanFactories,
+    bool HasDescriptorCatalog);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -33,6 +33,7 @@ internal static class RegistrationEmitter
     private const string QueryBuilderFullName = "global::Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection.QueryModuleBuilder";
     private const string EventBuilderFullName = "global::Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection.EventModuleBuilder";
     private const string DispatchRootsFullName = "global::Stella.Ergosfare.Core.Abstractions.GeneratedDispatchRoots";
+    private const string DescriptorCatalogFullName = "global::Stella.Ergosfare.Core.Abstractions.GeneratedDescriptorCatalog";
 
     /// <summary>
     ///     Emits the <c>ErgosfareGeneratedRegistrations</c> class for the discovered types.
@@ -101,6 +102,11 @@ internal static class RegistrationEmitter
         {
             EmitDispatchRoots(sb, ref wroteMember, types, voidPlans, resultPlans,
                 builders.DispatchRootsHasPlanFactories);
+        }
+
+        if (builders.HasDescriptorCatalog && useDescriptors && HasDescriptors(types))
+        {
+            EmitDescriptorCatalog(sb, ref wroteMember, types);
         }
 
         EmitMatchesHelper(sb, ref wroteMember);
@@ -389,6 +395,52 @@ internal static class RegistrationEmitter
             sb.Append("                ").Append(receiver).AppendLine(".RegisterDescriptors(descriptors);");
             sb.AppendLine("            }");
         }
+    }
+
+    /// <summary>
+    ///     Emits the module initializer that hands every modeled handler type's
+    ///     compile-time descriptor factory to <c>GeneratedDescriptorCatalog</c>: from then
+    ///     on a manual <c>Register&lt;THandler&gt;()</c> — including ones that never call
+    ///     <c>RegisterGenerated()</c> — registers without reflection. Purely a lookup
+    ///     contribution: nothing is registered here, so initialization order and
+    ///     discovery-key gating are unaffected.
+    /// </summary>
+    private static void EmitDescriptorCatalog(
+        StringBuilder sb,
+        ref bool wroteMember,
+        IReadOnlyList<RegistrableTypeModel> types)
+    {
+        StartMember(sb, ref wroteMember);
+        sb.AppendLine("        [global::System.Runtime.CompilerServices.ModuleInitializer]");
+        sb.AppendLine("        internal static void PopulateDescriptorCatalog()");
+        sb.AppendLine("        {");
+
+        foreach (var type in types)
+        {
+            if (type.Descriptors.Length == 0)
+            {
+                continue;
+            }
+
+            sb.Append("            ").Append(DescriptorCatalogFullName)
+              .Append(".Add(typeof(").Append(type.TypeofExpression)
+              .Append("), static () => new global::System.Collections.Generic.List<")
+              .Append(DescriptorFullName).Append("> { ");
+
+            for (var i = 0; i < type.Descriptors.Length; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+
+                AppendDescriptorExpression(sb, type, type.Descriptors[i]);
+            }
+
+            sb.AppendLine(" });");
+        }
+
+        sb.AppendLine("        }");
     }
 
     private static void AppendDescriptorExpression(StringBuilder sb, in RegistrableTypeModel type, in DescriptorModel descriptor)

--- a/test/Stella.Ergosfare.Command.Test/GeneratedDescriptorCatalogTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedDescriptorCatalogTests.cs
@@ -1,0 +1,98 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// The compile-time descriptor catalog behind runtime registration: a manual
+/// <c>Register&lt;THandler&gt;()</c> for a catalogued type must serve the precomputed
+/// descriptor instance (reference-equal — proof the reflective builders never ran),
+/// dispatch through it normally, and stay idempotent against the generated
+/// <c>RegisterDescriptors</c> path. Helper types are excluded from discovery so assembly
+/// scans cannot register them first.
+/// </summary>
+public class GeneratedDescriptorCatalogTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class CatalogProbeCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class CatalogProbeCommandHandler : ICommandHandler<CatalogProbeCommand>
+    {
+        public ValueTask HandleAsync(CatalogProbeCommand command, IExecutionContext context)
+        {
+            context.Set("catalogRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task CatalogedType_RegistersWithThePrecomputedDescriptor_AndDispatches()
+    {
+        // Exactly what a generated module initializer contributes.
+        var descriptor = HandlerDescriptors.Handler(
+            typeof(CatalogProbeCommand), typeof(ValueTask), typeof(CatalogProbeCommandHandler));
+        GeneratedDescriptorCatalog.Add(
+            typeof(CatalogProbeCommandHandler), () => new[] { (IHandlerDescriptor)descriptor });
+
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<CatalogProbeCommandHandler>()))
+            .BuildServiceProvider();
+
+        // The registry must carry the catalog's very instance — reference equality is the
+        // proof the reflective descriptor builders never ran for this type.
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+        var message = registry.Single(m => m.MessageType == typeof(CatalogProbeCommand));
+        Assert.Contains(message.Handlers, h => ReferenceEquals(h, descriptor));
+
+        // And the pipeline built from it dispatches normally.
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings();
+        await mediator.SendAsync(new CatalogProbeCommand(), settings);
+        Assert.Equal(true, settings.Items["catalogRan"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class DualPathCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class DualPathCommandHandler : ICommandHandler<DualPathCommand>
+    {
+        public ValueTask HandleAsync(DualPathCommand command, IExecutionContext context)
+            => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task CatalogRegistration_StaysIdempotent_AgainstRegisterDescriptors()
+    {
+        var descriptor = HandlerDescriptors.Handler(
+            typeof(DualPathCommand), typeof(ValueTask), typeof(DualPathCommandHandler));
+        GeneratedDescriptorCatalog.Add(
+            typeof(DualPathCommandHandler), () => new[] { (IHandlerDescriptor)descriptor });
+
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<DualPathCommandHandler>()))
+            .BuildServiceProvider();
+
+        var registry = provider.GetRequiredService<IMessageRegistry>();
+
+        // The generated-registration path following a catalog-backed manual registration
+        // must be a no-op: both paths mark the handler type processed.
+        registry.RegisterDescriptors([
+            HandlerDescriptors.Handler(typeof(DualPathCommand), typeof(ValueTask), typeof(DualPathCommandHandler))
+        ]);
+
+        var message = registry.Single(m => m.MessageType == typeof(DualPathCommand));
+        Assert.Single(message.Handlers);
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/DescriptorCatalogEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/DescriptorCatalogEmissionTests.cs
@@ -1,0 +1,40 @@
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+/// The descriptor-catalog module initializer: every modeled handler type contributes its
+/// compile-time descriptor factory, plain messages contribute nothing, and the emitted
+/// initializer compiles — from then on a manual <c>Register&lt;THandler&gt;()</c> in the
+/// compilation registers without reflection.
+/// </summary>
+public class DescriptorCatalogEmissionTests
+{
+    [Fact]
+    public void HandlerTypes_ContributeTheirDescriptorFactories()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record CatalogPing : ICommand;
+
+                public sealed class CatalogPingHandler : ICommandHandler<CatalogPing>
+                {
+                    public ValueTask HandleAsync(CatalogPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains("[global::System.Runtime.CompilerServices.ModuleInitializer]", result.GeneratedSource);
+        Assert.Contains(
+            "GeneratedDescriptorCatalog.Add(typeof(global::TestApp.CatalogPingHandler), static () =>",
+            result.GeneratedSource);
+
+        // The message type itself carries no handler contracts — no catalog entry.
+        Assert.DoesNotContain("GeneratedDescriptorCatalog.Add(typeof(global::TestApp.CatalogPing),", result.GeneratedSource);
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/ErgosfareRegistrationGeneratorTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/ErgosfareRegistrationGeneratorTests.cs
@@ -65,11 +65,13 @@ public class ErgosfareRegistrationGeneratorTests
         Assert.Equal(1, CountOccurrences(source, "builder.Register(typeof(global::TestApp.PingCreated));"));
 
         // The handler registers through a pre-computed descriptor: once in the assembly-wide
-        // factory and once in its module's factory — never through the runtime fallback.
+        // factory, once in its module's factory, and once in the descriptor-catalog module
+        // initializer (which backs manual Register<T>() calls) — never through the runtime
+        // fallback.
         const string handlerDescriptor =
             "global::Stella.Ergosfare.Core.Abstractions.Registry.Descriptors.HandlerDescriptors.Handler(" +
             "typeof(global::TestApp.CreatePing), typeof(global::System.Threading.Tasks.ValueTask), typeof(global::TestApp.CreatePingHandler))";
-        Assert.Equal(2, CountOccurrences(source, handlerDescriptor));
+        Assert.Equal(3, CountOccurrences(source, handlerDescriptor));
         Assert.DoesNotContain("Register(typeof(global::TestApp.CreatePingHandler))", source);
     }
 


### PR DESCRIPTION
The generator now emits a `[ModuleInitializer]` that hands `GeneratedDescriptorCatalog` one compile-time descriptor factory per modeled handler type. `MessageRegistry.Register(Type)` — the path behind every manual `Register<THandler>()` — consults the catalog before the reflection-based descriptor builders, which remain the fallback for types no generator saw (runtime-loaded plugin assemblies, manually registered open generics, foreign assemblies without the analyzer).

Key properties:

- **Manual-registration users benefit without calling `RegisterGenerated()`** — the module initializer populates the lookup on assembly load, so `AddCommandModule(c => c.Register<MyHandler>())` registers reflection-free wherever the generator ran. This was the point of the feature: gradually retiring reflection from the registration path.
- **Purely a lookup contribution.** Nothing registers at module load; initialization order, discovery-key gating and both idempotence contracts (`_processedTypes` on `Register`, handler-type dedupe on `RegisterDescriptors`) are untouched. The runtime test proves the registry serves the catalog's very descriptor instance (reference equality — the reflective builders provably never ran) and that a subsequent `RegisterDescriptors` for the same handler stays a no-op.
- **Interchangeability rests on the pinned parity contract:** the generator's descriptor computation mirrors the runtime builders exactly (existing generator test suite), so catalog-vs-reflective is a pure implementation detail.
- **Degrades against older packages:** emission is availability-probed on the catalog type; without it the generated output is unchanged.

Also updates `ModuleMembership_TypesAppearInTheirModulesRegistrationOnly` — a handler's descriptor expression now legitimately appears three times (assembly-wide factory, module factory, catalog initializer).

Verification: full build 0 warnings; full suite green on net9.0 + net10.0 (+3 new tests). Independent of #113 — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)