### PR TITLE
perf: static interceptor invocation strategies

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/ExceptionInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/ExceptionInterceptorInvocationStrategy.cs
@@ -19,20 +19,25 @@ namespace Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 /// The pipeline's result type — <see cref="ValueTask"/> for void pipelines, where the
 /// completed-task box stands in as the (meaningless) result object.
 /// </typeparam>
-internal sealed class ExceptionInterceptorInvocationStrategy<TMessage, TResult>(
-    IMessageDependencies messageDependencies,
-    IServiceProvider serviceProvider)
+/// <remarks>
+/// Static: the pipeline state travels as arguments, so a dispatch allocates no invoker object.
+/// </remarks>
+internal static class ExceptionInterceptorInvocationStrategy<TMessage, TResult>
     where TMessage : notnull
 {
     /// <summary>
     /// Executes all exception interceptors for the specified message, result, and exception.
     /// </summary>
+    /// <param name="messageDependencies">The message's pipeline composition, supplying the exception-interceptor list.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; interceptors resolve from it.</param>
     /// <param name="message">The message whose processing threw.</param>
     /// <param name="result">The result produced by the pipeline so far, if any.</param>
     /// <param name="exceptionDispatchInfo">The captured exception; rethrown when no interceptor is registered.</param>
     /// <param name="executionContext">The execution context for the current pipeline invocation.</param>
     /// <returns>The (possibly replaced) result after all exception interceptors have executed.</returns>
-    public async ValueTask<object?> Invoke(
+    public static async ValueTask<object?> Invoke(
+        IMessageDependencies messageDependencies,
+        IServiceProvider serviceProvider,
         TMessage message,
         object? result,
         ExceptionDispatchInfo exceptionDispatchInfo,

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategy.cs
@@ -17,19 +17,28 @@ namespace Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 /// The pipeline's result type — <see cref="ValueTask"/> for void pipelines, where the
 /// completed-task box stands in as the (meaningless) result object.
 /// </typeparam>
-internal sealed class FinalInterceptorInvocationStrategy<TMessage, TResult>(
-    IMessageDependencies messageDependencies,
-    IServiceProvider serviceProvider)
+/// <remarks>
+/// Static: the pipeline state travels as arguments, so a dispatch allocates no invoker object.
+/// </remarks>
+internal static class FinalInterceptorInvocationStrategy<TMessage, TResult>
     where TMessage : notnull
 {
     /// <summary>
     /// Executes all final interceptors for the specified message, result, and exception.
     /// </summary>
+    /// <param name="messageDependencies">The message's pipeline composition, supplying the final-interceptor list.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; interceptors resolve from it.</param>
     /// <param name="message">The message that was processed.</param>
     /// <param name="result">The final result, if any.</param>
     /// <param name="exception">The exception that terminated the pipeline, if any.</param>
     /// <param name="executionContext">The execution context for the current pipeline invocation.</param>
-    public async ValueTask Invoke(TMessage message, object? result, Exception? exception, IExecutionContext executionContext)
+    public static async ValueTask Invoke(
+        IMessageDependencies messageDependencies,
+        IServiceProvider serviceProvider,
+        TMessage message,
+        object? result,
+        Exception? exception,
+        IExecutionContext executionContext)
     {
         var interceptors = messageDependencies.FinalInterceptors;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PostInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PostInterceptorInvocationStrategy.cs
@@ -17,21 +17,30 @@ namespace Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 /// The pipeline's result type — <see cref="ValueTask"/> for void pipelines, where the
 /// completed-task box stands in as the (meaningless) result object.
 /// </typeparam>
+/// <remarks>
+/// Static: the pipeline state travels as arguments, so a dispatch allocates no invoker object.
+/// </remarks>
 #pragma warning disable CS8714 // TResult is used as a pattern type argument; interceptor contracts declare notnull results
-internal sealed class PostInterceptorInvocationStrategy<TMessage, TResult>(
-    IMessageDependencies messageDependencies,
-    IResultAdapterService? resultAdapterService,
-    IServiceProvider serviceProvider)
+internal static class PostInterceptorInvocationStrategy<TMessage, TResult>
     where TMessage : notnull
 {
     /// <summary>
     /// Executes all post-interceptors for the specified message and result.
     /// </summary>
+    /// <param name="messageDependencies">The message's pipeline composition, supplying the post-interceptor list.</param>
+    /// <param name="resultAdapterService">Adapters that surface a failure carried inside an interceptor's result, if configured.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; interceptors resolve from it.</param>
     /// <param name="message">The message that was handled.</param>
     /// <param name="result">The result produced by the pipeline so far.</param>
     /// <param name="context">The execution context for the current pipeline invocation.</param>
     /// <returns>The (possibly replaced) result after all post-interceptors have executed.</returns>
-    public async ValueTask<object?> Invoke(TMessage message, object? result, IExecutionContext context)
+    public static async ValueTask<object?> Invoke(
+        IMessageDependencies messageDependencies,
+        IResultAdapterService? resultAdapterService,
+        IServiceProvider serviceProvider,
+        TMessage message,
+        object? result,
+        IExecutionContext context)
     {
         var interceptors = messageDependencies.PostInterceptors;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PreInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/PreInterceptorInvocationStrategy.cs
@@ -9,16 +9,17 @@ namespace Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 /// <see cref="IAsyncPreInterceptor{TMessage}"/>, synchronous ones via
 /// <see cref="IPreInterceptor{TMessage}"/>. There is no object-typed bridge and no boxed
 /// awaitable: `in TMessage` variance admits interceptors registered for base message types.
+/// Static: the pipeline state travels as arguments, so a dispatch allocates no invoker object.
 /// </summary>
 /// <typeparam name="TMessage">The dispatch message type (the runtime type on executor paths).</typeparam>
-internal sealed class PreInterceptorInvocationStrategy<TMessage>(
-    IMessageDependencies messageDependencies,
-    IServiceProvider serviceProvider)
+internal static class PreInterceptorInvocationStrategy<TMessage>
     where TMessage : notnull
 {
     /// <summary>
     /// Executes all pre-interceptors for the specified message.
     /// </summary>
+    /// <param name="messageDependencies">The message's pipeline composition, supplying the pre-interceptor list.</param>
+    /// <param name="serviceProvider">The provider of the scope this dispatch runs in; interceptors resolve from it.</param>
     /// <param name="message">The message being processed.</param>
     /// <param name="executionContext">The execution context for the current pipeline invocation.</param>
     /// <returns>
@@ -26,7 +27,11 @@ internal sealed class PreInterceptorInvocationStrategy<TMessage>(
     /// the message as <see cref="object"/>; each subsequent interceptor receives it cast back
     /// to <typeparamref name="TMessage"/>.
     /// </returns>
-    public async ValueTask<object> Invoke(TMessage message, IExecutionContext executionContext)
+    public static async ValueTask<object> Invoke(
+        IMessageDependencies messageDependencies,
+        IServiceProvider serviceProvider,
+        TMessage message,
+        IExecutionContext executionContext)
     {
         var interceptors = messageDependencies.PreInterceptors;
         object current = message;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -95,8 +95,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
         {
             if (preInterceptorCount > 0)
             {
-                var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-                message = (TMessage) await preInvoker.Invoke(message, context);
+                message = (TMessage) await PreInterceptorInvocationStrategy<TMessage>.Invoke(
+                    messageDependencies, serviceProvider, message, context);
             }
 
             var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
@@ -109,9 +109,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
 
             if (postInterceptorCount > 0)
             {
-                var postInvoker = new PostInterceptorInvocationStrategy<TMessage, TResult>(messageDependencies, resultAdapterService, serviceProvider);
-
-                var postResult = (TResult?)await postInvoker.Invoke(message, result, context);
+                var postResult = (TResult?) await PostInterceptorInvocationStrategy<TMessage, TResult>.Invoke(
+                    messageDependencies, resultAdapterService, serviceProvider, message, result, context);
                 result = postResult is null ? result : postResult;
             }
         }
@@ -128,12 +127,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
                 throw;
             }
 
-            var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, TResult>(messageDependencies, serviceProvider);
-            var exceptionResult  = (TResult?)await exceptionInvoker.Invoke(
-                message,
-                result,
-                ExceptionDispatchInfo.Capture(exception),
-                context);
+            var exceptionResult = (TResult?) await ExceptionInterceptorInvocationStrategy<TMessage, TResult>.Invoke(
+                messageDependencies, serviceProvider, message, result, ExceptionDispatchInfo.Capture(exception), context);
 
             result = exceptionResult is null ? result : exceptionResult;
 
@@ -142,8 +137,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
         {
             if (finalInterceptorCount > 0)
             {
-                var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, TResult>(messageDependencies, serviceProvider);
-                await finalInvoker.Invoke(message, result, exception, context);
+                await FinalInterceptorInvocationStrategy<TMessage, TResult>.Invoke(
+                    messageDependencies, serviceProvider, message, result, exception, context);
             }
         }
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -94,8 +94,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
         {
             if (preInterceptorCount > 0)
             {
-                var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-                message = (TMessage) await preInvoker.Invoke(message, context);
+                message = (TMessage) await PreInterceptorInvocationStrategy<TMessage>.Invoke(
+                    messageDependencies, serviceProvider, message, context);
             }
 
             var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
@@ -112,8 +112,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
 
             if (postInterceptorCount > 0)
             {
-                var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, resultAdapterService, serviceProvider);
-                var invokedPostResult =  (ValueTask?) await postInvoker.Invoke(message, result, context);
+                var invokedPostResult = (ValueTask?) await PostInterceptorInvocationStrategy<TMessage, ValueTask>.Invoke(
+                    messageDependencies, resultAdapterService, serviceProvider, message, result, context);
                 result = invokedPostResult ?? result;
             }
         }
@@ -126,9 +126,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
                 throw;
             }
 
-            var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-            var invokedResult = (ValueTask?) await exceptionInvoker.Invoke(message, result, ExceptionDispatchInfo.Capture(e),
-                context);
+            var invokedResult = (ValueTask?) await ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>.Invoke(
+                messageDependencies, serviceProvider, message, result, ExceptionDispatchInfo.Capture(e), context);
             result = invokedResult ?? result;
 
         }
@@ -136,8 +135,8 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
         {
             if (finalInterceptorCount > 0)
             {
-                var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-                await finalInvoker.Invoke(message, result, exception, context);
+                await FinalInterceptorInvocationStrategy<TMessage, ValueTask>.Invoke(
+                    messageDependencies, serviceProvider, message, result, exception, context);
             }
         }
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
@@ -63,8 +63,8 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
         try
         {
             // run pre interceptors
-            var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-            message =  (TMessage)await preInvoker.Invoke(message, context) ;
+            message = (TMessage) await PreInterceptorInvocationStrategy<TMessage>.Invoke(
+                messageDependencies, serviceProvider, message, context);
 
 
             // Typed dispatch only — no object bridge. `in TMessage` variance admits handlers
@@ -130,9 +130,9 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
         {
             if (_unknownException is null)
             {
-                var postInvoker = new PostInterceptorInvocationStrategy<TMessage, IAsyncEnumerator<TResult>>(messageDependencies, resultAdapterService, serviceProvider);
                 // we can't override result since its chunked
-                await postInvoker.Invoke(message, enumerator, context).ConfigureAwait(false);
+                await PostInterceptorInvocationStrategy<TMessage, IAsyncEnumerator<TResult>>.Invoke(
+                    messageDependencies, resultAdapterService, serviceProvider, message, enumerator, context).ConfigureAwait(false);
             }
         }
         catch (ExecutionAbortedException)
@@ -145,13 +145,10 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
         {
             if (_unknownException is not null)
             {
-                var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, IAsyncEnumerator<TResult>>(messageDependencies, serviceProvider);
                 // we can't override result since its chunked
-                await exceptionInvoker.Invoke(
-                    message,
-                    enumerator,
-                    ExceptionDispatchInfo.Capture(_unknownException),
-                    context).ConfigureAwait(false);
+                await ExceptionInterceptorInvocationStrategy<TMessage, IAsyncEnumerator<TResult>>.Invoke(
+                    messageDependencies, serviceProvider, message, enumerator,
+                    ExceptionDispatchInfo.Capture(_unknownException), context).ConfigureAwait(false);
             }
         }
         catch (Exception e) when (e is not ExecutionAbortedException)
@@ -160,8 +157,8 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
         }
         finally
         {
-            var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, IAsyncEnumerator<TResult>>(messageDependencies, serviceProvider);
-            await finalInvoker.Invoke(message, enumerator, _unknownException, context);
+            await FinalInterceptorInvocationStrategy<TMessage, IAsyncEnumerator<TResult>>.Invoke(
+                messageDependencies, serviceProvider, message, enumerator, _unknownException, context);
         }
     }
     

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -70,17 +70,16 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         Exception? exception = null;
         try
         {
-            // Empty stages are skipped before any invoker object exists — an invoker over an
-            // empty stage is a no-op, so the guards change allocations, not behavior.
+            // Empty stages are skipped outright — an invoker pass over an empty stage is a
+            // no-op, so the guards only cut dead work, not behavior.
             if (messageDependencies.PreInterceptors.Count > 0)
             {
-                // events doesn't need result adapter, since events intended to not return a result
-                var preInvoker = new PreInterceptorInvocationStrategy<TMessage>(messageDependencies, serviceProvider);
-
                 // Pre-interceptors may transform the event — including returning a brand new
                 // instance — so the broadcast continues with the returned message, exactly as
-                // the single-handler strategies do.
-                message = (TMessage) await preInvoker.Invoke(message, context);
+                // the single-handler strategies do. Events don't need a result adapter, since
+                // events aren't intended to return a result.
+                message = (TMessage) await PreInterceptorInvocationStrategy<TMessage>.Invoke(
+                    messageDependencies, serviceProvider, message, context);
             }
 
             if (handlers.Count > 0)
@@ -97,8 +96,8 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
             {
                 // A ValueTask may be awaited only once — the completed ValueTask stands in as the
                 // (meaningless for events) result object flowing through the interceptor stages.
-                var postInvoker = new PostInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, null, serviceProvider);
-                await postInvoker.Invoke(message, CompletedResultBox.Instance, context);
+                await PostInterceptorInvocationStrategy<TMessage, ValueTask>.Invoke(
+                    messageDependencies, null, serviceProvider, message, CompletedResultBox.Instance, context);
             }
         }
         catch (Exception e)
@@ -106,15 +105,15 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
             exception = e;
 
             // Zero exception interceptors: rethrow directly — identical to the invoker's own
-            // empty-stage behavior (it rethrows via ExceptionDispatchInfo), minus the
-            // allocations. Final interceptors still run from the finally block.
+            // empty-stage behavior (it rethrows via ExceptionDispatchInfo), minus the capture.
+            // Final interceptors still run from the finally block.
             if (messageDependencies.ExceptionInterceptors.Count == 0)
             {
                 throw;
             }
 
-            var exceptionInvoker = new ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-            await exceptionInvoker.Invoke(message, CompletedResultBox.Instance,
+            await ExceptionInterceptorInvocationStrategy<TMessage, ValueTask>.Invoke(
+                messageDependencies, serviceProvider, message, CompletedResultBox.Instance,
                 ExceptionDispatchInfo.Capture(e), context);
 
         }
@@ -123,8 +122,8 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
         {
             if (messageDependencies.FinalInterceptors.Count > 0)
             {
-                var finalInvoker = new FinalInterceptorInvocationStrategy<TMessage, ValueTask>(messageDependencies, serviceProvider);
-                await finalInvoker.Invoke(message, CompletedResultBox.Instance, exception, context);
+                await FinalInterceptorInvocationStrategy<TMessage, ValueTask>.Invoke(
+                    messageDependencies, serviceProvider, message, CompletedResultBox.Instance, exception, context);
             }
         }
     }

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -21,7 +21,8 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        BenchmarkRunner.Run<MediationBenchmark>();
+        // Args flow through so filtered runs work, e.g. `-- --filter *Intercepted`.
+        BenchmarkRunner.Run<MediationBenchmark>(args: args);
     }
 }
 
@@ -79,6 +80,49 @@ public sealed class FirstGroupedPingEventHandler : IEventHandler<GroupedPingEven
 public sealed class SecondGroupedPingEventHandler : IEventHandler<GroupedPingEvent>
 {
     public ValueTask HandleAsync(GroupedPingEvent @event, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+// Intercepted variants on their own message types: one pass-through pre- and one
+// pass-through post-interceptor each, so these rows measure the interceptor-bearing
+// strategy path — the staged-plans epic baseline — without disturbing the default
+// rows' interceptor-free fast lanes (interceptors bind to their message type only).
+
+public sealed class InterceptedCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+
+public sealed class InterceptedCommandHandler : ICommandHandler<InterceptedCommand>
+{
+    public ValueTask HandleAsync(InterceptedCommand command, IExecutionContext context) => ValueTask.CompletedTask;
+}
+
+public sealed class InterceptedCommandPreInterceptor : ICommandPreInterceptor<InterceptedCommand>
+{
+    public ValueTask<InterceptedCommand> HandleAsync(InterceptedCommand command, IExecutionContext context)
+        => ValueTask.FromResult(command);
+}
+
+public sealed class InterceptedCommandPostInterceptor : ICommandPostInterceptor<InterceptedCommand>
+{
+    public ValueTask<object> HandleAsync(InterceptedCommand command, object messageResult, IExecutionContext context)
+        => ValueTask.FromResult(messageResult);
+}
+
+public sealed class InterceptedIntQuery : IQuery<int> { }
+
+public sealed class InterceptedIntQueryHandler : IQueryHandler<InterceptedIntQuery, int>
+{
+    public ValueTask<int> HandleAsync(InterceptedIntQuery query, IExecutionContext context) => ValueTask.FromResult(7);
+}
+
+public sealed class InterceptedIntQueryPreInterceptor : IQueryPreInterceptor<InterceptedIntQuery>
+{
+    public ValueTask<InterceptedIntQuery> HandleAsync(InterceptedIntQuery query, IExecutionContext context)
+        => ValueTask.FromResult(query);
+}
+
+public sealed class InterceptedIntQueryPostInterceptor : IQueryPostInterceptor<InterceptedIntQuery, int>
+{
+    public ValueTask<int> HandleAsync(InterceptedIntQuery query, int queryResult, IExecutionContext context)
+        => ValueTask.FromResult(queryResult);
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +232,8 @@ public class MediationBenchmark
     private readonly PingEvent _pingEvent = new();
     private readonly GroupedCommand _groupedCommand = new();
     private readonly GroupedPingEvent _groupedPingEvent = new();
+    private readonly InterceptedCommand _interceptedCommand = new();
+    private readonly InterceptedIntQuery _interceptedIntQuery = new();
 
     private static readonly string[] BenchGroups = ["bench"];
     private static readonly GroupSet BenchGroupSet = GroupSet.Of("bench");
@@ -213,8 +259,17 @@ public class MediationBenchmark
                 {
                     commands.Register<VoidCommandHandler>();
                     commands.Register<GroupedCommandHandler>();
+                    commands.Register<InterceptedCommandHandler>();
+                    commands.Register<InterceptedCommandPreInterceptor>();
+                    commands.Register<InterceptedCommandPostInterceptor>();
                 });
-                options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
+                options.AddQueryModule(queries =>
+                {
+                    queries.Register<IntQueryHandler>();
+                    queries.Register<InterceptedIntQueryHandler>();
+                    queries.Register<InterceptedIntQueryPreInterceptor>();
+                    queries.Register<InterceptedIntQueryPostInterceptor>();
+                });
                 options.AddEventModule(events =>
                 {
                     events.Register<FirstPingEventHandler>();
@@ -329,8 +384,19 @@ public class MediationBenchmark
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Command_Void_Memoized() => _memoizedCommands.SendAsync(_voidCommand);
 
+    /// <summary>
+    /// The interceptor-bearing strategy path (one pass-through pre- and post-interceptor):
+    /// the baseline the staged-plans epic optimizes. Every dispatch that can't take a fast
+    /// lane pays this shape.
+    /// </summary>
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Intercepted() => _commands.SendAsync(_interceptedCommand);
+
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> Query_Result_Intercepted() => _queries.QueryAsync(_interceptedIntQuery);
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result_Generated() => _generatedQueries.QueryAsync(_intQuery);


### PR DESCRIPTION
## What

- The four interceptor invokers (`Pre/Post/Exception/Final InterceptorInvocationStrategy`) become **static classes** — pipeline state (`messageDependencies`, `serviceProvider`, `resultAdapterService` where applicable) travels as `Invoke` arguments, so an intercepted dispatch no longer allocates an invoker object per populated stage. All four call sites updated (void, result, stream, broadcast). The types are `internal`; no public API impact, behavior identical.
- Benchmark gains the **staged-plans epic baseline rows**: `Command_Void_Intercepted` / `Query_Result_Intercepted` — one pass-through pre + post interceptor on their own message types, so the default rows' interceptor-free fast lanes stay untouched. `Main` now forwards `args` to BenchmarkDotNet, so `-- --filter` works for partial re-runs.

## Measurements (.NET 9, Root category)

| Row | Mean | Allocated |
|---|---|---:|
| Engine_Void (baseline) | 33.0 ns | 24 B |
| Command_Void | 32.5 ns | 24 B |
| **Command_Void_Intercepted** | **195.6 ns** | **104 B** |
| Query_Result | 37.5 ns | 24 B |
| **Query_Result_Intercepted** | **189.7 ns** | **144 B** |

Allocation ground truth outside BDN (plain await loop, 1M dispatches, `GC.GetAllocatedBytesForCurrentThread`): intercepted void dispatch **176 B → 104 B**; the removed 72 B is exactly the pre (32 B) + post (40 B) invoker objects. The remaining 104 B = three transient instances (handler + 2 interceptors, 72 B) + the `ValueTask?` box (32 B) — targets of the later epic PRs.

**Honest note:** BDN's own table shows no before/after allocation delta — in the JIT state BDN's harness reaches, the old code's invoker allocations were already elided (even with `DOTNET_JitObjectStackAllocation=0`). In a realistic plain await loop the difference is real and stable. The win is structural: guaranteed zero at every tier, on NativeAOT, and a clean static substrate for the staged-executor PRs (C/D).

## Verification

- Build: 0 warnings. Tests: green on both TFMs (net9.0 / net10.0), all suites.
- Interceptor-free rows stayed at 24 B — fast lanes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
