### PR TITLE
perf: staged plan emission (bespoke pipelines per message)

### DIFF
--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -118,6 +118,9 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                     && HasProviderFactoryOverload(dispatchRoots)
                     && compilation.GetTypeByMetadataName(ServiceProviderExtensionsMetadataName) is not null,
                 HasKeyedServiceExtensions: compilation.GetTypeByMetadataName(KeyedServiceExtensionsMetadataName) is not null,
+                DispatchRootsHasStagedPlans: dispatchRoots is not null
+                    && !dispatchRoots.GetMembers("AddStagedPlan").IsEmpty
+                    && compilation.GetTypeByMetadataName(ServiceProviderExtensionsMetadataName) is not null,
                 HasDescriptorCatalog: compilation.GetTypeByMetadataName(DescriptorCatalogMetadataName) is not null);
         });
 
@@ -519,6 +522,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
             ProviderConstructionExpression = providerConstruction,
             ProviderConstructionUsesKeyedServices = usesKeyedServices,
+            HasPipelineExclusion = HasPipelineExclusionAttribute(symbol),
+            IsValueType = symbol.IsValueType,
+            IsNestedType = symbol.ContainingType is not null,
+            AssignableKeys = isDispatchable ? GetAssignableKeys(symbol) : ImmutableArray<string>.Empty,
+            ContractShapes = isAccessible ? BuildContractShapes(symbol) : ImmutableArray<ContractShapeModel>.Empty,
         };
     }
 
@@ -581,7 +589,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                     continue;
             }
 
-            var model = new DispatchResultModel(VerbatimTypeExpression(iface.TypeArguments[0]), isStream);
+            var model = new DispatchResultModel(
+                VerbatimTypeExpression(iface.TypeArguments[0]), isStream, iface.TypeArguments[0].IsValueType);
 
             results ??= ImmutableArray.CreateBuilder<DispatchResultModel>();
 
@@ -602,6 +611,120 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private static bool IsExcludedFromDiscovery(INamedTypeSymbol symbol)
         => HasExcludeFromDiscovery(symbol.GetAttributes())
            || HasExcludeFromDiscovery(symbol.ContainingAssembly.GetAttributes());
+
+    /// <summary>
+    ///     Whether the type declares <c>[ExcludeFromPipeline]</c>. The attribute shapes the
+    ///     indirect interceptor stages at runtime; staged plans conservatively skip such
+    ///     messages instead of modeling the exclusion.
+    /// </summary>
+    private static bool HasPipelineExclusionAttribute(INamedTypeSymbol symbol)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (attribute.AttributeClass is { Name: "ExcludeFromPipelineAttribute" } attributeClass
+                && IsInNamespace(attributeClass, AttributeNamespace))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     The normalized type expressions of every base type and implemented interface —
+    ///     the compile-time domain of the runtime's <c>IsAssignableTo</c> checks that admit
+    ///     indirect (covariantly registered) interceptors into a message's pipeline.
+    /// </summary>
+    private static ImmutableArray<string> GetAssignableKeys(INamedTypeSymbol symbol)
+    {
+        var keys = ImmutableArray.CreateBuilder<string>();
+
+        for (var baseType = symbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            keys.Add(NormalizedTypeExpression(baseType));
+        }
+
+        foreach (var iface in symbol.AllInterfaces)
+        {
+            keys.Add(NormalizedTypeExpression(iface));
+        }
+
+        return keys.ToImmutable();
+    }
+
+    /// <summary>
+    ///     Collects the raw interceptor contracts the type implements — the undeduped
+    ///     counterpart of <see cref="BuildDescriptors"/>'s interceptor walk, keeping the
+    ///     async/sync and result-typed facts the staged-plan arm selection needs.
+    /// </summary>
+    private static ImmutableArray<ContractShapeModel> BuildContractShapes(INamedTypeSymbol symbol)
+    {
+        for (var current = symbol; current is not null; current = current.ContainingType)
+        {
+            if (current.Arity > 0)
+            {
+                return ImmutableArray<ContractShapeModel>.Empty;
+            }
+        }
+
+        ImmutableArray<ContractShapeModel>.Builder? shapes = null;
+
+        foreach (var iface in symbol.AllInterfaces)
+        {
+            if (iface.Arity is not (1 or 2) || !IsInNamespace(iface, HandlerContractNamespace))
+            {
+                continue;
+            }
+
+            var arguments = iface.TypeArguments;
+
+            ContractShapeModel? shape = iface.Name switch
+            {
+                "IPreInterceptor" when iface.Arity == 1 => new ContractShapeModel(
+                    DescriptorKind.PreInterceptor, IsAsync: false, IsResultTyped: false,
+                    NormalizedTypeExpression(arguments[0]), null),
+                "IAsyncPreInterceptor" when iface.Arity == 1 => new ContractShapeModel(
+                    DescriptorKind.PreInterceptor, IsAsync: true, IsResultTyped: false,
+                    NormalizedTypeExpression(arguments[0]), null),
+                "IPostInterceptor" when iface.Arity == 2 => new ContractShapeModel(
+                    DescriptorKind.PostInterceptor, IsAsync: false, IsResultTyped: true,
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                "IAsyncPostInterceptor" when iface.Arity == 2 => new ContractShapeModel(
+                    DescriptorKind.PostInterceptor, IsAsync: true, IsResultTyped: true,
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                "IAsyncPostInterceptor" when iface.Arity == 1 => new ContractShapeModel(
+                    DescriptorKind.PostInterceptor, IsAsync: true, IsResultTyped: false,
+                    NormalizedTypeExpression(arguments[0]), null),
+                "IExceptionInterceptor" when iface.Arity == 2 => new ContractShapeModel(
+                    DescriptorKind.ExceptionInterceptor, IsAsync: false, IsResultTyped: true,
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                "IAsyncExceptionInterceptor" when iface.Arity == 2 => new ContractShapeModel(
+                    DescriptorKind.ExceptionInterceptor, IsAsync: true, IsResultTyped: true,
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                "IAsyncExceptionInterceptor" when iface.Arity == 1 => new ContractShapeModel(
+                    DescriptorKind.ExceptionInterceptor, IsAsync: true, IsResultTyped: false,
+                    NormalizedTypeExpression(arguments[0]), null),
+                "IFinalInterceptor" when iface.Arity == 2 => new ContractShapeModel(
+                    DescriptorKind.FinalInterceptor, IsAsync: false, IsResultTyped: true,
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                "IAsyncFinalInterceptor" when iface.Arity == 2 => new ContractShapeModel(
+                    DescriptorKind.FinalInterceptor, IsAsync: true, IsResultTyped: true,
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                "IAsyncFinalInterceptor" when iface.Arity == 1 => new ContractShapeModel(
+                    DescriptorKind.FinalInterceptor, IsAsync: true, IsResultTyped: false,
+                    NormalizedTypeExpression(arguments[0]), null),
+                _ => null,
+            };
+
+            if (shape is { } value)
+            {
+                (shapes ??= ImmutableArray.CreateBuilder<ContractShapeModel>()).Add(value);
+            }
+        }
+
+        return shapes?.ToImmutable() ?? ImmutableArray<ContractShapeModel>.Empty;
+    }
 
     private static bool HasExcludeFromDiscovery(ImmutableArray<AttributeData> attributes)
     {
@@ -901,6 +1024,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsDirectlyConstructible = isAccessible && IsDirectlyConstructible(symbol),
             ProviderConstructionExpression = providerConstruction,
             ProviderConstructionUsesKeyedServices = usesKeyedServices,
+            HasPipelineExclusion = HasPipelineExclusionAttribute(symbol),
+            IsValueType = symbol.IsValueType,
+            IsNestedType = symbol.ContainingType is not null,
+            AssignableKeys = isDispatchable ? GetAssignableKeys(symbol) : ImmutableArray<string>.Empty,
+            ContractShapes = isAccessible ? BuildContractShapes(symbol) : ImmutableArray<ContractShapeModel>.Empty,
         };
     }
 
@@ -982,8 +1110,369 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             ? ComputeResultPlans(types)
             : (IReadOnlyList<ResultPlanModel>)Array.Empty<ResultPlanModel>();
 
-        var source = RegistrationEmitter.Emit(types, availability, voidPlans, resultPlans, GeneratorVersion);
+        var stagedPlans = availability.DispatchRootsHasStagedPlans
+            ? ComputeStagedPlans(types)
+            : (IReadOnlyList<StagedPlanModel>)Array.Empty<StagedPlanModel>();
+
+        var source = RegistrationEmitter.Emit(types, availability, voidPlans, resultPlans, stagedPlans, GeneratorVersion);
         context.AddSource("ErgosfareRegistrations.g.cs", SourceText.From(source, Encoding.UTF8));
+    }
+
+    /// <summary>
+    ///     Computes the staged pipeline plans: a dispatchable command (void) or
+    ///     command/query (single closed result) qualifies when its sole discovered handler
+    ///     is the matching async contract AND at least one discovered interceptor
+    ///     participates in its pipeline AND every part of that pipeline could be modeled
+    ///     exactly — the composition (membership and order) replicates the runtime
+    ///     shape-builder, and every call's pattern-match arm is decidable at compile time.
+    ///     Anything unmodelable disqualifies the message rather than risking divergence;
+    ///     the runtime gate then simply never sees a staged plan for it. The plan stays
+    ///     advisory regardless: the hosting executor re-validates the composition per
+    ///     registry version.
+    /// </summary>
+    private static List<StagedPlanModel> ComputeStagedPlans(List<RegistrableTypeModel> types)
+    {
+        CollectPipelineFacts(types, out var handlerCounts, out var soleHandlers, out _);
+
+        var plans = new List<StagedPlanModel>();
+
+        foreach (var type in types)
+        {
+            if (!type.IsDispatchableMessage || type.HasPipelineExclusion)
+            {
+                continue;
+            }
+
+            string? resultTypeExpression = null;
+            var resultIsValueType = false;
+
+            if (type.IsCommand && type.DispatchResults.Length == 0)
+            {
+                // Void pipeline.
+            }
+            else if ((type.IsCommand || type.IsQuery)
+                     && type.DispatchResults.Length == 1
+                     && !type.DispatchResults[0].IsStream)
+            {
+                resultTypeExpression = type.DispatchResults[0].ResultTypeExpression;
+                resultIsValueType = type.DispatchResults[0].ResultIsValueType;
+            }
+            else
+            {
+                continue;
+            }
+
+            // The sole handler gate mirrors the single-handler plans, minus the
+            // interceptor suppression (interceptors are the whole point here).
+            if (!handlerCounts.TryGetValue(type.TypeofExpression, out var count) || count != 1)
+            {
+                continue;
+            }
+
+            var (handler, handlerDescriptor) = soleHandlers[type.TypeofExpression];
+
+            if (!handler.IsAccessible || !handler.DiscoveryKeys.IsEmpty || handler.GroupsExpression is not null)
+            {
+                continue;
+            }
+
+            var expectedHandlerResult = resultTypeExpression is null
+                ? ValueTaskExpression
+                : ValueTaskExpression + "<" + resultTypeExpression + ">";
+
+            if (handlerDescriptor.ResultTypeExpression != expectedHandlerResult
+                || handlerDescriptor.MessageTypeExpression != type.TypeofExpression)
+            {
+                continue;
+            }
+
+            if (!TryAssembleStagedStages(type, types, resultTypeExpression, resultIsValueType,
+                    out var pre, out var post, out var exceptionCalls, out var finalCalls))
+            {
+                continue;
+            }
+
+            if (pre.Length + post.Length + exceptionCalls.Length + finalCalls.Length == 0)
+            {
+                // No interceptors: the single-handler plans already cover this shape.
+                continue;
+            }
+
+            plans.Add(new StagedPlanModel(
+                type.TypeofExpression,
+                resultTypeExpression,
+                resultIsValueType,
+                handler.TypeofExpression,
+                pre, post, exceptionCalls, finalCalls));
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    ///     Assembles the four staged interceptor stages for a message in the runtime
+    ///     shape-builder's exact execution order, or fails when any participant cannot be
+    ///     modeled: grouped/keyed/inaccessible/nested participants, a participant matching
+    ///     through more than one deduped contract registration, a participant with no
+    ///     variance-resolvable arm (the runtime would throw for it), or a reference-typed
+    ///     pipeline result with an inexactly-typed contract (runtime result variance the
+    ///     string model cannot verify).
+    /// </summary>
+    private static bool TryAssembleStagedStages(
+        RegistrableTypeModel message,
+        List<RegistrableTypeModel> types,
+        string? resultTypeExpression,
+        bool resultIsValueType,
+        out ImmutableArray<StagedCallModel> preCalls,
+        out ImmutableArray<StagedCallModel> postCalls,
+        out ImmutableArray<StagedCallModel> exceptionCalls,
+        out ImmutableArray<StagedCallModel> finalCalls)
+    {
+        preCalls = postCalls = exceptionCalls = finalCalls = ImmutableArray<StagedCallModel>.Empty;
+
+        // The pipeline result the arms match against: the declared result for result
+        // pipelines, the ValueTask carrier for void ones (a struct either way unless the
+        // declared result is a reference type).
+        var pipelineResultExpression = resultTypeExpression ?? ValueTaskExpression;
+        var pipelineResultIsValueType = resultTypeExpression is null || resultIsValueType;
+
+        var stages = new List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct)>?[4];
+
+        foreach (var candidate in types)
+        {
+            if (candidate.ContractShapes.IsEmpty)
+            {
+                continue;
+            }
+
+            for (var kindIndex = 0; kindIndex < 4; kindIndex++)
+            {
+                var kind = (DescriptorKind)(kindIndex + 1);
+
+                // Deduped registrations of this candidate that reach the message —
+                // mirrors the descriptor builders' first-wins (message, result) dedupe,
+                // where result-agnostic async contracts carry `object`.
+                string? matchedMessageKey = null;
+                var matchedDirect = false;
+                var registrationCount = 0;
+                HashSet<string>? seenRegistrations = null;
+
+                foreach (var shape in candidate.ContractShapes)
+                {
+                    if (shape.Kind != kind)
+                    {
+                        continue;
+                    }
+
+                    var direct = shape.MessageTypeExpression == message.TypeofExpression;
+
+                    if (!direct && !message.AssignableKeys.Contains(shape.MessageTypeExpression))
+                    {
+                        continue;
+                    }
+
+                    var dedupeKey = shape.MessageTypeExpression + "\x1f"
+                        + (kind == DescriptorKind.PreInterceptor
+                            ? string.Empty
+                            : shape.IsResultTyped ? shape.ResultTypeExpression : "object");
+
+                    if ((seenRegistrations ??= new HashSet<string>(StringComparer.Ordinal)).Add(dedupeKey))
+                    {
+                        registrationCount++;
+                        matchedMessageKey = shape.MessageTypeExpression;
+                        matchedDirect = direct;
+                    }
+                }
+
+                if (registrationCount == 0)
+                {
+                    continue;
+                }
+
+                // More than one registration would put the type into the stage more than
+                // once; the order among them is not worth modeling — disqualify.
+                if (registrationCount > 1)
+                {
+                    return false;
+                }
+
+                // Participation established. The participant itself must be modelable.
+                if (!candidate.IsAccessible
+                    || !candidate.DiscoveryKeys.IsEmpty
+                    || candidate.GroupsExpression is not null
+                    || candidate.IsNestedType)
+                {
+                    return false;
+                }
+
+                if (!TrySelectArm(candidate, kind, message, pipelineResultExpression, pipelineResultIsValueType,
+                        out var arm))
+                {
+                    return false;
+                }
+
+                (stages[kindIndex] ??= []).Add((candidate, arm, matchedDirect));
+                _ = matchedMessageKey;
+            }
+        }
+
+        preCalls = OrderStage(stages[0]);
+        postCalls = OrderStage(stages[1]);
+        exceptionCalls = OrderStage(stages[2]);
+        finalCalls = OrderStage(stages[3]);
+        return true;
+    }
+
+    /// <summary>
+    ///     Selects the pattern-match arm the runtime invoker would take for the
+    ///     interceptor, or fails when none resolves (the runtime would throw
+    ///     <c>NotSupportedException</c> — the strategy fallback preserves that) or when a
+    ///     reference-typed pipeline result meets an inexactly-typed contract (possible
+    ///     runtime result variance the string model cannot decide).
+    /// </summary>
+    private static bool TrySelectArm(
+        RegistrableTypeModel candidate,
+        DescriptorKind kind,
+        RegistrableTypeModel message,
+        string pipelineResultExpression,
+        bool pipelineResultIsValueType,
+        out StagedCallArm arm)
+    {
+        arm = default;
+
+        var hasAsyncTyped = false;
+        var hasAsyncAgnostic = false;
+        var hasSync = false;
+
+        foreach (var shape in candidate.ContractShapes)
+        {
+            if (shape.Kind != kind)
+            {
+                continue;
+            }
+
+            // Message-side variance: exact match always works; a base/interface
+            // registration matches only for reference-typed messages.
+            var messageMatches = shape.MessageTypeExpression == message.TypeofExpression
+                || (!message.IsValueType && message.AssignableKeys.Contains(shape.MessageTypeExpression));
+
+            if (!messageMatches)
+            {
+                continue;
+            }
+
+            if (shape.IsResultTyped)
+            {
+                // Exact result match always works. An `object`-typed contract (the
+                // flavored marker interfaces' shape) matches any reference-typed result
+                // through the runtime's `in TResult` variance; value-typed results have
+                // no variance, so the contract is simply invisible to the pattern match.
+                if (shape.ResultTypeExpression == pipelineResultExpression
+                    || (!pipelineResultIsValueType && shape.ResultTypeExpression == "object"))
+                {
+                    if (shape.IsAsync)
+                    {
+                        hasAsyncTyped = true;
+                    }
+                    else
+                    {
+                        hasSync = true;
+                    }
+                }
+                else if (!pipelineResultIsValueType)
+                {
+                    // Any other base-of relationship the variance could admit is
+                    // undecidable in the string model — disqualify.
+                    return false;
+                }
+            }
+            else if (shape.IsAsync)
+            {
+                hasAsyncAgnostic = true;
+            }
+            else
+            {
+                // Sync pre carries no result typing.
+                hasSync = true;
+            }
+        }
+
+        if (kind == DescriptorKind.PreInterceptor)
+        {
+            if (hasAsyncAgnostic)
+            {
+                arm = StagedCallArm.AsyncAgnostic;
+                return true;
+            }
+
+            if (hasSync)
+            {
+                arm = StagedCallArm.Sync;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (hasAsyncTyped)
+        {
+            arm = StagedCallArm.AsyncTyped;
+            return true;
+        }
+
+        if (hasAsyncAgnostic)
+        {
+            arm = StagedCallArm.AsyncAgnostic;
+            return true;
+        }
+
+        if (hasSync)
+        {
+            arm = StagedCallArm.Sync;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Orders one staged stage exactly like the runtime shape builder: the direct
+    ///     segment first, then the indirect one, each sorted by weight descending with the
+    ///     type name as the ordinal tie-break (participants are non-nested and
+    ///     non-generic, so the display name equals the runtime <c>Type.FullName</c>).
+    /// </summary>
+    private static ImmutableArray<StagedCallModel> OrderStage(
+        List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct)>? entries)
+    {
+        if (entries is null)
+        {
+            return ImmutableArray<StagedCallModel>.Empty;
+        }
+
+        entries.Sort(static (x, y) =>
+        {
+            var bySegment = y.Direct.CompareTo(x.Direct);
+
+            if (bySegment != 0)
+            {
+                return bySegment;
+            }
+
+            var byWeight = y.Type.Weight.CompareTo(x.Type.Weight);
+
+            return byWeight != 0
+                ? byWeight
+                : string.CompareOrdinal(x.Type.DisplayName, y.Type.DisplayName);
+        });
+
+        var calls = ImmutableArray.CreateBuilder<StagedCallModel>(entries.Count);
+
+        foreach (var (type, arm, _) in entries)
+        {
+            calls.Add(new StagedCallModel(type.TypeofExpression, arm));
+        }
+
+        return calls.MoveToImmutable();
     }
 
     /// <summary>

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ContractShapeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ContractShapeModel.cs
@@ -1,0 +1,19 @@
+namespace Stella.Ergosfare.SourceGenerator.Models;
+
+/// <summary>
+///     One raw interceptor contract a type implements — the undeduped counterpart of
+///     <see cref="DescriptorModel"/>, keeping the async/sync and result-typed/agnostic
+///     facts the staged-plan emission needs to reproduce the invocation strategies'
+///     pattern-match arm selection at compile time.
+/// </summary>
+/// <param name="Kind">The interceptor stage the contract belongs to; never <see cref="DescriptorKind.MainHandler"/>.</param>
+/// <param name="IsAsync">Whether the contract is the asynchronous flavor.</param>
+/// <param name="IsResultTyped">Whether the contract carries a typed result parameter (arity-2 for post/exception/final).</param>
+/// <param name="MessageTypeExpression">The contract's registered message type, normalized like descriptor message types.</param>
+/// <param name="ResultTypeExpression">The declared result type for result-typed contracts, <c>null</c> otherwise.</param>
+internal readonly record struct ContractShapeModel(
+    DescriptorKind Kind,
+    bool IsAsync,
+    bool IsResultTyped,
+    string MessageTypeExpression,
+    string? ResultTypeExpression);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/DispatchResultModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/DispatchResultModel.cs
@@ -7,6 +7,11 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// </summary>
 /// <param name="ResultTypeExpression">Fully qualified expression of the closed result type.</param>
 /// <param name="IsStream">Whether the root feeds the streaming dispatch path.</param>
+/// <param name="ResultIsValueType">
+/// Whether the result is a value type — staged emission mirrors the runtime's erased
+/// generic cast semantics, which differ between value and reference results.
+/// </param>
 internal readonly record struct DispatchResultModel(
     string ResultTypeExpression,
-    bool IsStream);
+    bool IsStream,
+    bool ResultIsValueType);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -36,6 +36,10 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     factories for handlers with <c>[FromKeyedServices]</c> parameters; without it such
 ///     handlers keep the factory-less plan form.
 /// </param>
+/// <param name="DispatchRootsHasStagedPlans">
+///     Whether the store exposes <c>AddStagedPlan</c> (staged pipeline plans for
+///     interceptor-bearing messages); older packages simply skip the staged emission.
+/// </param>
 /// <param name="HasDescriptorCatalog">
 ///     Whether <c>GeneratedDescriptorCatalog</c> is resolvable — the lookup that makes
 ///     runtime <c>Register&lt;THandler&gt;()</c> reflection-free for generator-modeled
@@ -56,4 +60,5 @@ internal readonly record struct ModuleBuilderAvailability(
     bool DispatchRootsHasPlanFactories,
     bool DispatchRootsHasProviderPlanFactories,
     bool HasKeyedServiceExtensions,
+    bool DispatchRootsHasStagedPlans,
     bool HasDescriptorCatalog);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -120,6 +120,35 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
     /// </summary>
     public required bool ProviderConstructionUsesKeyedServices { get; init; }
 
+    /// <summary>Whether the type carries <c>[ExcludeFromPipeline]</c>; such messages stay off staged plans.</summary>
+    public required bool HasPipelineExclusion { get; init; }
+
+    /// <summary>Whether the type is a value type — variance never applies to it at runtime.</summary>
+    public required bool IsValueType { get; init; }
+
+    /// <summary>
+    ///     Whether the type is nested in another type. The runtime orders pipeline
+    ///     segments by <c>Type.FullName</c>, whose nested separator (<c>+</c>) sorts
+    ///     differently from the display name's dot — nested participants therefore
+    ///     disqualify staged plans instead of risking a divergent order.
+    /// </summary>
+    public required bool IsNestedType { get; init; }
+
+    /// <summary>
+    ///     For dispatchable messages: the normalized type expressions of every base type
+    ///     and implemented interface — the compile-time domain of the runtime's
+    ///     <c>IsAssignableTo</c> checks that admit indirect (covariant) interceptors.
+    ///     Empty for non-dispatchable types.
+    /// </summary>
+    public required ImmutableArray<string> AssignableKeys { get; init; }
+
+    /// <summary>
+    ///     The raw interceptor contracts the type implements (undeduped), feeding the
+    ///     staged-plan arm selection; see <see cref="ContractShapeModel"/>. Empty for
+    ///     plain messages.
+    /// </summary>
+    public required ImmutableArray<ContractShapeModel> ContractShapes { get; init; }
+
     public bool Equals(RegistrableTypeModel other)
     {
         if (TypeofExpression != other.TypeofExpression
@@ -136,11 +165,32 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
             || IsDirectlyConstructible != other.IsDirectlyConstructible
             || ProviderConstructionExpression != other.ProviderConstructionExpression
             || ProviderConstructionUsesKeyedServices != other.ProviderConstructionUsesKeyedServices
+            || HasPipelineExclusion != other.HasPipelineExclusion
+            || IsValueType != other.IsValueType
+            || IsNestedType != other.IsNestedType
             || Descriptors.Length != other.Descriptors.Length
             || DiscoveryKeys.Length != other.DiscoveryKeys.Length
-            || DispatchResults.Length != other.DispatchResults.Length)
+            || DispatchResults.Length != other.DispatchResults.Length
+            || AssignableKeys.Length != other.AssignableKeys.Length
+            || ContractShapes.Length != other.ContractShapes.Length)
         {
             return false;
+        }
+
+        for (var i = 0; i < AssignableKeys.Length; i++)
+        {
+            if (!string.Equals(AssignableKeys[i], other.AssignableKeys[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        for (var i = 0; i < ContractShapes.Length; i++)
+        {
+            if (!ContractShapes[i].Equals(other.ContractShapes[i]))
+            {
+                return false;
+            }
         }
 
         for (var i = 0; i < Descriptors.Length; i++)

--- a/src/Stella.Ergosfare.SourceGenerator/Models/StagedPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/StagedPlanModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.Immutable;
+
+namespace Stella.Ergosfare.SourceGenerator.Models;
+
+/// <summary>
+///     The pattern-match arm the runtime invocation strategy would select for one staged
+///     interceptor call — determined at compile time from the interceptor's implemented
+///     contracts, so the emitted call invokes exactly the member the strategy would.
+/// </summary>
+internal enum StagedCallArm : byte
+{
+    /// <summary>The result-typed asynchronous contract (first arm of the runtime pattern match).</summary>
+    AsyncTyped,
+
+    /// <summary>The result-agnostic asynchronous contract (second arm; also the sole async pre arm).</summary>
+    AsyncAgnostic,
+
+    /// <summary>The synchronous contract (last arm).</summary>
+    Sync,
+}
+
+/// <summary>One staged interceptor call: the concrete type to resolve and the arm to invoke it through.</summary>
+internal readonly record struct StagedCallModel(string TypeExpression, StagedCallArm Arm);
+
+/// <summary>
+///     A staged pipeline plan ready for emission: a message whose whole discovered
+///     pipeline — one async handler plus at least one interceptor stage — could be
+///     modeled exactly, with every stage in the runtime shape-builder's execution order
+///     (direct first, then indirect, each segment weight-descending then ordinal by type
+///     name) and every call's pattern-match arm resolved at compile time. Advisory like
+///     every plan: the hosting executor re-validates the baked composition per registry
+///     version and falls back to the runtime strategy on any mismatch.
+/// </summary>
+internal sealed record StagedPlanModel(
+    string MessageTypeExpression,
+    string? ResultTypeExpression,
+    bool ResultIsValueType,
+    string HandlerTypeExpression,
+    ImmutableArray<StagedCallModel> PreCalls,
+    ImmutableArray<StagedCallModel> PostCalls,
+    ImmutableArray<StagedCallModel> ExceptionCalls,
+    ImmutableArray<StagedCallModel> FinalCalls);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -43,6 +43,7 @@ internal static class RegistrationEmitter
         ModuleBuilderAvailability builders,
         IReadOnlyList<VoidPlanModel> voidPlans,
         IReadOnlyList<ResultPlanModel> resultPlans,
+        IReadOnlyList<StagedPlanModel> stagedPlans,
         string generatorVersion)
     {
         var useDescriptors = builders.HasDescriptorFactory;
@@ -100,10 +101,12 @@ internal static class RegistrationEmitter
 
         if (emitDispatchRoots)
         {
-            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans, resultPlans,
+            EmitDispatchRoots(sb, ref wroteMember, types, voidPlans, resultPlans, stagedPlans,
                 builders.DispatchRootsHasPlanFactories,
                 builders.DispatchRootsHasProviderPlanFactories,
                 builders.HasKeyedServiceExtensions);
+
+            EmitStagedPlanClasses(sb, ref wroteMember, stagedPlans);
         }
 
         if (builders.HasDescriptorCatalog && useDescriptors && HasDescriptors(types))
@@ -255,6 +258,7 @@ internal static class RegistrationEmitter
         IReadOnlyList<RegistrableTypeModel> types,
         IReadOnlyList<VoidPlanModel> voidPlans,
         IReadOnlyList<ResultPlanModel> resultPlans,
+        IReadOnlyList<StagedPlanModel> stagedPlans,
         bool emitPlanFactories,
         bool emitProviderPlanFactories,
         bool hasKeyedServiceExtensions)
@@ -317,7 +321,409 @@ internal static class RegistrationEmitter
             sb.AppendLine(");");
         }
 
+        // Staged plans: bespoke straight-line pipelines for interceptor-bearing messages,
+        // emitted as sealed plan classes below. Advisory like every plan — the hosting
+        // executor re-validates the baked composition per registry version.
+        for (var i = 0; i < stagedPlans.Count; i++)
+        {
+            var plan = stagedPlans[i];
+
+            sb.Append("            ").Append(DispatchRootsFullName)
+              .Append(".AddStagedPlan<").Append(plan.MessageTypeExpression);
+
+            if (plan.ResultTypeExpression is not null)
+            {
+                sb.Append(", ").Append(plan.ResultTypeExpression);
+            }
+
+            sb.Append(">(new StagedPlan").Append(i).AppendLine("());");
+        }
+
         sb.AppendLine("        }");
+    }
+
+    private const string HandlersNamespace = "global::Stella.Ergosfare.Core.Abstractions.Handlers.";
+    private const string StagedCompositionFullName = "global::Stella.Ergosfare.Core.Abstractions.StagedPlanComposition";
+    private const string ExecutionContextFullName = "global::Stella.Ergosfare.Core.Abstractions.IExecutionContext";
+    private const string AbortedExceptionFullName = "global::Stella.Ergosfare.Core.Abstractions.Exceptions.ExecutionAbortedException";
+    private const string ValueTaskFullName = "global::System.Threading.Tasks.ValueTask";
+    private const string GetRequiredServiceFullName = "global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService";
+
+    /// <summary>
+    ///     Emits one sealed plan class per staged plan: the baked composition plus a
+    ///     bespoke <c>Execute</c> reproducing the runtime strategy's semantics exactly for
+    ///     the baked pipeline — pre stages in order (each may rewrite the message), the
+    ///     handler, post stages with result rewrite, exception stages (skipped for
+    ///     <c>ExecutionAbortedException</c>, swallowing the exception once they ran, like
+    ///     the strategy), and final stages that always run. Casts mirror the strategy and
+    ///     invoker code shapes, including the erased-generic unbox semantics for
+    ///     value-typed results. Participants resolve from the dispatching provider — what
+    ///     the runtime references do outside memoized mode, which the hosting executor's
+    ///     gate excludes.
+    /// </summary>
+    private static void EmitStagedPlanClasses(
+        StringBuilder sb,
+        ref bool wroteMember,
+        IReadOnlyList<StagedPlanModel> stagedPlans)
+    {
+        for (var i = 0; i < stagedPlans.Count; i++)
+        {
+            var plan = stagedPlans[i];
+            var isVoid = plan.ResultTypeExpression is null;
+
+            StartMember(sb, ref wroteMember);
+            sb.Append("        private sealed class StagedPlan").Append(i).Append(" : global::Stella.Ergosfare.Core.Abstractions.");
+
+            if (isVoid)
+            {
+                sb.Append("StagedVoidPlan<").Append(plan.MessageTypeExpression).AppendLine(">");
+            }
+            else
+            {
+                sb.Append("StagedResultPlan<").Append(plan.MessageTypeExpression)
+                  .Append(", ").Append(plan.ResultTypeExpression).AppendLine(">");
+            }
+
+            sb.AppendLine("        {");
+
+            if (isVoid)
+            {
+                sb.Append("            private static readonly object CompletedVoidResult = default(")
+                  .Append(ValueTaskFullName).AppendLine(");");
+                sb.AppendLine();
+            }
+
+            sb.Append("            private static readonly ").Append(StagedCompositionFullName)
+              .Append(" BakedComposition = new ").Append(StagedCompositionFullName).AppendLine("(");
+            sb.Append("                typeof(").Append(plan.HandlerTypeExpression).AppendLine("),");
+            AppendCompositionStage(sb, plan.PreCalls);
+            sb.AppendLine(",");
+            AppendCompositionStage(sb, plan.PostCalls);
+            sb.AppendLine(",");
+            AppendCompositionStage(sb, plan.ExceptionCalls);
+            sb.AppendLine(",");
+            AppendCompositionStage(sb, plan.FinalCalls);
+            sb.AppendLine(");");
+            sb.AppendLine();
+            sb.Append("            public override ").Append(StagedCompositionFullName).AppendLine(" Composition");
+            sb.AppendLine("            {");
+            sb.AppendLine("                get { return BakedComposition; }");
+            sb.AppendLine("            }");
+            sb.AppendLine();
+
+            sb.Append("            public override async ").Append(ValueTaskFullName);
+
+            if (!isVoid)
+            {
+                sb.Append('<').Append(plan.ResultTypeExpression).Append('>');
+            }
+
+            sb.AppendLine(" Execute(");
+            sb.Append("                ").Append(plan.MessageTypeExpression).AppendLine(" message,");
+            sb.Append("                ").Append(ExecutionContextFullName).AppendLine(" context,");
+            sb.AppendLine("                global::System.IServiceProvider serviceProvider)");
+            sb.AppendLine("            {");
+
+            if (isVoid)
+            {
+                EmitVoidExecuteBody(sb, plan);
+            }
+            else
+            {
+                EmitResultExecuteBody(sb, plan);
+            }
+
+            sb.AppendLine("            }");
+            sb.AppendLine("        }");
+        }
+    }
+
+    private static void AppendCompositionStage(StringBuilder sb, System.Collections.Immutable.ImmutableArray<StagedCallModel> calls)
+    {
+        if (calls.IsEmpty)
+        {
+            sb.Append("                global::System.Array.Empty<global::System.Type>()");
+            return;
+        }
+
+        sb.Append("                new global::System.Type[] { ");
+
+        for (var i = 0; i < calls.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append("typeof(").Append(calls[i].TypeExpression).Append(')');
+        }
+
+        sb.Append(" }");
+    }
+
+    private static void AppendResolve(StringBuilder sb, string typeExpression)
+        => sb.Append(GetRequiredServiceFullName).Append('<').Append(typeExpression).Append(">(serviceProvider)");
+
+    /// <summary>The strategy/invoker-parity cast of the chained object result back to the pipeline result type.</summary>
+    private static string ResultCast(string resultExpression, bool resultIsValueType, string operand)
+        => resultIsValueType
+            ? "(" + resultExpression + ")" + operand + "!"
+            : "(" + resultExpression + "?)" + operand;
+
+    private static void EmitPreCalls(StringBuilder sb, StagedPlanModel plan, string indent)
+    {
+        foreach (var call in plan.PreCalls)
+        {
+            sb.Append(indent).Append("message = (").Append(plan.MessageTypeExpression).Append(") ");
+
+            if (call.Arm == StagedCallArm.Sync)
+            {
+                sb.Append("((").Append(HandlersNamespace).Append("IPreInterceptor<").Append(plan.MessageTypeExpression).Append(">)");
+                AppendResolve(sb, call.TypeExpression);
+                sb.AppendLine(").Handle(message, context);");
+            }
+            else
+            {
+                sb.Append("await ((").Append(HandlersNamespace).Append("IAsyncPreInterceptor<").Append(plan.MessageTypeExpression).Append(">)");
+                AppendResolve(sb, call.TypeExpression);
+                sb.AppendLine(").HandleAsync(message, context);");
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Emits one interceptor-chain call for a result-carrying stage, rewriting the
+    ///     given object-typed chain variable exactly as the runtime invoker loop does.
+    /// </summary>
+    private static void EmitChainCall(
+        StringBuilder sb,
+        StagedPlanModel plan,
+        StagedCallModel call,
+        string stageInterface,
+        string chainVariable,
+        string? exceptionArgument,
+        string indent)
+    {
+        var pipelineResult = plan.ResultTypeExpression ?? ValueTaskFullName;
+        var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
+        var extraArgument = exceptionArgument is null ? string.Empty : ", " + exceptionArgument;
+
+        sb.Append(indent).Append(chainVariable).Append(" = ");
+
+        switch (call.Arm)
+        {
+            case StagedCallArm.AsyncTyped:
+                sb.Append("await ((").Append(HandlersNamespace).Append("IAsync").Append(stageInterface)
+                  .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
+                AppendResolve(sb, call.TypeExpression);
+                sb.Append(").HandleAsync(message, ")
+                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
+                  .Append(extraArgument).AppendLine(", context);");
+                break;
+            case StagedCallArm.AsyncAgnostic:
+                sb.Append("await ((").Append(HandlersNamespace).Append("IAsync").Append(stageInterface)
+                  .Append('<').Append(plan.MessageTypeExpression).Append(">)");
+                AppendResolve(sb, call.TypeExpression);
+                sb.Append(").HandleAsync(message, ").Append(chainVariable)
+                  .Append(exceptionArgument is null ? "!" : string.Empty)
+                  .Append(extraArgument).AppendLine(", context);");
+                break;
+            default:
+                sb.Append("((").Append(HandlersNamespace).Append('I').Append(stageInterface)
+                  .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
+                AppendResolve(sb, call.TypeExpression);
+                sb.Append(").Handle(message, ")
+                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
+                  .Append(extraArgument).AppendLine(", context);");
+                break;
+        }
+    }
+
+    private static void EmitFinalCalls(StringBuilder sb, StagedPlanModel plan, string resultExpressionText, string indent)
+    {
+        var pipelineResult = plan.ResultTypeExpression ?? ValueTaskFullName;
+        var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
+
+        foreach (var call in plan.FinalCalls)
+        {
+            switch (call.Arm)
+            {
+                case StagedCallArm.AsyncTyped:
+                    sb.Append(indent).Append("await ((").Append(HandlersNamespace).Append("IAsyncFinalInterceptor<")
+                      .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
+                    AppendResolve(sb, call.TypeExpression);
+                    sb.Append(").HandleAsync(message, ")
+                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
+                      .AppendLine(", exception, context);");
+                    break;
+                case StagedCallArm.AsyncAgnostic:
+                    sb.Append(indent).Append("await ((").Append(HandlersNamespace).Append("IAsyncFinalInterceptor<")
+                      .Append(plan.MessageTypeExpression).Append(">)");
+                    AppendResolve(sb, call.TypeExpression);
+                    sb.Append(").HandleAsync(message, ").Append(resultExpressionText).AppendLine(", exception, context);");
+                    break;
+                default:
+                    sb.Append(indent).Append("((").Append(HandlersNamespace).Append("IFinalInterceptor<")
+                      .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
+                    AppendResolve(sb, call.TypeExpression);
+                    sb.Append(").Handle(message, ")
+                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
+                      .AppendLine(", exception, context);");
+                    break;
+            }
+        }
+    }
+
+    private static void EmitVoidExecuteBody(StringBuilder sb, StagedPlanModel plan)
+    {
+        var needsResult = !plan.PostCalls.IsEmpty || !plan.ExceptionCalls.IsEmpty || !plan.FinalCalls.IsEmpty;
+        var needsGuards = needsResult;
+
+        if (!needsGuards)
+        {
+            // Pre-only pipeline: with zero exception and final stages the strategy's
+            // try/catch/finally is a no-op shell — exceptions propagate unchanged.
+            EmitPreCalls(sb, plan, "                ");
+            sb.Append("                await ");
+            AppendResolve(sb, plan.HandlerTypeExpression);
+            sb.AppendLine(".HandleAsync(message, context);");
+            return;
+        }
+
+        sb.AppendLine("                object? result = null;");
+        sb.AppendLine("                global::System.Exception? exception = null;");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        EmitPreCalls(sb, plan, "                    ");
+        sb.Append("                    await ");
+        AppendResolve(sb, plan.HandlerTypeExpression);
+        sb.AppendLine(".HandleAsync(message, context);");
+        sb.AppendLine("                    result = CompletedVoidResult;");
+
+        if (!plan.PostCalls.IsEmpty)
+        {
+            foreach (var call in plan.PostCalls)
+            {
+                EmitChainCall(sb, plan, call, "PostInterceptor", "result", null, "                    ");
+            }
+
+            // The strategy's post epilogue: a null post result restores the completed
+            // task; anything non-ValueTask fails the closed nullable cast, exactly like
+            // the strategy's own cast would.
+            sb.Append("                    var invokedPostResult = (").Append(ValueTaskFullName).AppendLine("?) result;");
+            sb.AppendLine("                    result = invokedPostResult == null ? CompletedVoidResult : result;");
+        }
+
+        sb.AppendLine("                }");
+        sb.Append("                catch (global::System.Exception e) when (e is not ").Append(AbortedExceptionFullName).AppendLine(")");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    exception = e;");
+
+        if (plan.ExceptionCalls.IsEmpty)
+        {
+            sb.AppendLine("                    throw;");
+        }
+        else
+        {
+            sb.AppendLine("                    var resultBeforeExceptions = result;");
+
+            foreach (var call in plan.ExceptionCalls)
+            {
+                EmitChainCall(sb, plan, call, "ExceptionInterceptor", "result", "e", "                    ");
+            }
+
+            sb.Append("                    var invokedExceptionResult = (").Append(ValueTaskFullName).AppendLine("?) result;");
+            sb.AppendLine("                    result = invokedExceptionResult == null ? resultBeforeExceptions : result;");
+        }
+
+        sb.AppendLine("                }");
+        sb.AppendLine("                finally");
+        sb.AppendLine("                {");
+        EmitFinalCalls(sb, plan, "result", "                    ");
+        sb.AppendLine("                }");
+    }
+
+    private static void EmitResultExecuteBody(StringBuilder sb, StagedPlanModel plan)
+    {
+        var resultExpression = plan.ResultTypeExpression!;
+        var needsGuards = !plan.PostCalls.IsEmpty || !plan.ExceptionCalls.IsEmpty || !plan.FinalCalls.IsEmpty;
+
+        if (!needsGuards)
+        {
+            EmitPreCalls(sb, plan, "                ");
+            sb.Append("                return await ");
+            AppendResolve(sb, plan.HandlerTypeExpression);
+            sb.AppendLine(".HandleAsync(message, context);");
+            return;
+        }
+
+        sb.Append("                ").Append(resultExpression).AppendLine(" result = default!;");
+        sb.AppendLine("                global::System.Exception? exception = null;");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        EmitPreCalls(sb, plan, "                    ");
+        sb.Append("                    result = await ");
+        AppendResolve(sb, plan.HandlerTypeExpression);
+        sb.AppendLine(".HandleAsync(message, context);");
+
+        if (!plan.PostCalls.IsEmpty)
+        {
+            sb.AppendLine("                    object? postChain = result;");
+
+            foreach (var call in plan.PostCalls)
+            {
+                EmitChainCall(sb, plan, call, "PostInterceptor", "postChain", null, "                    ");
+            }
+
+            if (plan.ResultIsValueType)
+            {
+                // The strategy's erased (TResult?) cast is a plain unbox for value-typed
+                // results — a null post result throws there, so no null branch exists.
+                sb.Append("                    result = (").Append(resultExpression).AppendLine(") postChain!;");
+            }
+            else
+            {
+                sb.Append("                    var postResult = (").Append(resultExpression).AppendLine("?) postChain;");
+                sb.AppendLine("                    result = postResult == null ? result : postResult;");
+            }
+        }
+
+        sb.AppendLine("                }");
+        sb.Append("                catch (global::System.Exception e) when (e is not ").Append(AbortedExceptionFullName).AppendLine(")");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    exception = e;");
+
+        if (plan.ExceptionCalls.IsEmpty)
+        {
+            sb.AppendLine("                    throw;");
+        }
+        else
+        {
+            sb.AppendLine("                    object? exceptionChain = result;");
+
+            foreach (var call in plan.ExceptionCalls)
+            {
+                EmitChainCall(sb, plan, call, "ExceptionInterceptor", "exceptionChain", "e", "                    ");
+            }
+
+            if (plan.ResultIsValueType)
+            {
+                sb.Append("                    result = (").Append(resultExpression).AppendLine(") exceptionChain!;");
+            }
+            else
+            {
+                sb.Append("                    var exceptionResult = (").Append(resultExpression).AppendLine("?) exceptionChain;");
+                sb.AppendLine("                    result = exceptionResult == null ? result : exceptionResult;");
+            }
+        }
+
+        sb.AppendLine("                }");
+        sb.AppendLine("                finally");
+        sb.AppendLine("                {");
+        EmitFinalCalls(sb, plan, "result", "                    ");
+        sb.AppendLine("                }");
+        sb.AppendLine();
+        sb.AppendLine("                return result;");
     }
 
     /// <summary>

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -313,7 +313,8 @@ public class MediationBenchmark
     /// void pipeline plans process-wide, and the targeted setup keeps that installation
     /// away from the runtime-registration rows' processes so the comparison stays honest.
     /// </summary>
-    [GlobalSetup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
+    [GlobalSetup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated),
+        nameof(Command_Void_Intercepted_Generated), nameof(Query_Result_Intercepted_Generated)])]
     public void SetupGenerated()
     {
         _ergosfareGenerated = new ServiceCollection()
@@ -328,7 +329,8 @@ public class MediationBenchmark
         _generatedQueries = _ergosfareGenerated.GetRequiredService<IQueryMediator>();
     }
 
-    [GlobalCleanup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
+    [GlobalCleanup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated),
+        nameof(Command_Void_Intercepted_Generated), nameof(Query_Result_Intercepted_Generated)])]
     public void CleanupGenerated()
     {
         _ergosfareGenerated.Dispose();
@@ -400,6 +402,18 @@ public class MediationBenchmark
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask<int> Query_Result_Generated() => _generatedQueries.QueryAsync(_intQuery);
+
+    /// <summary>
+    /// The staged-plan lane: the same interceptor-bearing pipelines as the
+    /// <c>*_Intercepted</c> rows, dispatched through the generated provider whose
+    /// <c>RegisterGenerated</c> installed bespoke staged plans — the strategy machinery
+    /// those baseline rows pay for is replaced by straight-line emitted code.
+    /// </summary>
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask Command_Void_Intercepted_Generated() => _generatedCommands.SendAsync(_interceptedCommand);
+
+    [Benchmark, BenchmarkCategory("Root")]
+    public ValueTask<int> Query_Result_Intercepted_Generated() => _generatedQueries.QueryAsync(_interceptedIntQuery);
 
     [Benchmark, BenchmarkCategory("Root")]
     public ValueTask Command_Void_Grouped() => _commands.SendAsync(_groupedCommand, _groupedCommandSettings);

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
@@ -1,0 +1,202 @@
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+/// Staged pipeline plan emission: an interceptor-bearing message whose whole pipeline is
+/// modelable gets a bespoke sealed plan class plus an <c>AddStagedPlan</c> root; anything
+/// unmodelable — grouped participants, <c>[ExcludeFromPipeline]</c> messages — keeps the
+/// message off the staged store, where the runtime strategy serves it as before.
+/// </summary>
+public class StagedPlanEmissionTests
+{
+    [Fact]
+    public void InterceptedSoloHandler_EmitsTheStagedPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record StagedPing : ICommand;
+
+                public sealed class StagedPingHandler : ICommandHandler<StagedPing>
+                {
+                    public ValueTask HandleAsync(StagedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class StagedPingInterceptor : ICommandPreInterceptor<StagedPing>
+                {
+                    public ValueTask<StagedPing> HandleAsync(StagedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+
+        // The interceptor suppresses the single-handler plan and produces the staged one.
+        Assert.DoesNotContain("AddVoidPlan<global::TestApp.StagedPing", result.GeneratedSource);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddStagedPlan<global::TestApp.StagedPing>(new StagedPlan0());",
+            result.GeneratedSource);
+        Assert.Contains("typeof(global::TestApp.StagedPingHandler)", result.GeneratedSource);
+        Assert.Contains(
+            "message = (global::TestApp.StagedPing) await ((global::Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<global::TestApp.StagedPing>)",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void WeightAndSegmentOrdering_BakesTheRuntimeOrder()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record OrderedPing : ICommand;
+
+                public sealed class OrderedPingHandler : ICommandHandler<OrderedPing>
+                {
+                    public ValueTask HandleAsync(OrderedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                // Direct segment: weight descending, then ordinal type name.
+                public sealed class LightInterceptor : ICommandPreInterceptor<OrderedPing>
+                {
+                    public ValueTask<OrderedPing> HandleAsync(OrderedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+
+                [Weight(5)]
+                public sealed class HeavyInterceptor : ICommandPreInterceptor<OrderedPing>
+                {
+                    public ValueTask<OrderedPing> HandleAsync(OrderedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+
+                // Indirect segment (registered for the marker interface): always after the
+                // direct segment regardless of weight.
+                [Weight(9)]
+                public sealed class BroadInterceptor : ICommandPreInterceptor
+                {
+                    public ValueTask<object> HandleAsync(ICommand message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult<object>(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "new global::System.Type[] { typeof(global::TestApp.HeavyInterceptor), typeof(global::TestApp.LightInterceptor), typeof(global::TestApp.BroadInterceptor) }",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void GroupedInterceptor_SuppressesTheStagedPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record GroupedStagedPing : ICommand;
+
+                public sealed class GroupedStagedPingHandler : ICommandHandler<GroupedStagedPing>
+                {
+                    public ValueTask HandleAsync(GroupedStagedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                [Group("reporting")]
+                public sealed class GroupedStagedPingInterceptor : ICommandPreInterceptor<GroupedStagedPing>
+                {
+                    public ValueTask<GroupedStagedPing> HandleAsync(GroupedStagedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // A grouped participant makes the group-less pipeline content unmodelable-enough:
+        // conservatively no staged plan (and the interceptor also suppresses the
+        // single-handler plan) — the runtime strategy serves the message.
+        Assert.DoesNotContain("AddStagedPlan<global::TestApp.GroupedStagedPing", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ResultPipeline_EmitsTheStagedResultPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Queries.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record StagedNumberQuery : IQuery<int>;
+
+                public sealed class StagedNumberQueryHandler : IQueryHandler<StagedNumberQuery, int>
+                {
+                    public ValueTask<int> HandleAsync(StagedNumberQuery message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(7);
+                }
+
+                public sealed class StagedNumberQueryPostInterceptor : IQueryPostInterceptor<StagedNumberQuery, int>
+                {
+                    public ValueTask<int> HandleAsync(StagedNumberQuery query, int queryResult, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(queryResult);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(
+            "GeneratedDispatchRoots.AddStagedPlan<global::TestApp.StagedNumberQuery, int>(new StagedPlan0());",
+            result.GeneratedSource);
+
+        // The typed async post arm with the value-typed result's unbox-parity casts.
+        Assert.Contains(
+            "postChain = await ((global::Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<global::TestApp.StagedNumberQuery, int>)",
+            result.GeneratedSource);
+        Assert.Contains("result = (int) postChain!;", result.GeneratedSource);
+        Assert.Contains("return result;", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void ExcludeFromPipelineMessage_SuppressesTheStagedPlan()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using Stella.Ergosfare.Core.Abstractions.Attributes;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                [ExcludeFromPipeline]
+                public sealed record ShieldedPing : ICommand;
+
+                public sealed class ShieldedPingHandler : ICommandHandler<ShieldedPing>
+                {
+                    public ValueTask HandleAsync(ShieldedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class ShieldedPingInterceptor : ICommandPreInterceptor<ShieldedPing>
+                {
+                    public ValueTask<ShieldedPing> HandleAsync(ShieldedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.DoesNotContain("AddStagedPlan<global::TestApp.ShieldedPing", result.GeneratedSource);
+    }
+}

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
@@ -1,0 +1,323 @@
+using System.Reflection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.SourceGenerator.Test;
+
+/// <summary>
+/// Strategy-parity matrix for the emitted staged plans, executed end to end: the app
+/// source below compiles with the generator, the emitted assembly loads into the test
+/// process (it shares the real Ergosfare assemblies), its <c>RegisterGenerated</c> wires a
+/// real container, and dispatches run through the public mediators. Covered: message
+/// rewrite by pre-interceptors, execution order across stages, post result rewrite,
+/// exception capture with strategy-identical swallowing, propagation without exception
+/// interceptors, <c>ExecutionAbortedException</c> skipping the exception stage while
+/// finals still run, and finals observing the outcome. Participants log into a static
+/// sink inside the emitted assembly, read back reflectively.
+/// </summary>
+public class StagedPlanExecutionParityTests
+{
+    private const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Stella.Ergosfare.Commands.Abstractions;
+        using Stella.Ergosfare.Core.Abstractions;
+        using Stella.Ergosfare.Queries.Abstractions;
+
+        namespace TestApp
+        {
+            public static class Sink
+            {
+                public static readonly List<string> Entries = new List<string>();
+            }
+
+            // --- happy path: rewrite + order -------------------------------------
+
+            public sealed class GenHappyCommand : ICommand
+            {
+                public string Tag { get; set; } = "original";
+            }
+
+            public sealed class GenHappyCommandHandler : ICommandHandler<GenHappyCommand>
+            {
+                public ValueTask HandleAsync(GenHappyCommand command, IExecutionContext context)
+                {
+                    Sink.Entries.Add("handler:" + command.Tag);
+                    return default;
+                }
+            }
+
+            public sealed class GenHappyCommandPre : ICommandPreInterceptor<GenHappyCommand>
+            {
+                public ValueTask<GenHappyCommand> HandleAsync(GenHappyCommand command, IExecutionContext context)
+                {
+                    Sink.Entries.Add("pre:" + command.Tag);
+                    return ValueTask.FromResult(new GenHappyCommand { Tag = "rewritten" });
+                }
+            }
+
+            public sealed class GenHappyCommandPost : ICommandPostInterceptor<GenHappyCommand>
+            {
+                public ValueTask<object> HandleAsync(GenHappyCommand command, object messageResult, IExecutionContext context)
+                {
+                    Sink.Entries.Add("post:" + command.Tag);
+                    return ValueTask.FromResult(messageResult);
+                }
+            }
+
+            public sealed class GenHappyCommandFinal : ICommandFinalInterceptor<GenHappyCommand>
+            {
+                public ValueTask HandleAsync(GenHappyCommand command, object? messageResult, Exception? exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("final:" + (exception == null ? "clean" : exception.Message));
+                    return default;
+                }
+            }
+
+            // --- exception swallow (reference-typed result: the flavored exception
+            // interceptor's object-typed contract matches through result variance) ---
+
+            public sealed class GenSwallowCommand : ICommand<string> { }
+
+            public sealed class GenSwallowCommandHandler : ICommandHandler<GenSwallowCommand, string>
+            {
+                public ValueTask<string> HandleAsync(GenSwallowCommand command, IExecutionContext context)
+                {
+                    Sink.Entries.Add("handler");
+                    throw new InvalidOperationException("boom");
+                }
+            }
+
+            public sealed class GenSwallowCommandExceptionInterceptor : ICommandExceptionInterceptor<GenSwallowCommand>
+            {
+                public ValueTask<object> HandleAsync(GenSwallowCommand command, object? messageResult, Exception exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("exception:" + exception.Message);
+                    return ValueTask.FromResult<object>(messageResult!);
+                }
+            }
+
+            public sealed class GenSwallowCommandFinal : ICommandFinalInterceptor<GenSwallowCommand>
+            {
+                public ValueTask HandleAsync(GenSwallowCommand command, object? messageResult, Exception? exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("final:" + (exception == null ? "clean" : exception.Message));
+                    return default;
+                }
+            }
+
+            // --- exception propagation (no exception stage) -----------------------
+
+            public sealed class GenPropagateCommand : ICommand { }
+
+            public sealed class GenPropagateCommandHandler : ICommandHandler<GenPropagateCommand>
+            {
+                public ValueTask HandleAsync(GenPropagateCommand command, IExecutionContext context)
+                {
+                    throw new InvalidOperationException("unhandled");
+                }
+            }
+
+            public sealed class GenPropagateCommandFinal : ICommandFinalInterceptor<GenPropagateCommand>
+            {
+                public ValueTask HandleAsync(GenPropagateCommand command, object? messageResult, Exception? exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("final:" + (exception == null ? "clean" : exception.Message));
+                    return default;
+                }
+            }
+
+            // --- abort: exception stage skipped, finals run -----------------------
+
+            public sealed class GenAbortCommand : ICommand<string> { }
+
+            public sealed class GenAbortCommandHandler : ICommandHandler<GenAbortCommand, string>
+            {
+                public ValueTask<string> HandleAsync(GenAbortCommand command, IExecutionContext context)
+                {
+                    Sink.Entries.Add("handler");
+                    return ValueTask.FromResult("done");
+                }
+            }
+
+            public sealed class GenAbortCommandPre : ICommandPreInterceptor<GenAbortCommand>
+            {
+                public ValueTask<GenAbortCommand> HandleAsync(GenAbortCommand command, IExecutionContext context)
+                {
+                    Sink.Entries.Add("pre");
+                    context.Abort();
+                    return ValueTask.FromResult(command);
+                }
+            }
+
+            public sealed class GenAbortCommandExceptionInterceptor : ICommandExceptionInterceptor<GenAbortCommand>
+            {
+                public ValueTask<object> HandleAsync(GenAbortCommand command, object? messageResult, Exception exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("exception");
+                    return ValueTask.FromResult<object>(messageResult!);
+                }
+            }
+
+            public sealed class GenAbortCommandFinal : ICommandFinalInterceptor<GenAbortCommand>
+            {
+                public ValueTask HandleAsync(GenAbortCommand command, object? messageResult, Exception? exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("final");
+                    return default;
+                }
+            }
+
+            // --- result rewrite ---------------------------------------------------
+
+            public sealed class GenRewriteQuery : IQuery<int> { }
+
+            public sealed class GenRewriteQueryHandler : IQueryHandler<GenRewriteQuery, int>
+            {
+                public ValueTask<int> HandleAsync(GenRewriteQuery query, IExecutionContext context)
+                    => ValueTask.FromResult(7);
+            }
+
+            public sealed class GenRewriteQueryPost : IQueryPostInterceptor<GenRewriteQuery, int>
+            {
+                public ValueTask<int> HandleAsync(GenRewriteQuery query, int queryResult, IExecutionContext context)
+                    => ValueTask.FromResult(queryResult + 35);
+            }
+        }
+        """;
+
+    private static readonly Lazy<(Assembly Assembly, ServiceProvider Provider)> Host = new(() =>
+    {
+        var result = GeneratorTestHost.Run(Source);
+
+        Assert.Empty(result.CompilationErrors);
+
+        using var stream = new MemoryStream();
+        Assert.True(result.OutputCompilation.Emit(stream).Success);
+
+        var assembly = Assembly.Load(stream.ToArray());
+        var registrations = assembly.GetType("Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations", throwOnError: true)!;
+        var registerCommands = registrations.GetMethod("RegisterGenerated", [typeof(CommandModuleBuilder)])!;
+        var registerQueries = registrations.GetMethod("RegisterGenerated", [typeof(QueryModuleBuilder)])!;
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => registerCommands.Invoke(null, [commands]));
+                options.AddQueryModule(queries => registerQueries.Invoke(null, [queries]));
+            })
+            .BuildServiceProvider();
+
+        return (assembly, provider);
+    });
+
+    private static List<string> Entries
+        => (List<string>)Host.Value.Assembly.GetType("TestApp.Sink", throwOnError: true)!
+            .GetField("Entries", BindingFlags.Public | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    private static ICommand CreateCommand(string typeName)
+        => (ICommand)Activator.CreateInstance(Host.Value.Assembly.GetType(typeName, throwOnError: true)!)!;
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task HappyPath_RewritesTheMessageAndRunsStagesInOrder()
+    {
+        var (assembly, provider) = Host.Value;
+
+        Assert.NotNull(GeneratedDispatchRoots.FindStagedVoidPlan(assembly.GetType("TestApp.GenHappyCommand")!));
+
+        Entries.Clear();
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(CreateCommand("TestApp.GenHappyCommand"));
+
+        // The handler and post stage see the pre-interceptor's rewritten instance,
+        // exactly like the strategy path; the final stage observes a clean outcome last.
+        Assert.Equal(["pre:original", "handler:rewritten", "post:rewritten", "final:clean"], Entries);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task HandlerException_RunsTheExceptionStageAndSwallows()
+    {
+        var (assembly, provider) = Host.Value;
+
+        var commandType = assembly.GetType("TestApp.GenSwallowCommand", throwOnError: true)!;
+        Assert.NotNull(GeneratedDispatchRoots.FindStagedResultPlan(commandType, typeof(string)));
+
+        Entries.Clear();
+
+        // With an exception stage present the strategy swallows after the interceptors
+        // observed the exception — the dispatch completes normally, returning the
+        // (never produced) default result.
+        var command = (ICommand<string>)Activator.CreateInstance(commandType)!;
+        var result = await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.Null(result);
+        Assert.Equal(["handler", "exception:boom", "final:boom"], Entries);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task HandlerException_WithoutExceptionStage_PropagatesAfterFinals()
+    {
+        var (assembly, provider) = Host.Value;
+
+        Assert.NotNull(GeneratedDispatchRoots.FindStagedVoidPlan(assembly.GetType("TestApp.GenPropagateCommand")!));
+
+        Entries.Clear();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await provider.GetRequiredService<ICommandMediator>().SendAsync(CreateCommand("TestApp.GenPropagateCommand")));
+
+        Assert.Equal("unhandled", exception.Message);
+        Assert.Equal(["final:unhandled"], Entries);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Abort_SkipsTheExceptionStageAndStillRunsFinals()
+    {
+        var (assembly, provider) = Host.Value;
+
+        var commandType = assembly.GetType("TestApp.GenAbortCommand", throwOnError: true)!;
+        Assert.NotNull(GeneratedDispatchRoots.FindStagedResultPlan(commandType, typeof(string)));
+
+        Entries.Clear();
+
+        var command = (ICommand<string>)Activator.CreateInstance(commandType)!;
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(async () =>
+            await provider.GetRequiredService<ICommandMediator>().SendAsync(command));
+
+        // The abort never reaches the handler, is invisible to the exception stage, and
+        // the final stage still runs — the strategy's exact contract.
+        Assert.Equal(["pre", "final"], Entries);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PostInterceptor_RewritesTheResult()
+    {
+        var (assembly, provider) = Host.Value;
+
+        var queryType = assembly.GetType("TestApp.GenRewriteQuery", throwOnError: true)!;
+        Assert.NotNull(GeneratedDispatchRoots.FindStagedResultPlan(queryType, typeof(int)));
+
+        var query = (IQuery<int>)Activator.CreateInstance(queryType)!;
+        var result = await Host.Value.Provider.GetRequiredService<IQueryMediator>().QueryAsync(query);
+
+        Assert.Equal(42, result);
+    }
+}


### PR DESCRIPTION
## What

PR D of the staged-plans epic — the generator now emits **one bespoke sealed plan class per interceptor-bearing message** (no arity templates): the baked `StagedPlanComposition` plus an `Execute` that runs `pre1→pre2→handler→post1…` as straight-line typed calls. Registered via `AddStagedPlan` from `RootDispatchInstantiations`, hosted by PR C's advisory-gated executors.

- **Modeling**: `ContractShapeModel` (a type's raw interceptor contracts, undeduped — the arm-selection input), `AssignableKeys` on messages (bases + interfaces — the compile-time domain of the runtime's `IsAssignableTo` indirect matching), plus `HasPipelineExclusion`/`IsValueType`/`IsNestedType` and `DispatchResultModel.ResultIsValueType`.
- **Composition parity**: membership and order replicate the runtime shape builder exactly — direct segment before indirect, each sorted weight-descending with the ordinal type name tie-break (nested participants disqualify: `Type.FullName`'s `+` separator would sort differently).
- **Arm selection** replicates the invocation strategies' pattern match at compile time, variance-aware: the flavored contracts' `object`-typed result matches reference-typed pipeline results exactly as `in TResult` variance does at runtime. Every undecidable case — grouped/keyed/nested participants, a participant matching through two deduped registrations, participants no arm can serve, other reference-result variance — **disqualifies the message**; the advisory gate stays the safety net either way.
- **Semantics parity, bit for bit**: closed `(ValueTask?)` vs erased-generic `(TR)obj!`/`(TR?)obj` cast behavior, `ExecutionAbortedException` escaping the catch filter (exception stage never sees it, finals still run), exceptions swallowed once an exception stage observed them, minimal bodies when stages are empty.

## Measurements (.NET 9, Root)

| Row | Strategy baseline | Staged lane | |
|---|---|---|---|
| Command_Void_Intercepted | 203.1 ns / 104 B | **73.7 ns / 72 B** | **2.75×** |
| Query_Result_Intercepted | 182.5 ns / 144 B | **102.6 ns / 96 B** | **1.78×** |

Remaining 72 B = the three transient participant instances; fusing PR B's direct-construction activation into staged plans is a possible follow-up.

## Verification

Build 0 warnings; all suites green on net9.0 + net10.0. New: 5 emission tests + a **5-scenario strategy-parity matrix that executes the emitted assembly end to end** through a real container (message rewrite + stage order, exception capture with strategy-identical swallowing, propagation without an exception stage, `context.Abort()` skipping the exception stage while finals run and the abort propagates, post result rewrite).

## ⚠️ Found in passing: flavored exception interceptors break void pipelines

`ICommandExceptionInterceptor<TCommand>` extends the **result-typed** `IAsyncExceptionInterceptor<TCommand, object>`. On void pipelines (`TResult = ValueTask`, a struct — no variance) and value-typed-result pipelines, **no invoker arm can match it**: the moment that exception stage actually runs, the runtime throws `NotSupportedException`, burying the original exception. Reference-typed results work through `in TResult` variance. The flavored final interceptor is arity-1 (agnostic) — inconsistent with exception. The generator disqualifies such messages (parity with the broken strategy behavior). Candidate fix: re-base the flavored exception interceptor on the arity-1 contract like finals (erased member signature is identical); separate PR, maintainer's call.

## Deliberately deferred

- Analyzer infos ("collapse to a single public constructor", "[FromServices] has no effect on constructors") — small follow-up PR.
- Straight-through suspension ladder (the `PublishStraightThrough` precedent): v1 emits plain `async` Execute; at 73.7 ns the ladder's complexity can be weighed against data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
