### PR TITLE
perf: provider-taking plan factories (generated activation)

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
@@ -75,6 +75,23 @@ public static class GeneratedDispatchRoots
         where THandler : class, IAsyncHandler<TMessage>
         => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>(directHandlerFactory));
 
+    /// <summary>
+    /// Variant of <see cref="AddVoidPlan{TMessage, THandler}()"/> carrying a compile-time
+    /// construction path for handlers with constructor dependencies: the generator emits
+    /// <c>static provider =&gt; new THandler(provider.GetRequiredService&lt;TDep&gt;(), ...)</c>
+    /// for handlers whose single public constructor takes only plain (or
+    /// <c>[FromKeyedServices]</c>) service parameters — the one shape where the container's
+    /// own constructor selection and the emitted construction provably coincide. The same
+    /// advisory contract applies: the executor uses the factory only after verifying the
+    /// handler's DI registration is the module's own plain transient one, and the
+    /// dependencies resolve from the dispatching scope's provider exactly as container
+    /// activation would resolve them. Idempotent.
+    /// </summary>
+    public static void AddVoidPlan<TMessage, THandler>(Func<IServiceProvider, THandler> directHandlerFactory)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage>
+        => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>(directHandlerFactory));
+
     /// <summary>The void pipeline plan of the message type, or <c>null</c> when none was generated.</summary>
     public static VoidPlanRoot? FindVoidPlan(Type messageType)
         => VoidPlans.TryGetValue(messageType, out var root) ? root : null;
@@ -98,6 +115,17 @@ public static class GeneratedDispatchRoots
     /// Idempotent.
     /// </summary>
     public static void AddResultPlan<TMessage, TResult, THandler>(Func<THandler> directHandlerFactory)
+        where TMessage : notnull, IMessage
+        where THandler : class, IAsyncHandler<TMessage, TResult>
+        => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>(directHandlerFactory));
+
+    /// <summary>
+    /// Variant of <see cref="AddResultPlan{TMessage, TResult, THandler}()"/> carrying the
+    /// compile-time construction path for handlers with constructor dependencies; see
+    /// <see cref="AddVoidPlan{TMessage, THandler}(Func{IServiceProvider, THandler})"/> for
+    /// the contract. Idempotent.
+    /// </summary>
+    public static void AddResultPlan<TMessage, TResult, THandler>(Func<IServiceProvider, THandler> directHandlerFactory)
         where TMessage : notnull, IMessage
         where THandler : class, IAsyncHandler<TMessage, TResult>
         => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>(directHandlerFactory));
@@ -170,9 +198,10 @@ public abstract class VoidPlanRoot
     public abstract TReturn Accept<TReturn, TState>(IVoidPlanRootVisitor<TReturn, TState> visitor, TState state);
 
     /// <summary>
-    /// The compile-time handler construction path — a <c>Func&lt;THandler&gt;</c> carried
-    /// erased, cast back inside the executor's closed generic context — or <c>null</c>
-    /// when the generator emitted no factory for the handler.
+    /// The compile-time handler construction path — a <c>Func&lt;THandler&gt;</c> or a
+    /// provider-taking <c>Func&lt;IServiceProvider, THandler&gt;</c>, carried erased and
+    /// cast back inside the executor's closed generic context — or <c>null</c> when the
+    /// generator emitted no factory for the handler.
     /// </summary>
     internal virtual object? DirectHandlerFactory => null;
 }
@@ -182,7 +211,7 @@ public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
-    private readonly Func<THandler>? _directHandlerFactory;
+    private readonly object? _directHandlerFactory;
 
     /// <summary>Creates a plan without a compile-time construction path.</summary>
     public VoidPlanRoot()
@@ -190,6 +219,9 @@ public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
     }
 
     internal VoidPlanRoot(Func<THandler> directHandlerFactory)
+        => _directHandlerFactory = directHandlerFactory;
+
+    internal VoidPlanRoot(Func<IServiceProvider, THandler> directHandlerFactory)
         => _directHandlerFactory = directHandlerFactory;
 
     internal override object? DirectHandlerFactory => _directHandlerFactory;
@@ -227,7 +259,7 @@ public sealed class ResultPlanRoot<TMessage, TResult, THandler> : ResultPlanRoot
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage, TResult>
 {
-    private readonly Func<THandler>? _directHandlerFactory;
+    private readonly object? _directHandlerFactory;
 
     /// <summary>Creates a plan without a compile-time construction path.</summary>
     public ResultPlanRoot()
@@ -235,6 +267,9 @@ public sealed class ResultPlanRoot<TMessage, TResult, THandler> : ResultPlanRoot
     }
 
     internal ResultPlanRoot(Func<THandler> directHandlerFactory)
+        => _directHandlerFactory = directHandlerFactory;
+
+    internal ResultPlanRoot(Func<IServiceProvider, THandler> directHandlerFactory)
         => _directHandlerFactory = directHandlerFactory;
 
     internal override object? DirectHandlerFactory => _directHandlerFactory;

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -179,7 +179,8 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     IMessageDependenciesFactory dependenciesFactory,
     IResultAdapterService? resultAdapterService,
     string[] groups,
-    Func<THandler>? directHandlerFactory = null) : IPipelineExecutor
+    Func<THandler>? directHandlerFactory = null,
+    Func<IServiceProvider, THandler>? providerHandlerFactory = null) : IPipelineExecutor
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
@@ -188,13 +189,16 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
-    // Compile-time construction path for the planned handler; discarded up front for
+    // Compile-time construction paths for the planned handler; discarded up front for
     // disposable handlers — the container tracks transient disposables in the resolving
-    // scope, direct construction would not.
-    private readonly Func<THandler>? _directHandlerFactory =
-        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler))
-            ? null
-            : directHandlerFactory;
+    // scope, direct construction would not. The provider-taking shape covers handlers
+    // with constructor dependencies: it resolves them from the dispatching scope's
+    // provider, exactly where container activation would resolve them.
+    private static readonly bool HandlerIsDisposable =
+        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler));
+
+    private readonly Func<THandler>? _directHandlerFactory = HandlerIsDisposable ? null : directHandlerFactory;
+    private readonly Func<IServiceProvider, THandler>? _providerHandlerFactory = HandlerIsDisposable ? null : providerHandlerFactory;
 
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
@@ -218,7 +222,7 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             // hand: a version transition observed halfway can only route back through the
             // container, never construct a type the registry no longer plans.
             IHandler handler = _useDirectConstruction && handlerReference.HandlerType == typeof(THandler)
-                ? _directHandlerFactory!()
+                ? _directHandlerFactory is not null ? _directHandlerFactory() : _providerHandlerFactory!(serviceProvider)
                 : handlerReference.Resolve(serviceProvider);
 
             // The compile-time plan's handler type: a devirtualized call, no pattern
@@ -260,7 +264,7 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             var fastDependencies = dependencies as MessageDependencies;
             _cachedFastDependencies = fastDependencies;
             _cachedDependencies = dependencies;
-            _useDirectConstruction = _directHandlerFactory is not null
+            _useDirectConstruction = (_directHandlerFactory is not null || _providerHandlerFactory is not null)
                 && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
                 && plannedType == typeof(THandler)
                 && typedFactory.IsPlainTransientRegistration(typeof(THandler));
@@ -287,7 +291,8 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
     IMessageDependenciesFactory dependenciesFactory,
     IResultAdapterService? resultAdapterService,
     string[] groups,
-    Func<THandler>? directHandlerFactory = null) : IPipelineExecutor<TResult>
+    Func<THandler>? directHandlerFactory = null,
+    Func<IServiceProvider, THandler>? providerHandlerFactory = null) : IPipelineExecutor<TResult>
     where TMessage : notnull, IMessage
     where THandler : class, IAsyncHandler<TMessage, TResult>
 {
@@ -296,10 +301,11 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
     private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
-    private readonly Func<THandler>? _directHandlerFactory =
-        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler))
-            ? null
-            : directHandlerFactory;
+    private static readonly bool HandlerIsDisposable =
+        typeof(IDisposable).IsAssignableFrom(typeof(THandler)) || typeof(IAsyncDisposable).IsAssignableFrom(typeof(THandler));
+
+    private readonly Func<THandler>? _directHandlerFactory = HandlerIsDisposable ? null : directHandlerFactory;
+    private readonly Func<IServiceProvider, THandler>? _providerHandlerFactory = HandlerIsDisposable ? null : providerHandlerFactory;
 
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
@@ -315,7 +321,7 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
             && (_concreteAdapters is null || _concreteAdapters.IsEmpty))
         {
             IHandler handler = _useDirectConstruction && handlerReference.HandlerType == typeof(THandler)
-                ? _directHandlerFactory!()
+                ? _directHandlerFactory is not null ? _directHandlerFactory() : _providerHandlerFactory!(serviceProvider)
                 : handlerReference.Resolve(serviceProvider);
 
             if (handler is THandler planned)
@@ -352,7 +358,7 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
             var fastDependencies = dependencies as MessageDependencies;
             _cachedFastDependencies = fastDependencies;
             _cachedDependencies = dependencies;
-            _useDirectConstruction = _directHandlerFactory is not null
+            _useDirectConstruction = (_directHandlerFactory is not null || _providerHandlerFactory is not null)
                 && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
                 && plannedType == typeof(THandler)
                 && typedFactory.IsPlainTransientRegistration(typeof(THandler));
@@ -751,8 +757,8 @@ internal sealed class PipelineExecutorCache(
     /// <summary>
     /// Constructor arguments carried into the generic re-entry of a dispatch root.
     /// <paramref name="DirectHandlerFactory"/> is a plan's erased <c>Func&lt;THandler&gt;</c>
-    /// (cast back inside the closed generic), or <c>null</c> for plain roots and plans
-    /// without a construction path.
+    /// or <c>Func&lt;IServiceProvider, THandler&gt;</c> (cast back inside the closed
+    /// generic), or <c>null</c> for plain roots and plans without a construction path.
     /// </summary>
     private readonly record struct ExecutorState(
         IMessageDescriptor Descriptor,
@@ -798,7 +804,8 @@ internal sealed class PipelineExecutorCache(
             where THandler : class, IAsyncHandler<TMessage>
             => new GeneratedVoidPipelineExecutor<TMessage, THandler>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
-                state.DirectHandlerFactory as Func<THandler>);
+                state.DirectHandlerFactory as Func<THandler>,
+                state.DirectHandlerFactory as Func<IServiceProvider, THandler>);
     }
 
     /// <summary>
@@ -815,7 +822,8 @@ internal sealed class PipelineExecutorCache(
             where THandler : class, IAsyncHandler<TMessage, TResult>
             => new GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
-                state.DirectHandlerFactory as Func<THandler>);
+                state.DirectHandlerFactory as Func<THandler>,
+                state.DirectHandlerFactory as Func<IServiceProvider, THandler>);
     }
 
     private IMessageDescriptor FindDescriptor(Type messageType)

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -65,6 +66,10 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private const string ValueTaskExpression = "global::System.Threading.Tasks.ValueTask";
     private const string DescriptorCatalogMetadataName = "Stella.Ergosfare.Core.Abstractions.GeneratedDescriptorCatalog";
 
+    private const string ServiceProviderExtensionsMetadataName = "Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions";
+    private const string KeyedServiceExtensionsMetadataName = "Microsoft.Extensions.DependencyInjection.ServiceProviderKeyedServiceExtensions";
+    private const string DependencyInjectionNamespace = "Microsoft.Extensions.DependencyInjection";
+
     private const string ScanReferencesBuildProperty = "build_property.ErgosfareSourceGeneratorScanReferences";
     private const string ErgosfareAssemblyNamePrefix = "Stella.Ergosfare";
 
@@ -109,6 +114,10 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 DispatchRootsHasVoidPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddVoidPlan").IsEmpty,
                 DispatchRootsHasResultPlans: dispatchRoots is not null && !dispatchRoots.GetMembers("AddResultPlan").IsEmpty,
                 DispatchRootsHasPlanFactories: dispatchRoots is not null && HasFactoryOverload(dispatchRoots),
+                DispatchRootsHasProviderPlanFactories: dispatchRoots is not null
+                    && HasProviderFactoryOverload(dispatchRoots)
+                    && compilation.GetTypeByMetadataName(ServiceProviderExtensionsMetadataName) is not null,
+                HasKeyedServiceExtensions: compilation.GetTypeByMetadataName(KeyedServiceExtensionsMetadataName) is not null,
                 HasDescriptorCatalog: compilation.GetTypeByMetadataName(DescriptorCatalogMetadataName) is not null);
         });
 
@@ -152,6 +161,28 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     }
 
     /// <summary>
+    ///     Whether the referenced <c>GeneratedDispatchRoots</c> accepts a plan overload
+    ///     with a provider-taking factory parameter
+    ///     (<c>Func&lt;IServiceProvider, THandler&gt;</c>) — the surface the
+    ///     dependency-injected construction emission requires. Recognized by delegate
+    ///     arity: the parameterless factory overload's <c>Func&lt;THandler&gt;</c> has one
+    ///     type argument, the provider-taking one has two.
+    /// </summary>
+    private static bool HasProviderFactoryOverload(INamedTypeSymbol dispatchRoots)
+    {
+        foreach (var member in dispatchRoots.GetMembers("AddVoidPlan"))
+        {
+            if (member is IMethodSymbol { Parameters.Length: 1 } method
+                && method.Parameters[0].Type is INamedTypeSymbol { Arity: 2 })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     ///     Whether generated code can construct the type with <c>new()</c> and doing so
     ///     is provably interchangeable with resolving its plain transient registration:
     ///     a concrete, non-generic class whose ONLY instance constructor is public and
@@ -162,6 +193,29 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     ///     transient disposables; direct construction would not).
     /// </summary>
     private static bool IsDirectlyConstructible(INamedTypeSymbol symbol)
+    {
+        if (!HasDirectConstructionShape(symbol))
+        {
+            return false;
+        }
+
+        // Exactly one instance constructor, public and parameterless: with any richer
+        // constructor present (records' synthesized copy constructor included), the
+        // container's selection and `new()` can diverge — dropping dependencies the
+        // container would have injected.
+        return symbol.InstanceConstructors.Length == 1
+               && symbol.InstanceConstructors[0] is { Parameters.IsEmpty: true, DeclaredAccessibility: Accessibility.Public };
+    }
+
+    /// <summary>
+    ///     Shared base qualification of both construction factories: a concrete,
+    ///     non-generic class implementing neither <c>IDisposable</c> nor
+    ///     <c>IAsyncDisposable</c> (the container tracks transient disposables in the
+    ///     resolving scope; direct construction would not), with no <c>required</c>
+    ///     members anywhere in the hierarchy (an emitted <c>new</c> fails compilation
+    ///     with CS9035, while the container activation the factory replaces ignores them).
+    /// </summary>
+    private static bool HasDirectConstructionShape(INamedTypeSymbol symbol)
     {
         if (symbol.TypeKind != TypeKind.Class || symbol.IsAbstract || symbol.IsGenericType)
         {
@@ -176,9 +230,6 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             }
         }
 
-        // Required members anywhere in the hierarchy make an emitted `new()` a compile
-        // error (CS9035); the reflection-based container activation the plan replaces
-        // does not enforce them, so such types stay on the container path.
         for (var type = symbol; type is not null; type = type.BaseType)
         {
             foreach (var member in type.GetMembers())
@@ -190,12 +241,222 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             }
         }
 
-        // Exactly one instance constructor, public and parameterless: with any richer
-        // constructor present (records' synthesized copy constructor included), the
-        // container's selection and `new()` can diverge — dropping dependencies the
-        // container would have injected.
-        return symbol.InstanceConstructors.Length == 1
-               && symbol.InstanceConstructors[0] is { Parameters.IsEmpty: true, DeclaredAccessibility: Accessibility.Public };
+        return true;
+    }
+
+    /// <summary>
+    ///     Builds the provider-taking construction factory
+    ///     (<c>static provider =&gt; new THandler(...)</c>) for a handler whose
+    ///     construction is provably identical to container activation, or <c>null</c>
+    ///     when the type does not qualify. The gate mirrors what
+    ///     <c>Microsoft.Extensions.DependencyInjection</c> would do with the type's plain
+    ///     transient registration: the container considers only public constructors, so a
+    ///     type with exactly one public constructor leaves it no choice; every parameter
+    ///     must be a plain service resolution (<c>GetRequiredService</c>) or a
+    ///     <c>[FromKeyedServices]</c> one (<c>GetRequiredKeyedService</c>) from the very
+    ///     provider container activation would resolve from. Anything that makes the
+    ///     container's behavior content-dependent disqualifies: optional/default-valued
+    ///     parameters (the container falls back to the default only when the service is
+    ///     unregistered), multiple public constructors (greedy selection), <c>ref</c>-ish
+    ///     or <c>params</c> parameters, <c>[ServiceKey]</c> injection, non-nameable
+    ///     parameter types, and keys the emission cannot reproduce exactly.
+    /// </summary>
+    private static string? GetProviderConstructionExpression(
+        INamedTypeSymbol symbol,
+        string handlerTypeExpression,
+        IAssemblySymbol? currentAssembly,
+        out bool usesKeyedServices)
+    {
+        usesKeyedServices = false;
+
+        if (!HasDirectConstructionShape(symbol))
+        {
+            return null;
+        }
+
+        IMethodSymbol? publicConstructor = null;
+
+        foreach (var constructor in symbol.InstanceConstructors)
+        {
+            if (constructor.DeclaredAccessibility != Accessibility.Public)
+            {
+                // Invisible to the container's constructor selection; irrelevant here too.
+                continue;
+            }
+
+            if (publicConstructor is not null)
+            {
+                return null;
+            }
+
+            publicConstructor = constructor;
+        }
+
+        // Parameterless construction stays on the cheaper Func<THandler> shape.
+        if (publicConstructor is null || publicConstructor.Parameters.IsEmpty)
+        {
+            return null;
+        }
+
+        var arguments = new List<string>(publicConstructor.Parameters.Length);
+
+        foreach (var parameter in publicConstructor.Parameters)
+        {
+            if (parameter.RefKind != RefKind.None || parameter.IsParams || parameter.IsOptional || parameter.HasExplicitDefaultValue)
+            {
+                return null;
+            }
+
+            string? keyLiteral = null;
+
+            foreach (var attribute in parameter.GetAttributes())
+            {
+                if (attribute.AttributeClass is not { } attributeClass
+                    || !IsDependencyInjectionNamespace(attributeClass.ContainingNamespace))
+                {
+                    continue;
+                }
+
+                switch (attributeClass.Name)
+                {
+                    case "FromKeyedServicesAttribute":
+                        keyLiteral = GetServiceKeyLiteral(attribute, currentAssembly);
+
+                        if (keyLiteral is null)
+                        {
+                            return null;
+                        }
+
+                        break;
+                    case "ServiceKeyAttribute":
+                        return null;
+                }
+            }
+
+            if (parameter.Type is not INamedTypeSymbol parameterType
+                || parameterType.IsRefLikeType
+                || parameterType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                || !IsNameableClosedType(parameterType, currentAssembly))
+            {
+                return null;
+            }
+
+            var typeExpression = parameterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+            arguments.Add(keyLiteral is null
+                ? "global::" + ServiceProviderExtensionsMetadataName + ".GetRequiredService<" + typeExpression + ">(provider)"
+                : "global::" + KeyedServiceExtensionsMetadataName + ".GetRequiredKeyedService<" + typeExpression + ">(provider, " + keyLiteral + ")");
+
+            usesKeyedServices |= keyLiteral is not null;
+        }
+
+        return "static provider => new " + handlerTypeExpression + "(" + string.Join(", ", arguments) + ")";
+    }
+
+    /// <summary>
+    ///     Whether generated code in the current compilation can name the closed type in
+    ///     a generic argument position: spellable names and public accessibility along the
+    ///     whole containing chain (internal accepted only for the current compilation's
+    ///     own types — referenced-assembly IVT grants are deliberately not modeled here),
+    ///     recursively for every generic type argument.
+    /// </summary>
+    private static bool IsNameableClosedType(INamedTypeSymbol type, IAssemblySymbol? currentAssembly)
+    {
+        if (type.IsUnboundGenericType || !HasSpellableName(type))
+        {
+            return false;
+        }
+
+        for (var current = type; current is not null; current = current.ContainingType)
+        {
+            switch (current.DeclaredAccessibility)
+            {
+                case Accessibility.Public:
+                    break;
+                case Accessibility.Internal:
+                case Accessibility.ProtectedOrInternal:
+                    if (currentAssembly is null
+                        || !SymbolEqualityComparer.Default.Equals(current.ContainingAssembly, currentAssembly))
+                    {
+                        return false;
+                    }
+
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        foreach (var argument in type.TypeArguments)
+        {
+            if (argument is not INamedTypeSymbol named || !IsNameableClosedType(named, currentAssembly))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsDependencyInjectionNamespace(INamespaceSymbol? ns)
+        => ns is
+        {
+            Name: "DependencyInjection",
+            ContainingNamespace:
+            {
+                Name: "Extensions",
+                ContainingNamespace: { Name: "Microsoft", ContainingNamespace.IsGlobalNamespace: true }
+            }
+        };
+
+    /// <summary>
+    ///     The C# literal reproducing a <c>[FromKeyedServices]</c> key exactly — the
+    ///     container matches keys by boxed equality, so the emitted constant must carry
+    ///     the same runtime type and value as the attribute's. Strings, chars, bools,
+    ///     integral primitives, enums and <c>typeof</c> keys are reproducible; anything
+    ///     else (null, floating-point, arrays) returns <c>null</c> and keeps the handler
+    ///     on the container path.
+    /// </summary>
+    private static string? GetServiceKeyLiteral(AttributeData attribute, IAssemblySymbol? currentAssembly)
+    {
+        if (attribute.ConstructorArguments.Length != 1)
+        {
+            return null;
+        }
+
+        var key = attribute.ConstructorArguments[0];
+
+        switch (key.Kind)
+        {
+            case TypedConstantKind.Primitive:
+                return key.Value switch
+                {
+                    string s => SymbolDisplay.FormatLiteral(s, quote: true),
+                    char c => SymbolDisplay.FormatLiteral(c, quote: true),
+                    bool b => b ? "true" : "false",
+                    int i => i.ToString(CultureInfo.InvariantCulture),
+                    long l => l.ToString(CultureInfo.InvariantCulture) + "L",
+                    sbyte v => "(sbyte)" + v.ToString(CultureInfo.InvariantCulture),
+                    byte v => "(byte)" + v.ToString(CultureInfo.InvariantCulture),
+                    short v => "(short)" + v.ToString(CultureInfo.InvariantCulture),
+                    ushort v => "(ushort)" + v.ToString(CultureInfo.InvariantCulture),
+                    uint v => v.ToString(CultureInfo.InvariantCulture) + "U",
+                    ulong v => v.ToString(CultureInfo.InvariantCulture) + "UL",
+                    _ => null,
+                };
+            case TypedConstantKind.Enum:
+                return key.Type is INamedTypeSymbol enumType && IsNameableClosedType(enumType, currentAssembly)
+                    ? "(" + enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ")("
+                      + Convert.ToString(key.Value, CultureInfo.InvariantCulture) + ")"
+                    : null;
+            case TypedConstantKind.Type:
+                return key.Value is INamedTypeSymbol { IsUnboundGenericType: false } keyType
+                       && IsNameableClosedType(keyType, currentAssembly)
+                    ? "typeof(" + keyType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + ")"
+                    : null;
+            default:
+                return null;
+        }
     }
 
     /// <summary>
@@ -232,10 +493,16 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         var isAccessible = IsAccessibleFromGeneratedCode(symbol);
         var descriptors = isAccessible ? BuildDescriptors(symbol) : ImmutableArray<DescriptorModel>.Empty;
         var isDispatchable = isAccessible && IsDispatchableMessage(symbol, descriptors);
+        var typeofExpression = BuildTypeofExpression(symbol);
+
+        var usesKeyedServices = false;
+        var providerConstruction = isAccessible
+            ? GetProviderConstructionExpression(symbol, typeofExpression, symbol.ContainingAssembly, out usesKeyedServices)
+            : null;
 
         return new RegistrableTypeModel
         {
-            TypeofExpression = BuildTypeofExpression(symbol),
+            TypeofExpression = typeofExpression,
             DisplayName = symbol.ToDisplayString(),
             IsCommand = isCommand,
             IsQuery = isQuery,
@@ -250,6 +517,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsDispatchableMessage = isDispatchable,
             DispatchResults = isDispatchable ? GetDispatchResults(symbol) : ImmutableArray<DispatchResultModel>.Empty,
             IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
+            ProviderConstructionExpression = providerConstruction,
+            ProviderConstructionUsesKeyedServices = usesKeyedServices,
         };
     }
 
@@ -604,10 +873,18 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         var isAccessible = IsVisibleToCompilation(symbol, givesAccess) && HasSpellableName(symbol);
         var descriptors = isAccessible ? BuildDescriptors(symbol) : ImmutableArray<DescriptorModel>.Empty;
         var isDispatchable = isAccessible && IsDispatchableMessage(symbol, descriptors);
+        var typeofExpression = BuildTypeofExpression(symbol);
+
+        // Referenced handlers get no current-assembly grant: their construction factory
+        // qualifies only over fully public parameter types (IVT grants are not modeled).
+        var usesKeyedServices = false;
+        var providerConstruction = isAccessible
+            ? GetProviderConstructionExpression(symbol, typeofExpression, currentAssembly: null, out usesKeyedServices)
+            : null;
 
         return new RegistrableTypeModel
         {
-            TypeofExpression = BuildTypeofExpression(symbol),
+            TypeofExpression = typeofExpression,
             DisplayName = symbol.ToDisplayString(),
             IsCommand = isCommand,
             IsQuery = isQuery,
@@ -622,6 +899,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsDispatchableMessage = isDispatchable,
             DispatchResults = isDispatchable ? GetDispatchResults(symbol) : ImmutableArray<DispatchResultModel>.Empty,
             IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
+            ProviderConstructionExpression = providerConstruction,
+            ProviderConstructionUsesKeyedServices = usesKeyedServices,
         };
     }
 
@@ -744,7 +1023,12 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 continue;
             }
 
-            plans.Add(new VoidPlanModel(type.TypeofExpression, handler.TypeofExpression, handler.IsDirectlyConstructible));
+            plans.Add(new VoidPlanModel(
+                type.TypeofExpression,
+                handler.TypeofExpression,
+                handler.IsDirectlyConstructible,
+                handler.ProviderConstructionExpression,
+                handler.ProviderConstructionUsesKeyedServices));
         }
 
         return plans;
@@ -797,7 +1081,9 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 type.TypeofExpression,
                 dispatchResult.ResultTypeExpression,
                 handler.TypeofExpression,
-                handler.IsDirectlyConstructible));
+                handler.IsDirectlyConstructible,
+                handler.ProviderConstructionExpression,
+                handler.ProviderConstructionUsesKeyedServices));
         }
 
         return plans;

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -24,6 +24,18 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     <c>Func&lt;THandler&gt;</c> overloads); older packages take only the parameterless
 ///     form, and emission degrades accordingly.
 /// </param>
+/// <param name="DispatchRootsHasProviderPlanFactories">
+///     Whether the plan surface accepts provider-taking construction factories (the
+///     <c>Func&lt;IServiceProvider, THandler&gt;</c> overloads) and the compilation can
+///     name <c>ServiceProviderServiceExtensions</c> the emitted factory resolves
+///     dependencies through; without either, dependency-injected handlers keep the
+///     factory-less plan form.
+/// </param>
+/// <param name="HasKeyedServiceExtensions">
+///     Whether <c>ServiceProviderKeyedServiceExtensions</c> is resolvable — required by
+///     factories for handlers with <c>[FromKeyedServices]</c> parameters; without it such
+///     handlers keep the factory-less plan form.
+/// </param>
 /// <param name="HasDescriptorCatalog">
 ///     Whether <c>GeneratedDescriptorCatalog</c> is resolvable — the lookup that makes
 ///     runtime <c>Register&lt;THandler&gt;()</c> reflection-free for generator-modeled
@@ -42,4 +54,6 @@ internal readonly record struct ModuleBuilderAvailability(
     bool DispatchRootsHasVoidPlans,
     bool DispatchRootsHasResultPlans,
     bool DispatchRootsHasPlanFactories,
+    bool DispatchRootsHasProviderPlanFactories,
+    bool HasKeyedServiceExtensions,
     bool HasDescriptorCatalog);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -102,6 +102,24 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
     /// </summary>
     public required bool IsDirectlyConstructible { get; init; }
 
+    /// <summary>
+    ///     The emitted provider-taking construction factory
+    ///     (<c>static provider =&gt; new THandler(provider.GetRequiredService&lt;TDep&gt;(), ...)</c>)
+    ///     for a handler whose single public constructor takes only plain (or
+    ///     <c>[FromKeyedServices]</c>) service parameters, or <c>null</c> when the type
+    ///     does not qualify. Mutually exclusive with
+    ///     <see cref="IsDirectlyConstructible"/> — parameterless construction stays on the
+    ///     cheaper <c>Func&lt;THandler&gt;</c> shape. Meaningful for handler types only.
+    /// </summary>
+    public required string? ProviderConstructionExpression { get; init; }
+
+    /// <summary>
+    ///     Whether <see cref="ProviderConstructionExpression"/> resolves any parameter
+    ///     through the keyed-service extensions; emission then additionally requires
+    ///     those extensions to be resolvable in the consuming compilation.
+    /// </summary>
+    public required bool ProviderConstructionUsesKeyedServices { get; init; }
+
     public bool Equals(RegistrableTypeModel other)
     {
         if (TypeofExpression != other.TypeofExpression
@@ -116,6 +134,8 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
             || ReferencedAssemblyName != other.ReferencedAssemblyName
             || IsDispatchableMessage != other.IsDispatchableMessage
             || IsDirectlyConstructible != other.IsDirectlyConstructible
+            || ProviderConstructionExpression != other.ProviderConstructionExpression
+            || ProviderConstructionUsesKeyedServices != other.ProviderConstructionUsesKeyedServices
             || Descriptors.Length != other.Descriptors.Length
             || DiscoveryKeys.Length != other.DiscoveryKeys.Length
             || DispatchResults.Length != other.DispatchResults.Length)

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
@@ -16,8 +16,18 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     Whether the handler qualifies for the plan's direct-construction factory; see
 ///     <see cref="RegistrableTypeModel.IsDirectlyConstructible"/>.
 /// </param>
+/// <param name="ProviderConstructionExpression">
+///     The provider-taking construction factory for a dependency-injected handler, or
+///     <c>null</c>; see <see cref="RegistrableTypeModel.ProviderConstructionExpression"/>.
+/// </param>
+/// <param name="UsesKeyedServices">
+///     Whether the provider factory needs the keyed-service extensions; see
+///     <see cref="RegistrableTypeModel.ProviderConstructionUsesKeyedServices"/>.
+/// </param>
 internal readonly record struct ResultPlanModel(
     string MessageTypeExpression,
     string ResultTypeExpression,
     string HandlerTypeExpression,
-    bool HasDirectConstruction);
+    bool HasDirectConstruction,
+    string? ProviderConstructionExpression,
+    bool UsesKeyedServices);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
@@ -15,7 +15,17 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     (<c>static () => new THandler()</c>); see
 ///     <see cref="RegistrableTypeModel.IsDirectlyConstructible"/>.
 /// </param>
+/// <param name="ProviderConstructionExpression">
+///     The provider-taking construction factory for a dependency-injected handler, or
+///     <c>null</c>; see <see cref="RegistrableTypeModel.ProviderConstructionExpression"/>.
+/// </param>
+/// <param name="UsesKeyedServices">
+///     Whether the provider factory needs the keyed-service extensions; see
+///     <see cref="RegistrableTypeModel.ProviderConstructionUsesKeyedServices"/>.
+/// </param>
 internal readonly record struct VoidPlanModel(
     string MessageTypeExpression,
     string HandlerTypeExpression,
-    bool HasDirectConstruction);
+    bool HasDirectConstruction,
+    string? ProviderConstructionExpression,
+    bool UsesKeyedServices);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -101,7 +101,9 @@ internal static class RegistrationEmitter
         if (emitDispatchRoots)
         {
             EmitDispatchRoots(sb, ref wroteMember, types, voidPlans, resultPlans,
-                builders.DispatchRootsHasPlanFactories);
+                builders.DispatchRootsHasPlanFactories,
+                builders.DispatchRootsHasProviderPlanFactories,
+                builders.HasKeyedServiceExtensions);
         }
 
         if (builders.HasDescriptorCatalog && useDescriptors && HasDescriptors(types))
@@ -253,7 +255,9 @@ internal static class RegistrationEmitter
         IReadOnlyList<RegistrableTypeModel> types,
         IReadOnlyList<VoidPlanModel> voidPlans,
         IReadOnlyList<ResultPlanModel> resultPlans,
-        bool emitPlanFactories)
+        bool emitPlanFactories,
+        bool emitProviderPlanFactories,
+        bool hasKeyedServiceExtensions)
     {
         StartMember(sb, ref wroteMember);
         sb.AppendLine("        private static void RootDispatchInstantiations()");
@@ -280,9 +284,10 @@ internal static class RegistrationEmitter
 
         // Compile-time pipeline plans: the runtime re-validates each one against the
         // registry per version, so a plan can only lose its speedup, never change
-        // behavior. Directly-constructible handlers additionally carry a construction
-        // factory, which the runtime uses only after verifying the handler's effective
-        // DI registration is the module's own plain transient one.
+        // behavior. Qualifying handlers additionally carry a construction factory —
+        // parameterless `new` or a provider-taking one for dependency-injected
+        // constructors — which the runtime uses only after verifying the handler's
+        // effective DI registration is the module's own plain transient one.
         foreach (var plan in voidPlans)
         {
             sb.Append("            ").Append(DispatchRootsFullName)
@@ -290,10 +295,9 @@ internal static class RegistrationEmitter
               .Append(", ").Append(plan.HandlerTypeExpression)
               .Append(">(");
 
-            if (emitPlanFactories && plan.HasDirectConstruction)
-            {
-                sb.Append("static () => new ").Append(plan.HandlerTypeExpression).Append("()");
-            }
+            AppendPlanFactory(sb, plan.HandlerTypeExpression, plan.HasDirectConstruction,
+                plan.ProviderConstructionExpression, plan.UsesKeyedServices,
+                emitPlanFactories, emitProviderPlanFactories, hasKeyedServiceExtensions);
 
             sb.AppendLine(");");
         }
@@ -306,15 +310,43 @@ internal static class RegistrationEmitter
               .Append(", ").Append(plan.HandlerTypeExpression)
               .Append(">(");
 
-            if (emitPlanFactories && plan.HasDirectConstruction)
-            {
-                sb.Append("static () => new ").Append(plan.HandlerTypeExpression).Append("()");
-            }
+            AppendPlanFactory(sb, plan.HandlerTypeExpression, plan.HasDirectConstruction,
+                plan.ProviderConstructionExpression, plan.UsesKeyedServices,
+                emitPlanFactories, emitProviderPlanFactories, hasKeyedServiceExtensions);
 
             sb.AppendLine(");");
         }
 
         sb.AppendLine("        }");
+    }
+
+    /// <summary>
+    ///     Appends a plan's construction-factory argument when one qualifies and the
+    ///     referenced surfaces support it: the parameterless <c>new</c> shape first (the
+    ///     cheaper one, and available against older packages), the provider-taking shape
+    ///     for dependency-injected constructors otherwise — keyed resolutions only when
+    ///     the keyed-service extensions are resolvable in the consuming compilation.
+    /// </summary>
+    private static void AppendPlanFactory(
+        StringBuilder sb,
+        string handlerTypeExpression,
+        bool hasDirectConstruction,
+        string? providerConstructionExpression,
+        bool usesKeyedServices,
+        bool emitPlanFactories,
+        bool emitProviderPlanFactories,
+        bool hasKeyedServiceExtensions)
+    {
+        if (emitPlanFactories && hasDirectConstruction)
+        {
+            sb.Append("static () => new ").Append(handlerTypeExpression).Append("()");
+        }
+        else if (emitProviderPlanFactories
+                 && providerConstructionExpression is not null
+                 && (!usesKeyedServices || hasKeyedServiceExtensions))
+        {
+            sb.Append(providerConstructionExpression);
+        }
     }
 
     /// <summary>

--- a/test/Stella.Ergosfare.Command.Test/GeneratedPlanProviderConstructionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedPlanProviderConstructionTests.cs
@@ -1,0 +1,177 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime behavior of the plans' provider-taking construction factories — the shape the
+/// generator emits for handlers with constructor dependencies. The same gate as the
+/// parameterless factories applies (plain transient registration only, lifetime overrides
+/// route back through the container); on top of that, the factory must resolve every
+/// dependency from the dispatching scope's provider, exactly where container activation
+/// would resolve it. Test factories construct marked instances, which generated code never
+/// does, precisely so the chosen construction path is observable. Helper types are
+/// excluded from discovery so assembly scans (the registry is process-wide) cannot alter
+/// these pipelines.
+/// </summary>
+public class GeneratedPlanProviderConstructionTests
+{
+    public interface IProbeDependency
+    {
+        Guid Id { get; }
+    }
+
+    public sealed class ProbeDependency : IProbeDependency
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class InjectedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class InjectedCommandHandler(IProbeDependency dependency) : ICommandHandler<InjectedCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public bool ViaPlanFactory { get; init; }
+
+        public ValueTask HandleAsync(InjectedCommand command, IExecutionContext context)
+        {
+            context.Set("handlerId", _id);
+            context.Set("dependencyId", dependency.Id);
+            context.Set("viaPlanFactory", ViaPlanFactory);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlainTransientRegistration_ConstructsThroughTheProviderFactory()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<InjectedCommand, InjectedCommandHandler>(
+            static provider => new InjectedCommandHandler(provider.GetRequiredService<IProbeDependency>())
+            {
+                ViaPlanFactory = true,
+            });
+
+        var provider = new ServiceCollection()
+            .AddSingleton<IProbeDependency, ProbeDependency>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<InjectedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new CommandMediationSettings();
+        await mediator.SendAsync(new InjectedCommand(), first);
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new InjectedCommand(), second);
+
+        // The factory constructs (transient semantics intact — fresh handler per
+        // dispatch), and the dependency is the container's own singleton instance.
+        Assert.Equal(true, first.Items["viaPlanFactory"]);
+        Assert.Equal(true, second.Items["viaPlanFactory"]);
+        Assert.NotEqual(first.Items["handlerId"], second.Items["handlerId"]);
+        Assert.Equal(provider.GetRequiredService<IProbeDependency>().Id, first.Items["dependencyId"]);
+        Assert.Equal(provider.GetRequiredService<IProbeDependency>().Id, second.Items["dependencyId"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class ScopedInjectedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class ScopedInjectedCommandHandler(IProbeDependency dependency) : ICommandHandler<ScopedInjectedCommand>
+    {
+        public ValueTask HandleAsync(ScopedInjectedCommand command, IExecutionContext context)
+        {
+            context.Set("dependencyId", dependency.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ScopedDependency_ResolvesFromTheDispatchingScope()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<ScopedInjectedCommand, ScopedInjectedCommandHandler>(
+            static provider => new ScopedInjectedCommandHandler(provider.GetRequiredService<IProbeDependency>()));
+
+        var provider = new ServiceCollection()
+            .AddScoped<IProbeDependency, ProbeDependency>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<ScopedInjectedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        // Container activation resolves a scoped dependency from the resolving scope;
+        // the provider factory must land on the very same instance.
+        using var firstScope = provider.CreateScope();
+        var firstSettings = new CommandMediationSettings();
+        await firstScope.ServiceProvider.GetRequiredService<ICommandMediator>()
+            .SendAsync(new ScopedInjectedCommand(), firstSettings);
+
+        Assert.Equal(
+            firstScope.ServiceProvider.GetRequiredService<IProbeDependency>().Id,
+            firstSettings.Items["dependencyId"]);
+
+        using var secondScope = provider.CreateScope();
+        var secondSettings = new CommandMediationSettings();
+        await secondScope.ServiceProvider.GetRequiredService<ICommandMediator>()
+            .SendAsync(new ScopedInjectedCommand(), secondSettings);
+
+        Assert.Equal(
+            secondScope.ServiceProvider.GetRequiredService<IProbeDependency>().Id,
+            secondSettings.Items["dependencyId"]);
+        Assert.NotEqual(firstSettings.Items["dependencyId"], secondSettings.Items["dependencyId"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class OverriddenInjectedCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class OverriddenInjectedCommandHandler(IProbeDependency dependency) : ICommandHandler<OverriddenInjectedCommand>
+    {
+        private readonly Guid _id = Guid.NewGuid();
+
+        public ValueTask HandleAsync(OverriddenInjectedCommand command, IExecutionContext context)
+        {
+            _ = dependency;
+            context.Set("handlerId", _id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task SingletonLifetimeOverride_KeepsTheSharedInstance()
+    {
+        GeneratedDispatchRoots.AddVoidPlan<OverriddenInjectedCommand, OverriddenInjectedCommandHandler>(
+            static provider => new OverriddenInjectedCommandHandler(provider.GetRequiredService<IProbeDependency>()));
+
+        var provider = new ServiceCollection()
+            .AddSingleton<IProbeDependency, ProbeDependency>()
+            .AddSingleton<OverriddenInjectedCommandHandler>()
+            .AddErgosfare(x => x.AddCommandModule(c => c.Register<OverriddenInjectedCommandHandler>()))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // A provider-factory construction would hand out fresh instances; the user's
+        // singleton override must keep sharing one — the gate routes back through the
+        // container exactly as it does for parameterless factories.
+        var first = new CommandMediationSettings();
+        await mediator.SendAsync(new OverriddenInjectedCommand(), first);
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new OverriddenInjectedCommand(), second);
+
+        Assert.Equal(first.Items["handlerId"], second.Items["handlerId"]);
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/VoidPlanEmissionTests.cs
@@ -38,7 +38,7 @@ public class VoidPlanEmissionTests
     }
 
     [Fact]
-    public void ConstructorDependency_SuppressesTheFactoryButKeepsThePlan()
+    public void ConstructorDependency_EmitsTheProviderFactory()
     {
         var result = GeneratorTestHost.Run("""
             using Stella.Ergosfare.Commands.Abstractions;
@@ -46,11 +46,13 @@ public class VoidPlanEmissionTests
 
             namespace TestApp
             {
+                public interface IGreeter { }
+
                 public sealed record NeedyPing : ICommand;
 
                 public sealed class NeedyPingHandler : ICommandHandler<NeedyPing>
                 {
-                    public NeedyPingHandler(string dependency) { }
+                    public NeedyPingHandler(IGreeter greeter, string dependency) { }
 
                     public ValueTask HandleAsync(NeedyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
                         => default;
@@ -59,8 +61,78 @@ public class VoidPlanEmissionTests
             """);
 
         Assert.Empty(result.CompilationErrors);
+
+        // A single public constructor whose every parameter is a plain service resolution
+        // is the one shape where the container's own selection has no choice — the plan
+        // carries a provider-taking factory resolving each dependency from the
+        // dispatching scope, exactly as container activation would.
         Assert.Contains(
-            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.NeedyPing, global::TestApp.NeedyPingHandler>();",
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.NeedyPing, global::TestApp.NeedyPingHandler>("
+            + "static provider => new global::TestApp.NeedyPingHandler("
+            + "global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::TestApp.IGreeter>(provider), "
+            + "global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<string>(provider)));",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void KeyedConstructorDependency_EmitsTheKeyedProviderFactory()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Microsoft.Extensions.DependencyInjection;
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public interface IGreeter { }
+
+                public sealed record KeyedNeedyPing : ICommand;
+
+                public sealed class KeyedNeedyPingHandler : ICommandHandler<KeyedNeedyPing>
+                {
+                    public KeyedNeedyPingHandler([FromKeyedServices("primary")] IGreeter greeter) { }
+
+                    public ValueTask HandleAsync(KeyedNeedyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.KeyedNeedyPing, global::TestApp.KeyedNeedyPingHandler>("
+            + "static provider => new global::TestApp.KeyedNeedyPingHandler("
+            + "global::Microsoft.Extensions.DependencyInjection.ServiceProviderKeyedServiceExtensions.GetRequiredKeyedService<global::TestApp.IGreeter>(provider, \"primary\")));",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void OptionalParameter_SuppressesTheFactoryButKeepsThePlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record DefaultyPing : ICommand;
+
+                public sealed class DefaultyPingHandler : ICommandHandler<DefaultyPing>
+                {
+                    public DefaultyPingHandler(string dependency = "fallback") { }
+
+                    public ValueTask HandleAsync(DefaultyPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // The container uses the default value only when no string service is registered —
+        // content-dependent behavior the emission cannot reproduce. Plan only, no factory.
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddVoidPlan<global::TestApp.DefaultyPing, global::TestApp.DefaultyPingHandler>();",
             result.GeneratedSource);
     }
 


### PR DESCRIPTION
## What

PR B of the staged-plans epic: dependency-injected handlers get compile-time construction factories on their pipeline plans.

- **Runtime** (`GeneratedDispatchRoots`, `PipelineExecutors`): `AddVoidPlan<TMessage, THandler>(Func<IServiceProvider, THandler>)` and `AddResultPlan<TMessage, TResult, THandler>(Func<IServiceProvider, THandler>)` overloads; plan roots carry either delegate shape erased, the generated executors invoke the provider-taking one with the dispatching scope's provider. The existing runtime gate is reused verbatim: factory construction happens only while the handler's effective DI registration is the module's own plain transient one (`IsPlainTransientRegistration` + `MemoizedInstances: false` + `HandlerType` pin per registry version).
- **Generator**: `GetProviderConstructionExpression` builds `static provider => new THandler(GetRequiredService<TDep>(provider), GetRequiredKeyedService<TKeyed>(provider, key), ...)` under a strict compile gate — **exactly one public constructor** (MS.DI's `CallSiteFactory` only considers public constructors, so a single public one leaves the container no choice; non-public extras are invisible to it and therefore ignored). Disqualifiers keep anything content-dependent on the container path: optional/default-valued parameters, multiple public constructors, disposables, `required` members, `ref`/`params` parameters, `[ServiceKey]`, `Nullable<T>` parameters, non-nameable parameter types, and `[FromKeyedServices]` keys the emission cannot reproduce exactly (supported: string/char/bool/integral/enum/typeof; rejected: null, floating-point).
- **Version skew**: two new availability probes (`DispatchRootsHasProviderPlanFactories` — the arity-2 `Func` overload plus `ServiceProviderServiceExtensions` visibility — and `HasKeyedServiceExtensions`); emission degrades to the factory-less plan form against older packages, keyed factories additionally require the keyed extensions.

## Semantics note

Dependencies resolve from the dispatching scope's provider — exactly where container activation would resolve them; the scoped-dependency parity test asserts the factory lands on the very scope instance. Known divergence: when a dependency is unregistered, both paths throw `InvalidOperationException` on dispatch, but the message differs (container's "while attempting to activate" wrapper vs `GetRequiredService`'s plain text).

## Verification

- Build 0 warnings; all suites green on net9.0 + net10.0.
- SourceGenerator.Test 43/43: provider-factory emission (plain + keyed) asserted verbatim; optional-parameter disqualification; the old "constructor dependency suppresses the factory" test updated to the new behavior.
- Command.Test 51/51 (+3): factory used under plain transient registration (fresh handler per dispatch, dependency = the container's singleton instance); scoped dependency resolves from the dispatching scope (parity proof); singleton lifetime override routes back through the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
