### PR TITLE
perf: staged pipeline plan runtime (advisory gate + executor hosting)

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDispatchRoots.cs
@@ -21,6 +21,8 @@ public static class GeneratedDispatchRoots
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), MessageResultRoot> Streams = new();
     private static readonly ConcurrentDictionary<Type, VoidPlanRoot> VoidPlans = new();
     private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), ResultPlanRoot> ResultPlans = new();
+    private static readonly ConcurrentDictionary<Type, StagedVoidPlan> StagedVoidPlans = new();
+    private static readonly ConcurrentDictionary<(Type MessageType, Type ResultType), StagedResultPlan> StagedResultPlans = new();
 
     /// <summary>Roots the void dispatch generics of a message type. Idempotent.</summary>
     public static void AddMessage<TMessage>() where TMessage : IMessage
@@ -133,6 +135,33 @@ public static class GeneratedDispatchRoots
     /// <summary>The result pipeline plan of the (message, result) pair, or <c>null</c> when none was generated.</summary>
     public static ResultPlanRoot? FindResultPlan(Type messageType, Type resultType)
         => ResultPlans.TryGetValue((messageType, resultType), out var root) ? root : null;
+
+    /// <summary>
+    /// Roots a staged pipeline plan for a void message whose pipeline carries interceptor
+    /// stages: bespoke straight-line code for the whole pipeline, replacing the runtime
+    /// strategy's generic machinery. Advisory exactly like the single-handler plans — the
+    /// hosting executor re-validates the plan's <see cref="StagedPlanComposition"/> against
+    /// the registry per version and falls back to the runtime strategy on any mismatch.
+    /// Idempotent.
+    /// </summary>
+    public static void AddStagedPlan<TMessage>(StagedVoidPlan<TMessage> plan)
+        where TMessage : notnull, IMessage
+        => StagedVoidPlans.TryAdd(typeof(TMessage), plan);
+
+    /// <summary>
+    /// Result-producing counterpart of <see cref="AddStagedPlan{TMessage}"/>. Idempotent.
+    /// </summary>
+    public static void AddStagedPlan<TMessage, TResult>(StagedResultPlan<TMessage, TResult> plan)
+        where TMessage : notnull, IMessage
+        => StagedResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), plan);
+
+    /// <summary>The staged void plan of the message type, or <c>null</c> when none was generated.</summary>
+    public static StagedVoidPlan? FindStagedVoidPlan(Type messageType)
+        => StagedVoidPlans.TryGetValue(messageType, out var plan) ? plan : null;
+
+    /// <summary>The staged result plan of the (message, result) pair, or <c>null</c> when none was generated.</summary>
+    public static StagedResultPlan? FindStagedResultPlan(Type messageType, Type resultType)
+        => StagedResultPlans.TryGetValue((messageType, resultType), out var plan) ? plan : null;
 }
 
 /// <summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Stella.Ergosfare.Core.Abstractions;
+
+/// <summary>
+/// The pipeline composition a staged plan was baked against: the sole main handler plus
+/// the four interceptor stages as ordered type lists — exactly the merged
+/// (direct-first, then indirect) order the runtime pipeline would execute them in.
+/// </summary>
+/// <remarks>
+/// The composition is the advisory contract's comparison key: on every registry-version
+/// rebuild the executor compares it against the live pipeline, and any difference —
+/// a runtime-registered interceptor, a different handler, reordered stages — routes the
+/// dispatch back through the runtime strategy. The arrays are captured as given (no
+/// defensive copy); plans are compile-time singletons whose compositions never change.
+/// </remarks>
+public sealed class StagedPlanComposition(
+    Type handlerType,
+    Type[] preInterceptorTypes,
+    Type[] postInterceptorTypes,
+    Type[] exceptionInterceptorTypes,
+    Type[] finalInterceptorTypes)
+{
+    internal readonly Type[] PreInterceptorTypeArray = preInterceptorTypes;
+    internal readonly Type[] PostInterceptorTypeArray = postInterceptorTypes;
+    internal readonly Type[] ExceptionInterceptorTypeArray = exceptionInterceptorTypes;
+    internal readonly Type[] FinalInterceptorTypeArray = finalInterceptorTypes;
+
+    /// <summary>The concrete type of the pipeline's sole main handler.</summary>
+    public Type HandlerType { get; } = handlerType;
+
+    /// <summary>The pre-interceptor types, in execution order.</summary>
+    public IReadOnlyList<Type> PreInterceptorTypes => PreInterceptorTypeArray;
+
+    /// <summary>The post-interceptor types, in execution order.</summary>
+    public IReadOnlyList<Type> PostInterceptorTypes => PostInterceptorTypeArray;
+
+    /// <summary>The exception-interceptor types, in execution order.</summary>
+    public IReadOnlyList<Type> ExceptionInterceptorTypes => ExceptionInterceptorTypeArray;
+
+    /// <summary>The final-interceptor types, in execution order.</summary>
+    public IReadOnlyList<Type> FinalInterceptorTypes => FinalInterceptorTypeArray;
+}
+
+/// <summary>
+/// A compile-time staged pipeline plan for a void message: bespoke code that runs the
+/// message's entire interceptor-bearing pipeline — pre stages, handler, post stages, with
+/// exception and final semantics — as straight-line typed calls instead of the runtime
+/// strategy's generic machinery. See <see cref="MessageRoot"/> for the visitor re-entry
+/// pattern.
+/// </summary>
+/// <remarks>
+/// The plan is advisory: the hosting executor re-validates <see cref="Composition"/>
+/// against the live registry on every version change and falls back to the runtime
+/// strategy whenever the pipeline no longer matches, so a stale plan only loses its
+/// speedup, never changes behavior. <see cref="StagedVoidPlan{TMessage}.Execute"/> must
+/// resolve every participant from the provider it is handed — that is exactly what the
+/// runtime handler references do outside memoized mode, which the executor's gate
+/// excludes.
+/// </remarks>
+public abstract class StagedVoidPlan
+{
+    /// <summary>The pipeline composition the plan was baked against.</summary>
+    public abstract StagedPlanComposition Composition { get; }
+
+    /// <summary>Invokes the visitor with this plan's message type as the generic argument.</summary>
+    public abstract TReturn Accept<TReturn, TState>(IStagedVoidPlanVisitor<TReturn, TState> visitor, TState state);
+}
+
+/// <summary>The typed closure of <see cref="StagedVoidPlan"/>; subclassed by generated (or hand-written) plans.</summary>
+public abstract class StagedVoidPlan<TMessage> : StagedVoidPlan
+    where TMessage : notnull, IMessage
+{
+    /// <summary>
+    /// Runs the baked pipeline for the message. Only invoked while the live pipeline
+    /// matches <see cref="StagedVoidPlan.Composition"/>; participants resolve from
+    /// <paramref name="serviceProvider"/> — the dispatching scope's provider.
+    /// </summary>
+    public abstract ValueTask Execute(TMessage message, IExecutionContext context, IServiceProvider serviceProvider);
+
+    /// <inheritdoc />
+    public sealed override TReturn Accept<TReturn, TState>(IStagedVoidPlanVisitor<TReturn, TState> visitor, TState state)
+        => visitor.Visit<TMessage>(state);
+}
+
+/// <summary>Generic re-entry point for consumers of <see cref="StagedVoidPlan"/>.</summary>
+public interface IStagedVoidPlanVisitor<out TReturn, in TState>
+{
+    /// <summary>Called with the plan's message type as the generic argument.</summary>
+    TReturn Visit<TMessage>(TState state) where TMessage : notnull, IMessage;
+}
+
+/// <summary>
+/// The result-producing counterpart of <see cref="StagedVoidPlan"/>: a compile-time
+/// staged pipeline plan for a message with a result contract. The same advisory contract
+/// applies — see <see cref="StagedVoidPlan"/>.
+/// </summary>
+public abstract class StagedResultPlan
+{
+    /// <summary>The pipeline composition the plan was baked against.</summary>
+    public abstract StagedPlanComposition Composition { get; }
+
+    /// <summary>Invokes the visitor with this plan's message and result types as the generic arguments.</summary>
+    public abstract TReturn Accept<TReturn, TState>(IStagedResultPlanVisitor<TReturn, TState> visitor, TState state);
+}
+
+/// <summary>The typed closure of <see cref="StagedResultPlan"/>; subclassed by generated (or hand-written) plans.</summary>
+public abstract class StagedResultPlan<TMessage, TResult> : StagedResultPlan
+    where TMessage : notnull, IMessage
+{
+    /// <inheritdoc cref="StagedVoidPlan{TMessage}.Execute"/>
+    public abstract ValueTask<TResult> Execute(TMessage message, IExecutionContext context, IServiceProvider serviceProvider);
+
+    /// <inheritdoc />
+    public sealed override TReturn Accept<TReturn, TState>(IStagedResultPlanVisitor<TReturn, TState> visitor, TState state)
+        => visitor.Visit<TMessage, TResult>(state);
+}
+
+/// <summary>Generic re-entry point for consumers of <see cref="StagedResultPlan"/>.</summary>
+public interface IStagedResultPlanVisitor<out TReturn, in TState>
+{
+    /// <summary>Called with the plan's message and result types as the generic arguments.</summary>
+    TReturn Visit<TMessage, TResult>(TState state) where TMessage : notnull, IMessage;
+}

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutors.cs
@@ -373,6 +373,170 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
 #pragma warning restore CS8714
 
 /// <summary>
+/// The staged plans' advisory gate: whether the live pipeline is exactly the composition a
+/// plan was baked against — one main handler of the planned type and the four interceptor
+/// stages matching the planned type lists in order. Anything else (a runtime-registered
+/// interceptor, a different or additional handler, reordered stages) fails the match and
+/// keeps the dispatch on the runtime strategy.
+/// </summary>
+internal static class StagedPlanGate
+{
+    internal static bool Matches(MessageDependencies dependencies, StagedPlanComposition composition)
+        => dependencies.Handlers.Count == 1
+           && dependencies.Handlers[0].HandlerType == composition.HandlerType
+           && StageMatches(dependencies.PreInterceptors, composition.PreInterceptorTypeArray)
+           && StageMatches(dependencies.PostInterceptors, composition.PostInterceptorTypeArray)
+           && StageMatches(dependencies.ExceptionInterceptors, composition.ExceptionInterceptorTypeArray)
+           && StageMatches(dependencies.FinalInterceptors, composition.FinalInterceptorTypeArray);
+
+    private static bool StageMatches<THandler, TDescriptor>(
+        IReadOnlyList<IHandlerReference<THandler, TDescriptor>> stage,
+        Type[] baked)
+        where TDescriptor : IHandlerDescriptor
+    {
+        if (stage.Count != baked.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < baked.Length; i++)
+        {
+            if (stage[i].HandlerType != baked[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// Void pipeline hosting a staged plan: bespoke straight-line code for the message's whole
+/// interceptor-bearing pipeline. The plan is advisory — the registry-version-guarded
+/// dependency cache re-validates the plan's composition against the live pipeline
+/// (<see cref="StagedPlanGate"/>) plus the memoization and adapter gates, and any mismatch
+/// falls back to the runtime strategy, preserving semantics exactly. The plan resolves its
+/// participants from the dispatching scope's provider — outside memoized mode that is
+/// literally what the runtime handler references do, so container semantics are preserved.
+/// Like every version-guarded executor, a dispatch racing a registration may run the
+/// previous shape once; it never runs a shape the registry has not published.
+/// </summary>
+internal sealed class StagedVoidPipelineExecutor<TMessage>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups,
+    StagedVoidPlan<TMessage> plan) : IPipelineExecutor
+    where TMessage : notnull, IMessage
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);
+
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private IMessageDependencies? _cachedDependencies;
+    private int _cachedVersion = int.MinValue;
+    private bool _useStagedPlan;
+
+    public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = GetDependencies();
+
+        if (_useStagedPlan)
+        {
+            return plan.Execute((TMessage)message, context, serviceProvider);
+        }
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            _cachedDependencies = dependencies;
+            _useStagedPlan = !_foreignAdapters
+                && (_concreteAdapters is null || _concreteAdapters.IsEmpty)
+                && dependencies is MessageDependencies { MemoizedInstances: false } fastDependencies
+                && StagedPlanGate.Matches(fastDependencies, plan.Composition);
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        _useStagedPlan = false;
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+    }
+}
+
+/// <summary>
+/// Result-producing counterpart of <see cref="StagedVoidPipelineExecutor{TMessage}"/>;
+/// the same advisory contract and gates apply.
+/// </summary>
+internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
+    IMessageDescriptor descriptor,
+    IMessageDependenciesFactory dependenciesFactory,
+    IResultAdapterService? resultAdapterService,
+    string[] groups,
+    StagedResultPlan<TMessage, TResult> plan) : IPipelineExecutor<TResult>
+    where TMessage : notnull, IMessage
+{
+    private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);
+
+    private readonly ResultAdapterService? _concreteAdapters = resultAdapterService as ResultAdapterService;
+    private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
+
+    private IMessageDependencies? _cachedDependencies;
+    private int _cachedVersion = int.MinValue;
+    private bool _useStagedPlan;
+
+    public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
+    {
+        var dependencies = GetDependencies();
+
+        if (_useStagedPlan)
+        {
+            return plan.Execute((TMessage)message, context, serviceProvider);
+        }
+
+        return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
+    }
+
+    private IMessageDependencies GetDependencies()
+    {
+        if (dependenciesFactory is MessageDependenciesFactory typedFactory)
+        {
+            var cached = _cachedDependencies;
+
+            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            {
+                return cached;
+            }
+
+            var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
+            _cachedDependencies = dependencies;
+            _useStagedPlan = !_foreignAdapters
+                && (_concreteAdapters is null || _concreteAdapters.IsEmpty)
+                && dependencies is MessageDependencies { MemoizedInstances: false } fastDependencies
+                && StagedPlanGate.Matches(fastDependencies, plan.Composition);
+            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            return dependencies;
+        }
+
+        _useStagedPlan = false;
+        return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
+    }
+}
+
+/// <summary>
 /// Process-wide cache of pipeline executors, one per (message runtime type, result type,
 /// group set). Executor construction closes the generic executor over the message's runtime
 /// type — one <see cref="Type.MakeGenericType"/> per message type, consistent with the
@@ -695,6 +859,18 @@ internal sealed class PipelineExecutorCache(
     {
         var descriptor = FindDescriptor(messageType);
 
+        // Staged plan: bespoke code for the whole interceptor-bearing pipeline. Checked
+        // before the single-handler plan — generation emits at most one plan kind per
+        // message, and the staged one is the more specific claim. Group-less pipelines
+        // only, like every plan below.
+        if (groups.Length == 0 && GeneratedDispatchRoots.FindStagedVoidPlan(messageType) is { } stagedPlan)
+        {
+            return stagedPlan.Accept(
+                StagedVoidExecutorVisitor.Instance,
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups,
+                    StagedPlan: stagedPlan));
+        }
+
         // Generated void plan: closed over (message, handler) at compile time, so the
         // fast path calls the handler devirtualized. Group-less pipelines only — a
         // grouped pipeline may exclude the planned handler, and the plain executor
@@ -731,6 +907,15 @@ internal sealed class PipelineExecutorCache(
     {
         var descriptor = FindDescriptor(messageType);
 
+        // Staged plan first, mirroring the void side.
+        if (groups.Length == 0 && GeneratedDispatchRoots.FindStagedResultPlan(messageType, resultType) is { } stagedPlan)
+        {
+            return stagedPlan.Accept(
+                StagedResultExecutorVisitor.Instance,
+                new ExecutorState(descriptor, dependenciesFactory, resultAdapterService, groups,
+                    StagedPlan: stagedPlan));
+        }
+
         // Generated result plan: closed over (message, result, handler) at compile time,
         // so the fast path calls the handler devirtualized. Group-less pipelines only,
         // mirroring the void plan above.
@@ -759,13 +944,16 @@ internal sealed class PipelineExecutorCache(
     /// <paramref name="DirectHandlerFactory"/> is a plan's erased <c>Func&lt;THandler&gt;</c>
     /// or <c>Func&lt;IServiceProvider, THandler&gt;</c> (cast back inside the closed
     /// generic), or <c>null</c> for plain roots and plans without a construction path.
+    /// <paramref name="StagedPlan"/> is a staged plan carried erased (cast back to its
+    /// typed base inside the closed generic), or <c>null</c> for every other root.
     /// </summary>
     private readonly record struct ExecutorState(
         IMessageDescriptor Descriptor,
         IMessageDependenciesFactory DependenciesFactory,
         IResultAdapterService? ResultAdapterService,
         string[] Groups,
-        object? DirectHandlerFactory = null);
+        object? DirectHandlerFactory = null,
+        object? StagedPlan = null);
 
     /// <summary>
     /// Re-enters a generic context with a root's message type and constructs the closed
@@ -824,6 +1012,33 @@ internal sealed class PipelineExecutorCache(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
                 state.DirectHandlerFactory as Func<THandler>,
                 state.DirectHandlerFactory as Func<IServiceProvider, THandler>);
+    }
+
+    /// <summary>
+    /// Re-enters a generic context with a staged plan's message type and constructs the
+    /// plan-hosting executor there — no reflection.
+    /// </summary>
+    private sealed class StagedVoidExecutorVisitor : IStagedVoidPlanVisitor<IPipelineExecutor, ExecutorState>
+    {
+        public static readonly StagedVoidExecutorVisitor Instance = new();
+
+        public IPipelineExecutor Visit<TMessage>(ExecutorState state)
+            where TMessage : notnull, IMessage
+            => new StagedVoidPipelineExecutor<TMessage>(
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
+                (StagedVoidPlan<TMessage>)state.StagedPlan!);
+    }
+
+    /// <summary>Result-executor counterpart of <see cref="StagedVoidExecutorVisitor"/>.</summary>
+    private sealed class StagedResultExecutorVisitor : IStagedResultPlanVisitor<object, ExecutorState>
+    {
+        public static readonly StagedResultExecutorVisitor Instance = new();
+
+        public object Visit<TMessage, TResult>(ExecutorState state)
+            where TMessage : notnull, IMessage
+            => new StagedResultPipelineExecutor<TMessage, TResult>(
+                state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
+                (StagedResultPlan<TMessage, TResult>)state.StagedPlan!);
     }
 
     private IMessageDescriptor FindDescriptor(Type messageType)

--- a/test/Stella.Ergosfare.Command.Test/StagedPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/StagedPlanExecutionTests.cs
@@ -1,0 +1,404 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Runtime skeleton of the staged pipeline plans: a hand-written
+/// <see cref="StagedVoidPlan{TMessage}"/>/<see cref="StagedResultPlan{TMessage,TResult}"/>
+/// stands in for what the generator will emit, so these tests validate the hosting
+/// executor's advisory gate — the plan runs only while the live pipeline matches its
+/// baked composition, and any divergence (a runtime registration, a mismatched
+/// composition, memoized instances) routes the dispatch back through the runtime
+/// strategy with identical behavior. Participants record execution into the message
+/// instance itself, and only the plan writes the "staged" marker, so the chosen path is
+/// observable. Helper types are excluded from discovery so assembly scans (the registry
+/// is process-wide) cannot alter these pipelines.
+/// </summary>
+public class StagedPlanExecutionTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class StagedCommand : ICommand
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class StagedCommandHandler : ICommandHandler<StagedCommand>
+    {
+        public ValueTask HandleAsync(StagedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class StagedCommandPreInterceptor : ICommandPreInterceptor<StagedCommand>
+    {
+        public ValueTask<StagedCommand> HandleAsync(StagedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class StagedCommandPostInterceptor : ICommandPostInterceptor<StagedCommand>
+    {
+        public ValueTask<object> HandleAsync(StagedCommand command, object messageResult, IExecutionContext context)
+        {
+            command.Order.Add("post");
+            return ValueTask.FromResult(messageResult);
+        }
+    }
+
+    private sealed class StagedCommandPlan : StagedVoidPlan<StagedCommand>
+    {
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(StagedCommandHandler),
+            [typeof(StagedCommandPreInterceptor)],
+            [typeof(StagedCommandPostInterceptor)],
+            [],
+            []);
+
+        public override async ValueTask Execute(StagedCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            message = await serviceProvider.GetRequiredService<StagedCommandPreInterceptor>().HandleAsync(message, context);
+            await serviceProvider.GetRequiredService<StagedCommandHandler>().HandleAsync(message, context);
+            await serviceProvider.GetRequiredService<StagedCommandPostInterceptor>().HandleAsync(message, ValueTask.CompletedTask, context);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task MatchingComposition_ExecutesThroughTheStagedPlan()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new StagedCommandPlan());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<StagedCommandHandler>();
+                c.Register<StagedCommandPreInterceptor>();
+                c.Register<StagedCommandPostInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var command = new StagedCommand();
+        await mediator.SendAsync(command);
+
+        Assert.Equal(["staged", "pre", "handler", "post"], command.Order);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class FallbackCommand : ICommand
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class FallbackCommandHandler : ICommandHandler<FallbackCommand>
+    {
+        public ValueTask HandleAsync(FallbackCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class FallbackCommandPreInterceptor : ICommandPreInterceptor<FallbackCommand>
+    {
+        public ValueTask<FallbackCommand> HandleAsync(FallbackCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class ExtraFallbackCommandPreInterceptor : ICommandPreInterceptor<FallbackCommand>
+    {
+        public ValueTask<FallbackCommand> HandleAsync(FallbackCommand command, IExecutionContext context)
+        {
+            command.Order.Add("extra-pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    private sealed class FallbackCommandPlan : StagedVoidPlan<FallbackCommand>
+    {
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(FallbackCommandHandler),
+            [typeof(FallbackCommandPreInterceptor)],
+            [],
+            [],
+            []);
+
+        public override async ValueTask Execute(FallbackCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            message = await serviceProvider.GetRequiredService<FallbackCommandPreInterceptor>().HandleAsync(message, context);
+            await serviceProvider.GetRequiredService<FallbackCommandHandler>().HandleAsync(message, context);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task RuntimeRegistration_FallsBackToTheStrategy()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new FallbackCommandPlan());
+
+        // The extra interceptor is resolvable from the container up front (a runtime
+        // registry registration cannot add DI registrations to an already-built
+        // provider) but joins the message's pipeline only through the registry below.
+        var provider = new ServiceCollection()
+            .AddTransient<ExtraFallbackCommandPreInterceptor>()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<FallbackCommandHandler>();
+                c.Register<FallbackCommandPreInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var beforeRegistration = new FallbackCommand();
+        await mediator.SendAsync(beforeRegistration);
+        Assert.Equal(["staged", "pre", "handler"], beforeRegistration.Order);
+
+        // A runtime registration bumps the registry version; the next rebuild sees a
+        // second pre-interceptor the plan was not baked for — the advisory contract
+        // demands the strategy path, which runs both interceptors.
+        provider.GetRequiredService<IMessageRegistry>().Register(typeof(ExtraFallbackCommandPreInterceptor));
+
+        var afterRegistration = new FallbackCommand();
+        await mediator.SendAsync(afterRegistration);
+
+        Assert.DoesNotContain("staged", afterRegistration.Order);
+        Assert.Contains("pre", afterRegistration.Order);
+        Assert.Contains("extra-pre", afterRegistration.Order);
+        Assert.Equal("handler", afterRegistration.Order[^1]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedCommand : ICommand
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedCommandHandler : ICommandHandler<MismatchedCommand>
+    {
+        public ValueTask HandleAsync(MismatchedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MismatchedCommandPreInterceptor : ICommandPreInterceptor<MismatchedCommand>
+    {
+        public ValueTask<MismatchedCommand> HandleAsync(MismatchedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    private sealed class MismatchedCommandPlan : StagedVoidPlan<MismatchedCommand>
+    {
+        // Baked against a post-interceptor stage the registry never sees — the gate must
+        // fail on the very first rebuild and keep the dispatch on the strategy path.
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(MismatchedCommandHandler),
+            [typeof(MismatchedCommandPreInterceptor)],
+            [typeof(StagedCommandPostInterceptor)],
+            [],
+            []);
+
+        public override ValueTask Execute(MismatchedCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task MismatchedComposition_FallsBackToTheStrategy()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new MismatchedCommandPlan());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<MismatchedCommandHandler>();
+                c.Register<MismatchedCommandPreInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var command = new MismatchedCommand();
+        await mediator.SendAsync(command);
+
+        Assert.Equal(["pre", "handler"], command.Order);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedStagedCommand : ICommand
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedStagedCommandHandler : ICommandHandler<MemoizedStagedCommand>
+    {
+        public ValueTask HandleAsync(MemoizedStagedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class MemoizedStagedCommandPreInterceptor : ICommandPreInterceptor<MemoizedStagedCommand>
+    {
+        public ValueTask<MemoizedStagedCommand> HandleAsync(MemoizedStagedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    private sealed class MemoizedStagedCommandPlan : StagedVoidPlan<MemoizedStagedCommand>
+    {
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(MemoizedStagedCommandHandler),
+            [typeof(MemoizedStagedCommandPreInterceptor)],
+            [],
+            [],
+            []);
+
+        public override ValueTask Execute(MemoizedStagedCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ForceMemoizedHandlers_FallsBackToTheStrategy()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new MemoizedStagedCommandPlan());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x =>
+            {
+                x.ForceMemoizedHandlers();
+                x.AddCommandModule(c =>
+                {
+                    c.Register<MemoizedStagedCommandHandler>();
+                    c.Register<MemoizedStagedCommandPreInterceptor>();
+                });
+            })
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Memoized pipelines cache instances inside their references; a plan resolving
+        // from the provider would construct fresh ones — the gate keeps the strategy path.
+        var command = new MemoizedStagedCommand();
+        await mediator.SendAsync(command);
+
+        Assert.Equal(["pre", "handler"], command.Order);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class StagedResultCommand : ICommand<int>
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class StagedResultCommandHandler : ICommandHandler<StagedResultCommand, int>
+    {
+        public ValueTask<int> HandleAsync(StagedResultCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.FromResult(42);
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class StagedResultCommandPreInterceptor : ICommandPreInterceptor<StagedResultCommand>
+    {
+        public ValueTask<StagedResultCommand> HandleAsync(StagedResultCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    private sealed class StagedResultCommandPlan : StagedResultPlan<StagedResultCommand, int>
+    {
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(StagedResultCommandHandler),
+            [typeof(StagedResultCommandPreInterceptor)],
+            [],
+            [],
+            []);
+
+        public override async ValueTask<int> Execute(StagedResultCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            message = await serviceProvider.GetRequiredService<StagedResultCommandPreInterceptor>().HandleAsync(message, context);
+            return await serviceProvider.GetRequiredService<StagedResultCommandHandler>().HandleAsync(message, context);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task MatchingComposition_ExecutesThroughTheStagedResultPlan()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new StagedResultCommandPlan());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<StagedResultCommandHandler>();
+                c.Register<StagedResultCommandPreInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var command = new StagedResultCommand();
+        var result = await mediator.SendAsync(command);
+
+        Assert.Equal(42, result);
+        Assert.Equal(["staged", "pre", "handler"], command.Order);
+    }
+}


### PR DESCRIPTION
## What

PR C of the staged-plans epic: the public runtime skeleton that PR D's generator emission will target — no generator changes here, hand-written plans stand in for emitted ones.

- **Public surface** (`Core.Abstractions/StagedPlans.cs`): `StagedVoidPlan<TMessage>` / `StagedResultPlan<TMessage, TResult>` abstract bases (bespoke `Execute` + `Composition`) and `StagedPlanComposition` — the baked pipeline shape (sole handler + four interceptor stages as ordered type lists), which is the advisory contract's comparison key. Visitor re-entry interfaces mirror the existing root pattern. `GeneratedDispatchRoots` gains `AddStagedPlan` (void + result overloads) and the `Find*` lookups; idempotent like every root.
- **Executor hosting** (`Core/Internal/Mediator/PipelineExecutors.cs`): `StagedVoidPipelineExecutor` / `StagedResultPipelineExecutor` wrap a plan with the familiar registry-version-guarded dependency cache; `StagedPlanGate` compares the live pipeline against the baked composition. The gate additionally requires `MemoizedInstances: false` and no configured result adapters. Any failure routes the dispatch through `SingleAsyncHandlerMediationStrategy` — behavior never changes, a stale plan only loses its speedup. Cache integration: staged lookup runs before the single-handler plans, group-less dispatches only.

## Cost model

The composition comparison runs once per message type per registry version — never per dispatch. Per dispatch the executor pays exactly what every existing executor already pays: the version compare plus a flag read. The match itself is an ordered `Type` reference comparison (~a handful of pointer compares for a typical pipeline).

## Parity argument

Outside memoized mode, `HandlerReference.Resolve` is literally `GetRequiredService(HandlerType)` from the dispatching scope's provider — so a plan resolving its participants the same way preserves container semantics for **every** DI lifetime; the one divergent mode (memoized) is excluded by the gate.

## Verification

Build 0 warnings; all suites green on net9.0 + net10.0 (Command.Test 56/56). New tests (`StagedPlanExecutionTests`): staged execution order (`staged→pre→handler→post`), fallback on runtime registration with the newly registered interceptor actually running, fallback on mismatched composition, fallback under `ForceMemoizedHandlers`, and the result-producing variant. One realistic detail the first run surfaced: a runtime registry registration cannot add DI registrations to an already-built provider, so the fallback test provisions the extra interceptor in DI up front and injects it into the pipeline through the registry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
