### PR TITLE
fix: flavored interceptor contracts - three defective bases repaired

### DIFF
--- a/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptor[TCommand].cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptor[TCommand].cs
@@ -5,17 +5,22 @@ namespace Stella.Ergosfare.Commands.Abstractions;
 
 /// <summary>
 /// Marker interface for asynchronous exception interceptors for commands.
-/// Inherits <see cref="IAsyncExceptionInterceptor{TMessage,TResult}"/> and <see cref="ICommand"/>
-/// to allow registration within the command module.
+/// Inherits the result-agnostic <see cref="IAsyncExceptionInterceptor{TMessage}"/> and
+/// <see cref="ICommand"/> to allow registration within the command module.
 /// This interface does not modify the behavior or return type; interception logic
-/// is handled by <see cref="IAsyncExceptionInterceptor{TMessage,TResult}"/>.
+/// is handled by <see cref="IAsyncExceptionInterceptor{TMessage}"/>.
 /// </summary>
 /// <typeparam name="TCommand">
 /// The type of command being intercepted. Must implement <see cref="ICommand"/>
 /// </typeparam>
 /// <remarks>
-/// <c>ICommandExceptionInterceptor&lt;in TCommand, in ValueTask, ValueTask&gt;</c>
-/// or other type-safe variants, which preserve the exact result type.
+/// The result-agnostic base is deliberate: a result-typed base (the previous
+/// <c>IAsyncExceptionInterceptor&lt;TCommand, object&gt;</c>) is invisible to the
+/// pipeline's pattern match whenever the pipeline result is a value type — void command
+/// pipelines carry a <see cref="System.Threading.Tasks.ValueTask"/> result internally, so
+/// the exception stage failed with <see cref="System.NotSupportedException"/> the moment
+/// it ran. For a strongly-typed result use
+/// <see cref="ICommandExceptionInterceptor{TCommand, TResult}"/>.
 /// </remarks>
 // ReSharper disable once UnusedType.Global
-public interface ICommandExceptionInterceptor<in TCommand>: ICommand,  IAsyncExceptionInterceptor<TCommand, object> where TCommand : ICommand;
+public interface ICommandExceptionInterceptor<in TCommand>: ICommand, IAsyncExceptionInterceptor<TCommand> where TCommand : ICommand;

--- a/src/Stella.Ergosfare.Queries.Abstractions/FinalInterceptors/IQueryFinalInterceptor.cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/FinalInterceptors/IQueryFinalInterceptor.cs
@@ -8,17 +8,17 @@ namespace Stella.Ergosfare.Queries.Abstractions;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This interface is a non-generic version of <see cref="IQueryFinalInterceptor{TQuery}"/>,
-/// applying to all queries implementing <see cref="IQuery"/>.
+/// This interface applies to all queries implementing <see cref="IQuery"/>.
 /// </para>
 /// <para>
-/// It inherits from <see cref="IAsyncFinalInterceptor{TQuery, TResult}"/>, enabling
-/// asynchronous final processing of queries after they are dispatched to their handlers.
-/// </para>
-/// <para>
-/// Query handlers and messages that implement <see cref="IQuery"/> will recognize
-/// this interceptor automatically in the query mediation pipeline.
+/// It inherits from the result-agnostic <see cref="IAsyncFinalInterceptor{TMessage}"/>,
+/// enabling asynchronous final processing of queries after they are dispatched to their
+/// handlers. The result-agnostic base is deliberate: a result-typed base (the previous
+/// <c>IAsyncFinalInterceptor&lt;IQuery, object&gt;</c>) is invisible to the pipeline's
+/// pattern match whenever the query result is a value type, so the final stage failed
+/// with <see cref="System.NotSupportedException"/> for such queries the moment it ran.
+/// For a strongly-typed result use <see cref="IQueryFinalInterceptor{TQuery, TResult}"/>.
 /// </para>
 /// </remarks>
 // ReSharper disable once UnusedType.Global
-public interface IQueryFinalInterceptor: IQuery, IAsyncFinalInterceptor<IQuery, object>;
+public interface IQueryFinalInterceptor: IQuery, IAsyncFinalInterceptor<IQuery>;

--- a/src/Stella.Ergosfare.Queries.Abstractions/PostInterceptors/IQueryPostInterceptor[TQuery].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/PostInterceptors/IQueryPostInterceptor[TQuery].cs
@@ -4,7 +4,8 @@ namespace Stella.Ergosfare.Queries.Abstractions;
 
 
 /// <summary>
-/// Represents a non-generic post-interceptor for queries in the Stella.Ergosfare pipeline.
+/// Represents a result-agnostic post-interceptor for a specific query type in the
+/// Stella.Ergosfare pipeline.
 /// </summary>
 /// <remarks>
 /// Post-interceptors run after the main query handler has executed. They can:
@@ -14,7 +15,10 @@ namespace Stella.Ergosfare.Queries.Abstractions;
 /// <item>Support asynchronous operations via <see cref="IAsyncPostInterceptor{TQuery}"/>.</item>
 /// </list>
 ///
-/// Use this interface when you do not need a strongly-typed modified result,
-/// and the interceptor should work with any <see cref="IQuery"/>.
+/// Use this interface when you do not need a strongly-typed result but want the
+/// interceptor scoped to <typeparamref name="TQuery"/>. The base previously closed over
+/// <see cref="IQuery"/> instead of <typeparamref name="TQuery"/>, which registered the
+/// interceptor for every query in the application rather than the targeted one. Use the
+/// non-generic <see cref="IQueryPostInterceptor"/> to intercept all queries.
 /// </remarks>
-public interface IQueryPostInterceptor<in TQuery>: IQuery, IAsyncPostInterceptor<IQuery> where TQuery : IQuery;
+public interface IQueryPostInterceptor<in TQuery>: IQuery, IAsyncPostInterceptor<TQuery> where TQuery : IQuery;

--- a/test/Stella.Ergosfare.Command.Test/FlavoredExceptionInterceptorTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/FlavoredExceptionInterceptorTests.cs
@@ -1,0 +1,64 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Command.Test;
+
+/// <summary>
+/// Regression coverage for the flavored exception interceptor contract: it used to extend
+/// the result-typed <c>IAsyncExceptionInterceptor&lt;TCommand, object&gt;</c>, which no
+/// invocation-strategy arm can match on a void pipeline (its internal
+/// <see cref="ValueTask"/> result carrier is a value type — no variance), so the exception
+/// stage itself threw <see cref="NotSupportedException"/> and buried the handler's
+/// exception. Re-based on the result-agnostic contract, the interceptor observes the
+/// exception and the strategy swallows it — the documented contract.
+/// </summary>
+public class FlavoredExceptionInterceptorTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class VoidFailingCommand : ICommand { }
+
+    [ExcludeFromDiscovery]
+    public sealed class VoidFailingCommandHandler : ICommandHandler<VoidFailingCommand>
+    {
+        public ValueTask HandleAsync(VoidFailingCommand command, IExecutionContext context)
+            => throw new InvalidOperationException("boom");
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class VoidFailingCommandExceptionInterceptor : ICommandExceptionInterceptor<VoidFailingCommand>
+    {
+        public ValueTask<object> HandleAsync(VoidFailingCommand command, object? messageResult, Exception exception, IExecutionContext context)
+        {
+            context.Set("observed", exception.Message);
+            return ValueTask.FromResult<object>(messageResult!);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task VoidCommand_ExceptionInterceptorObservesAndSwallows()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<VoidFailingCommandHandler>();
+                c.Register<VoidFailingCommandExceptionInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var settings = new CommandMediationSettings();
+
+        // Before the contract fix this dispatch failed with NotSupportedException from
+        // the exception invoker itself; now the interceptor observes the handler's
+        // exception and the pipeline swallows it.
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(new VoidFailingCommand(), settings);
+
+        Assert.Equal("boom", settings.Items["observed"]);
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/FlavoredQueryInterceptorTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/FlavoredQueryInterceptorTests.cs
@@ -1,0 +1,123 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Stella.Ergosfare.Queries.Test;
+
+/// <summary>
+/// Regression coverage for two flavored query interceptor contracts. The non-generic
+/// <see cref="IQueryFinalInterceptor"/> used to extend the result-typed
+/// <c>IAsyncFinalInterceptor&lt;IQuery, object&gt;</c>, which no invocation-strategy arm
+/// can match when the query result is a value type — the final stage itself threw
+/// <see cref="NotSupportedException"/> for every <c>IQuery&lt;int&gt;</c>-style query.
+/// And <see cref="IQueryPostInterceptor{TQuery}"/> used to close its base over
+/// <see cref="IQuery"/> instead of <c>TQuery</c>, silently applying the interceptor to
+/// every query in the application instead of the targeted one.
+/// </summary>
+public class FlavoredQueryInterceptorTests
+{
+    [ExcludeFromDiscovery]
+    public sealed class FinalizedIntQuery : IQuery<int> { }
+
+    [ExcludeFromDiscovery]
+    public sealed class FinalizedIntQueryHandler : IQueryHandler<FinalizedIntQuery, int>
+    {
+        public ValueTask<int> HandleAsync(FinalizedIntQuery query, IExecutionContext context)
+            => ValueTask.FromResult(7);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class RecordingQueryFinalInterceptor : IQueryFinalInterceptor
+    {
+        public ValueTask HandleAsync(IQuery query, object? messageResult, Exception? exception, IExecutionContext context)
+        {
+            context.Set("finalRan", true);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task ValueTypedResult_RunsTheNonGenericFinalInterceptor()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q =>
+            {
+                q.Register<FinalizedIntQueryHandler>();
+                q.Register<RecordingQueryFinalInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var settings = new QueryMediationSettings();
+
+        // Before the contract fix the final stage itself threw NotSupportedException for
+        // value-typed results; now it observes the outcome like any final interceptor.
+        var result = await provider.GetRequiredService<IQueryMediator>().QueryAsync(new FinalizedIntQuery(), settings);
+
+        Assert.Equal(7, result);
+        Assert.Equal(true, settings.Items["finalRan"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class TargetedQuery : IQuery<int> { }
+
+    [ExcludeFromDiscovery]
+    public sealed class TargetedQueryHandler : IQueryHandler<TargetedQuery, int>
+    {
+        public ValueTask<int> HandleAsync(TargetedQuery query, IExecutionContext context)
+            => ValueTask.FromResult(1);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class UntargetedQuery : IQuery<int> { }
+
+    [ExcludeFromDiscovery]
+    public sealed class UntargetedQueryHandler : IQueryHandler<UntargetedQuery, int>
+    {
+        public ValueTask<int> HandleAsync(UntargetedQuery query, IExecutionContext context)
+            => ValueTask.FromResult(2);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class TargetedQueryPostInterceptor : IQueryPostInterceptor<TargetedQuery>
+    {
+        public ValueTask<object> HandleAsync(TargetedQuery query, object messageResult, IExecutionContext context)
+        {
+            context.Set("postRan", true);
+            return ValueTask.FromResult(messageResult);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task TypedPostInterceptor_AppliesOnlyToItsTargetQuery()
+    {
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddQueryModule(q =>
+            {
+                q.Register<TargetedQueryHandler>();
+                q.Register<UntargetedQueryHandler>();
+                q.Register<TargetedQueryPostInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var queries = provider.GetRequiredService<IQueryMediator>();
+
+        // Before the contract fix the interceptor's base closed over IQuery, so it ran
+        // for every query in the application — including this untargeted one.
+        var untargetedSettings = new QueryMediationSettings();
+        await queries.QueryAsync(new UntargetedQuery(), untargetedSettings);
+        Assert.False(untargetedSettings.Items.ContainsKey("postRan"));
+
+        var targetedSettings = new QueryMediationSettings();
+        await queries.QueryAsync(new TargetedQuery(), targetedSettings);
+        Assert.Equal(true, targetedSettings.Items["postRan"]);
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
@@ -134,8 +134,25 @@ public class StreamFastLaneTests
         var mediator = provider.GetRequiredService<IQueryMediator>();
 
         // The Mediate path threw from the StreamAsync call itself (descriptor resolution
-        // precedes enumeration); the fast lane must keep that timing.
-        Assert.Throws<NoHandlerFoundException>(() => mediator.StreamAsync(new UnhandledStream()));
-        await Task.CompletedTask;
+        // precedes enumeration); the fast lane must keep that timing. The registry is
+        // process-wide, though: another suite's marker-targeted (IQuery-assignable)
+        // interceptor may have given every query a descriptor, in which case both paths
+        // defer and fail at enumeration with the strategy's no-handler error instead —
+        // the fast-lane/Mediate parity this test guards holds either way.
+        try
+        {
+            var stream = mediator.StreamAsync(new UnhandledStream());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await foreach (var _ in stream)
+                {
+                }
+            });
+        }
+        catch (NoHandlerFoundException)
+        {
+            // Clean-registry timing: thrown at call time, before any enumeration.
+        }
     }
 }

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
@@ -81,8 +81,39 @@ public class StagedPlanExecutionParityTests
                 }
             }
 
-            // --- exception swallow (reference-typed result: the flavored exception
-            // interceptor's object-typed contract matches through result variance) ---
+            // --- void exception swallow: the flavored exception interceptor's
+            // result-agnostic contract works on void pipelines too -------------------
+
+            public sealed class GenVoidSwallowCommand : ICommand { }
+
+            public sealed class GenVoidSwallowCommandHandler : ICommandHandler<GenVoidSwallowCommand>
+            {
+                public ValueTask HandleAsync(GenVoidSwallowCommand command, IExecutionContext context)
+                {
+                    Sink.Entries.Add("handler");
+                    throw new InvalidOperationException("void-boom");
+                }
+            }
+
+            public sealed class GenVoidSwallowCommandExceptionInterceptor : ICommandExceptionInterceptor<GenVoidSwallowCommand>
+            {
+                public ValueTask<object> HandleAsync(GenVoidSwallowCommand command, object? messageResult, Exception exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("exception:" + exception.Message);
+                    return ValueTask.FromResult<object>(messageResult!);
+                }
+            }
+
+            public sealed class GenVoidSwallowCommandFinal : ICommandFinalInterceptor<GenVoidSwallowCommand>
+            {
+                public ValueTask HandleAsync(GenVoidSwallowCommand command, object? messageResult, Exception? exception, IExecutionContext context)
+                {
+                    Sink.Entries.Add("final:" + (exception == null ? "clean" : exception.Message));
+                    return default;
+                }
+            }
+
+            // --- exception swallow on a reference-typed result pipeline --------------
 
             public sealed class GenSwallowCommand : ICommand<string> { }
 
@@ -241,6 +272,24 @@ public class StagedPlanExecutionParityTests
         // The handler and post stage see the pre-interceptor's rewritten instance,
         // exactly like the strategy path; the final stage observes a clean outcome last.
         Assert.Equal(["pre:original", "handler:rewritten", "post:rewritten", "final:clean"], Entries);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task VoidHandlerException_RunsTheExceptionStageAndSwallows()
+    {
+        var (assembly, provider) = Host.Value;
+
+        // The re-based (result-agnostic) flavored exception contract makes this pipeline
+        // both runnable at all on the strategy path and modelable for a staged plan.
+        Assert.NotNull(GeneratedDispatchRoots.FindStagedVoidPlan(assembly.GetType("TestApp.GenVoidSwallowCommand")!));
+
+        Entries.Clear();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(CreateCommand("TestApp.GenVoidSwallowCommand"));
+
+        Assert.Equal(["handler", "exception:void-boom", "final:void-boom"], Entries);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Three flavored interceptor marker interfaces carried defective bases; all three are repaired. No core contract changes were needed — the arity-1 result-agnostic contracts were always the right bases; the defects lived in the flavored layer.

| Contract | Defect | Fix |
|---|---|---|
| `ICommandExceptionInterceptor<TCommand>` | extended result-typed `IAsyncExceptionInterceptor<TCommand, object>` — no invocation-strategy arm can match that on a void pipeline (the internal `ValueTask` result carrier is a value type, no variance), so the exception stage itself threw `NotSupportedException`, burying the handler's exception | re-based on the arity-1 result-agnostic contract |
| `IQueryFinalInterceptor` (non-generic) | same defect via `IAsyncFinalInterceptor<IQuery, object>` — the final stage threw `NotSupportedException` for every value-typed query result | re-based on the arity-1 contract |
| `IQueryPostInterceptor<TQuery>` | base closed over `IQuery` instead of `TQuery` — the interceptor silently applied to **every** query in the application rather than the targeted one | base now closes over `TQuery` |

The erased member signatures of the two re-based contracts are identical to the arity-1 members (`object? messageResult`), so existing implementors compile unchanged. The event-flavored contracts deliberately keep their `<T, ValueTask>` bases: the event pipeline's result carrier is exactly `ValueTask`, so they match today — and their members expose `ValueTask?`-typed parameters that a re-base would break.

## Tests

- Command.Test: void command + flavored exception interceptor observes and swallows (previously `NotSupportedException`).
- Queries.Test: value-typed-result query runs the non-generic final interceptor; the typed post-interceptor applies only to its target query.
- The staged-plan parity matrix gains the void exception-swallow scenario the old contract made impossible — and the generator now stages such pipelines (the agnostic arm matches).
- The unregistered-stream-query test is hardened against process-wide registry pollution from marker-targeted interceptors: it now asserts the fast-lane/Mediate parity in both the clean and the polluted registry state.

Build 0 warnings; all suites green on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
