### PR TITLE
perf: epic closeout - TOCTOU stamps, analyzer infos, staged activation fusion

### DIFF
--- a/src/Stella.Ergosfare.Commands.Abstractions/ICommandMediator.cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/ICommandMediator.cs
@@ -32,23 +32,6 @@ public interface ICommandMediator
     ValueTask SendAsync(ICommand command, CommandMediationSettings? commandMediationSettings = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Asynchronously sends a command for mediation and returns a result.
-    /// </summary>
-    /// <typeparam name="TResult">The type of the result returned by the command.</typeparam>
-    /// <param name="command">The command to be sent.</param>
-    /// <param name="commandMediationSettings">
-    ///     Optional settings for command mediation that control aspects such as handler
-    ///     filtering.
-    /// </param>
-    /// <param name="cancellationToken">Cancellation token for the operation that can be used to cancel the command processing.</param>
-    /// <returns>A task representing the asynchronous operation with a result of type <typeparamref name="TResult" />.</returns>
-    /// <remarks>
-    ///     This method is used for commands that produce a result of type <typeparamref name="TResult" />.
-    ///     The command is routed to its appropriate handler based on its type, and the command handling pipeline
-    ///     is executed, including pre-handlers, the main handler, post-handlers, and error handlers if exceptions occur.
-    ///     The result produced by the handler is returned to the caller.
-    /// </remarks>
-    /// <summary>
     /// Sends a void command under an externally owned execution context — the
     /// nested-dispatch path: a handler opens a scope on its own context
     /// (<c>using var scope = context.CreateScope();</c>) and passes <c>scope.Context</c>
@@ -71,6 +54,23 @@ public interface ICommandMediator
     ValueTask<TResult> SendAsync<TResult>(ICommand<TResult> command, Core.Abstractions.IExecutionContext context,
         CommandMediationSettings? commandMediationSettings = null);
 
+    /// <summary>
+    ///     Asynchronously sends a command for mediation and returns a result.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the command.</typeparam>
+    /// <param name="command">The command to be sent.</param>
+    /// <param name="commandMediationSettings">
+    ///     Optional settings for command mediation that control aspects such as handler
+    ///     filtering.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token for the operation that can be used to cancel the command processing.</param>
+    /// <returns>A task representing the asynchronous operation with a result of type <typeparamref name="TResult" />.</returns>
+    /// <remarks>
+    ///     This method is used for commands that produce a result of type <typeparamref name="TResult" />.
+    ///     The command is routed to its appropriate handler based on its type, and the command handling pipeline
+    ///     is executed, including pre-handlers, the main handler, post-handlers, and error handlers if exceptions occur.
+    ///     The result produced by the handler is returned to the caller.
+    /// </remarks>
     ValueTask<TResult> SendAsync<TResult>(ICommand<TResult> command,
                                                    CommandMediationSettings? commandMediationSettings = null,
                                                    CancellationToken cancellationToken = default);

--- a/src/Stella.Ergosfare.Core.Abstractions/Attributes/Discovery.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Attributes/Discovery.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 
 namespace Stella.Ergosfare.Core.Abstractions.Attributes;

--- a/src/Stella.Ergosfare.Core.Abstractions/Context/ExecutionContextScope.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Context/ExecutionContextScope.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Stella.Ergosfare.Core.Abstractions;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/GeneratedDispatchRoots.cs
@@ -1,4 +1,4 @@
-using System;
+
 using System.Collections.Concurrent;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Abstractions.StagedPlans;
@@ -59,7 +59,7 @@ public static class GeneratedDispatchRoots
     /// different handler resolved, adapters configured). Idempotent.
     /// </summary>
     public static void AddVoidPlan<TMessage, THandler>()
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage>
         => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>());
 
@@ -74,7 +74,7 @@ public static class GeneratedDispatchRoots
     /// semantically identical. Idempotent.
     /// </summary>
     public static void AddVoidPlan<TMessage, THandler>(Func<THandler> directHandlerFactory)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage>
         => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>(directHandlerFactory));
 
@@ -91,7 +91,7 @@ public static class GeneratedDispatchRoots
     /// activation would resolve them. Idempotent.
     /// </summary>
     public static void AddVoidPlan<TMessage, THandler>(Func<IServiceProvider, THandler> directHandlerFactory)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage>
         => VoidPlans.TryAdd(typeof(TMessage), new VoidPlanRoot<TMessage, THandler>(directHandlerFactory));
 
@@ -107,7 +107,7 @@ public static class GeneratedDispatchRoots
     /// Idempotent.
     /// </summary>
     public static void AddResultPlan<TMessage, TResult, THandler>()
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage, TResult>
         => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>());
 
@@ -118,7 +118,7 @@ public static class GeneratedDispatchRoots
     /// Idempotent.
     /// </summary>
     public static void AddResultPlan<TMessage, TResult, THandler>(Func<THandler> directHandlerFactory)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage, TResult>
         => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>(directHandlerFactory));
 
@@ -129,7 +129,7 @@ public static class GeneratedDispatchRoots
     /// the contract. Idempotent.
     /// </summary>
     public static void AddResultPlan<TMessage, TResult, THandler>(Func<IServiceProvider, THandler> directHandlerFactory)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage, TResult>
         => ResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), new ResultPlanRoot<TMessage, TResult, THandler>(directHandlerFactory));
 
@@ -146,14 +146,14 @@ public static class GeneratedDispatchRoots
     /// Idempotent.
     /// </summary>
     public static void AddStagedPlan<TMessage>(StagedVoidPlan<TMessage> plan)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         => StagedVoidPlans.TryAdd(typeof(TMessage), plan);
 
     /// <summary>
     /// Result-producing counterpart of <see cref="AddStagedPlan{TMessage}"/>. Idempotent.
     /// </summary>
     public static void AddStagedPlan<TMessage, TResult>(StagedResultPlan<TMessage, TResult> plan)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         => StagedResultPlans.TryAdd((typeof(TMessage), typeof(TResult)), plan);
 
     /// <summary>The staged void plan of the message type, or <c>null</c> when none was generated.</summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/IResultPlanRootVisitor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/IResultPlanRootVisitor.cs
@@ -6,6 +6,6 @@ public interface IResultPlanRootVisitor<out TReturn, in TState>
 {
     /// <summary>Called with the plan's message, result and handler types as the generic arguments.</summary>
     TReturn Visit<TMessage, TResult, THandler>(TState state)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage, TResult>;
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/IVoidPlanRootVisitor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/IVoidPlanRootVisitor.cs
@@ -6,6 +6,6 @@ public interface IVoidPlanRootVisitor<out TReturn, in TState>
 {
     /// <summary>Called with the plan's message and handler types as the generic arguments.</summary>
     TReturn Visit<TMessage, THandler>(TState state)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
         where THandler : class, IAsyncHandler<TMessage>;
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/ResultPlanRoot[TMessage,TResult,THandler].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/ResultPlanRoot[TMessage,TResult,THandler].cs
@@ -1,10 +1,10 @@
-using System;
+
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 
 namespace Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 /// <summary>The concrete closure of <see cref="ResultPlanRoot"/>; instantiated by generated code.</summary>
 public sealed class ResultPlanRoot<TMessage, TResult, THandler> : ResultPlanRoot
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
     where THandler : class, IAsyncHandler<TMessage, TResult>
 {
     private readonly object? _directHandlerFactory;

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/VoidPlanRoot.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/VoidPlanRoot.cs
@@ -1,7 +1,7 @@
 namespace Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 /// <summary>
 /// A compile-time pipeline plan closed over a void message and its sole async handler;
-/// see <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}"/> and
+/// see <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}()"/> and
 /// <see cref="MessageRoot"/> for the visitor re-entry pattern.
 /// </summary>
 public abstract class VoidPlanRoot

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/VoidPlanRoot[TMessage,THandler].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/VoidPlanRoot[TMessage,THandler].cs
@@ -1,10 +1,10 @@
-using System;
+
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 
 namespace Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 /// <summary>The concrete closure of <see cref="VoidPlanRoot"/>; instantiated by generated code.</summary>
 public sealed class VoidPlanRoot<TMessage, THandler> : VoidPlanRoot
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
     private readonly object? _directHandlerFactory;

--- a/src/Stella.Ergosfare.Core.Abstractions/GeneratedDescriptorCatalog.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/GeneratedDescriptorCatalog.cs
@@ -1,6 +1,5 @@
-using System;
+
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 
 namespace Stella.Ergosfare.Core.Abstractions;

--- a/src/Stella.Ergosfare.Core.Abstractions/IMessageMediator.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/IMessageMediator.cs
@@ -22,7 +22,7 @@ public interface IMessageMediator
     /// <summary>
     /// Dispatches <paramref name="message"/> through the cached result-producing pipeline
     /// executor closed over its runtime type and the requested group set; see
-    /// <see cref="DispatchAsync"/>.
+    /// <see cref="DispatchAsync(object, IDictionary{object, object}, CancellationToken, IEnumerable{string})"/>.
     /// </summary>
     /// <typeparam name="TResult">The result type produced by the pipeline.</typeparam>
     /// <param name="message">The message instance to dispatch.</param>

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/IStagedResultPlanVisitor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/IStagedResultPlanVisitor.cs
@@ -4,5 +4,5 @@ namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 public interface IStagedResultPlanVisitor<out TReturn, in TState>
 {
     /// <summary>Called with the plan's message and result types as the generic arguments.</summary>
-    TReturn Visit<TMessage, TResult>(TState state) where TMessage : notnull, IMessage;
+    TReturn Visit<TMessage, TResult>(TState state) where TMessage : IMessage;
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/IStagedVoidPlanVisitor.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/IStagedVoidPlanVisitor.cs
@@ -4,5 +4,5 @@ namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 public interface IStagedVoidPlanVisitor<out TReturn, in TState>
 {
     /// <summary>Called with the plan's message type as the generic argument.</summary>
-    TReturn Visit<TMessage>(TState state) where TMessage : notnull, IMessage;
+    TReturn Visit<TMessage>(TState state) where TMessage : IMessage;
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedPlanComposition.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedPlanComposition.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 
 namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedResultPlan.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedResultPlan.cs
@@ -10,6 +10,9 @@ public abstract class StagedResultPlan
     /// <summary>The pipeline composition the plan was baked against.</summary>
     public abstract StagedPlanComposition Composition { get; }
 
+    /// <inheritdoc cref="StagedVoidPlan.SupportsDirectConstruction"/>
+    public virtual bool SupportsDirectConstruction => false;
+
     /// <summary>Invokes the visitor with this plan's message and result types as the generic arguments.</summary>
     public abstract TReturn Accept<TReturn, TState>(IStagedResultPlanVisitor<TReturn, TState> visitor, TState state);
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedResultPlan[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedResultPlan[TMessage,TResult].cs
@@ -3,7 +3,7 @@
 namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 /// <summary>The typed closure of <see cref="StagedResultPlan"/>; subclassed by generated (or hand-written) plans.</summary>
 public abstract class StagedResultPlan<TMessage, TResult> : StagedResultPlan
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
 {
     /// <inheritdoc cref="StagedVoidPlan{TMessage}.Execute"/>
     public abstract ValueTask<TResult> Execute(TMessage message, IExecutionContext context, IServiceProvider serviceProvider);

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedResultPlan[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedResultPlan[TMessage,TResult].cs
@@ -8,6 +8,10 @@ public abstract class StagedResultPlan<TMessage, TResult> : StagedResultPlan
     /// <inheritdoc cref="StagedVoidPlan{TMessage}.Execute"/>
     public abstract ValueTask<TResult> Execute(TMessage message, IExecutionContext context, IServiceProvider serviceProvider);
 
+    /// <inheritdoc cref="StagedVoidPlan{TMessage}.ExecuteDirect"/>
+    public virtual ValueTask<TResult> ExecuteDirect(TMessage message, IExecutionContext context, IServiceProvider serviceProvider)
+        => Execute(message, context, serviceProvider);
+
     /// <inheritdoc />
     public sealed override TReturn Accept<TReturn, TState>(IStagedResultPlanVisitor<TReturn, TState> visitor, TState state)
         => visitor.Visit<TMessage, TResult>(state);

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan.cs
@@ -3,7 +3,7 @@ namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 /// A compile-time staged pipeline plan for a void message: bespoke code that runs the
 /// message's entire interceptor-bearing pipeline — pre stages, handler, post stages, with
 /// exception and final semantics — as straight-line typed calls instead of the runtime
-/// strategy's generic machinery. See <see cref="MessageRoot"/> for the visitor re-entry
+/// strategy's generic machinery. See <see cref="DispatchRoots.MessageRoot"/> for the visitor re-entry
 /// pattern.
 /// </summary>
 /// <remarks>

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan.cs
@@ -20,6 +20,16 @@ public abstract class StagedVoidPlan
     /// <summary>The pipeline composition the plan was baked against.</summary>
     public abstract StagedPlanComposition Composition { get; }
 
+    /// <summary>
+    /// Whether the plan carries a direct-construction variant of its pipeline
+    /// (<c>ExecuteDirect</c>): every participant constructed with <c>new</c> instead of a
+    /// container resolution. The hosting executor uses that variant only after verifying
+    /// at runtime that every participant's effective DI registration is the module's own
+    /// plain transient one — the single shape where container resolution and direct
+    /// construction are observably identical.
+    /// </summary>
+    public virtual bool SupportsDirectConstruction => false;
+
     /// <summary>Invokes the visitor with this plan's message type as the generic argument.</summary>
     public abstract TReturn Accept<TReturn, TState>(IStagedVoidPlanVisitor<TReturn, TState> visitor, TState state);
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan[TMessage].cs
@@ -14,6 +14,17 @@ public abstract class StagedVoidPlan<TMessage> : StagedVoidPlan
     /// </summary>
     public abstract ValueTask Execute(TMessage message, IExecutionContext context, IServiceProvider serviceProvider);
 
+    /// <summary>
+    /// The direct-construction variant of <see cref="Execute"/>: participants are
+    /// constructed with <c>new</c> (dependencies still resolve from
+    /// <paramref name="serviceProvider"/>). Only invoked while
+    /// <see cref="StagedVoidPlan.SupportsDirectConstruction"/> is <c>true</c> AND the
+    /// hosting executor verified every participant's plain transient registration; the
+    /// default forwards to <see cref="Execute"/>.
+    /// </summary>
+    public virtual ValueTask ExecuteDirect(TMessage message, IExecutionContext context, IServiceProvider serviceProvider)
+        => Execute(message, context, serviceProvider);
+
     /// <inheritdoc />
     public sealed override TReturn Accept<TReturn, TState>(IStagedVoidPlanVisitor<TReturn, TState> visitor, TState state)
         => visitor.Visit<TMessage>(state);

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan[TMessage].cs
@@ -1,11 +1,9 @@
-using System;
-using System.Threading.Tasks;
 
 namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 
 /// <summary>The typed closure of <see cref="StagedVoidPlan"/>; subclassed by generated (or hand-written) plans.</summary>
 public abstract class StagedVoidPlan<TMessage> : StagedVoidPlan
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
 {
     /// <summary>
     /// Runs the baked pipeline for the message. Only invoked while the live pipeline

--- a/src/Stella.Ergosfare.Core/Internal/Caching/MessageDescriptorCache.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Caching/MessageDescriptorCache.cs
@@ -14,22 +14,31 @@ internal sealed class MessageDescriptorCache(IDescriptorCacheStrategy strategy)
     private readonly IDescriptorCacheStrategy _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
 
     /// <summary>
+    /// A cached value stamped with the registry version its build STARTED at. The stamp
+    /// closes the invalidate/add race: a build that began before a registration completes
+    /// may finish (and store) after the invalidation clear, but it carries the old
+    /// version, so readers at the new version miss it and rebuild instead of serving a
+    /// stale pipeline until the next (possibly never-coming) version bump.
+    /// </summary>
+    private readonly record struct VersionedEntry<T>(int Version, T Value);
+
+    /// <summary>
     /// Hot-path cache for resolved dependencies keyed by message type (no groups —
     /// the common case). Avoids building string keys on every dispatch.
     /// </summary>
-    private readonly ConcurrentDictionary<Type, IMessageDependencies> _dependenciesByType = new();
+    private readonly ConcurrentDictionary<Type, VersionedEntry<IMessageDependencies>> _dependenciesByType = new();
 
     /// <summary>
     /// Hot-path cache for resolved dependencies keyed by message type and group set.
     /// </summary>
-    private readonly ConcurrentDictionary<GroupedDependenciesKey, IMessageDependencies> _dependenciesByTypeAndGroups = new();
+    private readonly ConcurrentDictionary<GroupedDependenciesKey, VersionedEntry<IMessageDependencies>> _dependenciesByTypeAndGroups = new();
 
     /// <summary>
     /// Process-wide cache of provider-independent pipeline shapes (ordered, group-filtered
     /// descriptor arrays). Scoped dispatches materialize cheap lazy wrappers over these.
     /// </summary>
-    private readonly ConcurrentDictionary<Type, MessagePipelineShape> _shapesByType = new();
-    private readonly ConcurrentDictionary<GroupedDependenciesKey, MessagePipelineShape> _shapesByTypeAndGroups = new();
+    private readonly ConcurrentDictionary<Type, VersionedEntry<MessagePipelineShape>> _shapesByType = new();
+    private readonly ConcurrentDictionary<GroupedDependenciesKey, VersionedEntry<MessagePipelineShape>> _shapesByTypeAndGroups = new();
 
     private int _registryVersion = -1;
 
@@ -83,46 +92,67 @@ internal sealed class MessageDescriptorCache(IDescriptorCacheStrategy strategy)
 
     /// <summary>
     /// Returns the cached provider-independent pipeline shape for the message type and
-    /// group set, building it from the descriptor on first use.
+    /// group set, building it from the descriptor on first use. A cached shape counts
+    /// only when it was built at the given registry version — a stale entry (a build that
+    /// raced a registration) is rebuilt and overwritten in place.
     /// </summary>
-    public MessagePipelineShape GetOrAddShape(Type messageType, string[] groups, IMessageDescriptor descriptor)
+    public MessagePipelineShape GetOrAddShape(Type messageType, string[] groups, IMessageDescriptor descriptor, int registryVersion)
     {
         if (groups.Length == 0)
         {
-            if (_shapesByType.TryGetValue(messageType, out var shape))
+            if (_shapesByType.TryGetValue(messageType, out var entry) && entry.Version == registryVersion)
             {
-                return shape;
+                return entry.Value;
             }
 
-            return _shapesByType.GetOrAdd(messageType, MessagePipelineShape.Create(messageType, descriptor, groups));
+            var shape = MessagePipelineShape.Create(messageType, descriptor, groups);
+            _shapesByType[messageType] = new VersionedEntry<MessagePipelineShape>(registryVersion, shape);
+            return shape;
         }
 
         var key = new GroupedDependenciesKey(messageType, groups);
 
-        if (_shapesByTypeAndGroups.TryGetValue(key, out var groupedShape))
+        if (_shapesByTypeAndGroups.TryGetValue(key, out var groupedEntry) && groupedEntry.Version == registryVersion)
         {
-            return groupedShape;
+            return groupedEntry.Value;
         }
 
-        return _shapesByTypeAndGroups.GetOrAdd(key, MessagePipelineShape.Create(messageType, descriptor, groups));
+        var groupedShape = MessagePipelineShape.Create(messageType, descriptor, groups);
+        _shapesByTypeAndGroups[key] = new VersionedEntry<MessagePipelineShape>(registryVersion, groupedShape);
+        return groupedShape;
     }
 
-    public bool TryGetDependencies(Type messageType, string[] groups, out IMessageDependencies? dependencies)
+    /// <summary>
+    /// A cached entry counts only when it was built at the given registry version; see
+    /// <see cref="VersionedEntry{T}"/> for why a bare presence check is not enough.
+    /// </summary>
+    public bool TryGetDependencies(Type messageType, string[] groups, int registryVersion, out IMessageDependencies? dependencies)
     {
-        return groups.Length == 0
-            ? _dependenciesByType.TryGetValue(messageType, out dependencies)
-            : _dependenciesByTypeAndGroups.TryGetValue(new GroupedDependenciesKey(messageType, groups), out dependencies);
+        var found = groups.Length == 0
+            ? _dependenciesByType.TryGetValue(messageType, out var entry)
+            : _dependenciesByTypeAndGroups.TryGetValue(new GroupedDependenciesKey(messageType, groups), out entry);
+
+        if (found && entry.Version == registryVersion)
+        {
+            dependencies = entry.Value;
+            return true;
+        }
+
+        dependencies = null;
+        return false;
     }
 
-    public void AddDependencies(Type messageType, string[] groups, IMessageDependencies dependencies)
+    public void AddDependencies(Type messageType, string[] groups, IMessageDependencies dependencies, int registryVersion)
     {
+        var entry = new VersionedEntry<IMessageDependencies>(registryVersion, dependencies);
+
         if (groups.Length == 0)
         {
-            _dependenciesByType[messageType] = dependencies;
+            _dependenciesByType[messageType] = entry;
         }
         else
         {
-            _dependenciesByTypeAndGroups[new GroupedDependenciesKey(messageType, groups)] = dependencies;
+            _dependenciesByTypeAndGroups[new GroupedDependenciesKey(messageType, groups)] = entry;
         }
     }
 

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -69,23 +69,29 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
             _servicesResolved = true;
         }
 
+        // The registry version is read ONCE, before any shape or dependency build, and
+        // stamps every cache entry this call produces: a build racing a registration
+        // then lands with the old version and the next reader rebuilds instead of
+        // serving a stale pipeline. MessageRegistry.Version also changes when handlers
+        // are added to existing messages; Count is the fallback for foreign registry
+        // implementations, and 0 the constant when no registry is resolvable at all.
+        var registryVersion = 0;
+
         if (_registry is not null)
         {
-            // MessageRegistry.Version also changes when handlers are added to existing
-            // messages; Count is the fallback for foreign registry implementations.
-            var registryVersion = _registry is MessageRegistry registry ? registry.Version : _registry.Count;
+            registryVersion = _registry is MessageRegistry registry ? registry.Version : _registry.Count;
             cache.InvalidateIfRegistryChanged(registryVersion);
             _handlerLifetimes?.InvalidateIfRegistryChanged(registryVersion);
         }
 
         var groupsArray = groups as string[] ?? groups.ToArray();
 
-        if (cache.TryGetDependencies(messageType, groupsArray, out var cached))
+        if (cache.TryGetDependencies(messageType, groupsArray, registryVersion, out var cached))
         {
             return cached!;
         }
 
-        var shape = cache.GetOrAddShape(messageType, groupsArray, descriptor);
+        var shape = cache.GetOrAddShape(messageType, groupsArray, descriptor, registryVersion);
 
         // Pipelines that are fully singleton-registered (or forced via MemoizeAllHandlers)
         // cache handler instances inside their references, pinned to the root provider.
@@ -95,7 +101,7 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
         var dependencies = new MessageDependencies(
             shape, memoizeInstances ? _memoizedGraphProvider ?? serviceProvider : null);
 
-        cache.AddDependencies(messageType, groupsArray, dependencies);
+        cache.AddDependencies(messageType, groupsArray, dependencies, registryVersion);
 
         return dependencies;
     }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
@@ -23,7 +23,7 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
     string[] groups,
     Func<THandler>? directHandlerFactory = null,
     Func<IServiceProvider, THandler>? providerHandlerFactory = null) : IPipelineExecutor<TResult>
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
     where THandler : class, IAsyncHandler<TMessage, TResult>
 {
     private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions;
+﻿using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -77,9 +77,12 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            if (cached is not null && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -92,7 +95,7 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
                 && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
                 && plannedType == typeof(THandler)
                 && typedFactory.IsPlainTransientRegistration(typeof(THandler));
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
@@ -25,7 +25,7 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     string[] groups,
     Func<THandler>? directHandlerFactory = null,
     Func<IServiceProvider, THandler>? providerHandlerFactory = null) : IPipelineExecutor
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
     where THandler : class, IAsyncHandler<TMessage>
 {
     private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions;
+﻿using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -97,9 +97,12 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            if (cached is not null && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -112,7 +115,7 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
                 && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
                 && plannedType == typeof(THandler)
                 && typedFactory.IsPlainTransientRegistration(typeof(THandler));
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutorCache.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/PipelineExecutorCache.cs
@@ -214,8 +214,11 @@ internal sealed class PipelineExecutorCache(
     /// at most one graph per message type, which in a single-container process is the
     /// live one anyway — a WeakReference would tax every hot-path read instead.
     /// </summary>
+    // The type parameter is the cache key: one static slot per closed message type.
+    // ReSharper disable once UnusedTypeParameter
     private static class VoidExecutorHolder<TMessage> where TMessage : IMessage
     {
+        // ReSharper disable once StaticMemberInGenericType
         public static VoidExecutorSlot? Slot;
     }
 
@@ -232,6 +235,8 @@ internal sealed class PipelineExecutorCache(
                 static (t, cache) => cache.CreateVoidExecutor(t, EmptyGroups), this);
         }
 
+        // Deliberate: groups is matched allocation-free first and only materialized on a slot miss.
+        // ReSharper disable once PossibleMultipleEnumeration
         if (_groupedVoidSlotsByType.TryGetValue(messageType, out var slot)
             && SlotMatches(groups, slot.Groups, slot.Canonical))
         {
@@ -241,6 +246,7 @@ internal sealed class PipelineExecutorCache(
         // A canonical set contributes its immutable name array and precomputed key
         // directly — the refresh allocates nothing for it.
         var canonical = groups as GroupSet;
+        // ReSharper disable once PossibleMultipleEnumeration
         var materializedGroups = canonical?.Names ?? MaterializeGroups(groups);
         var key = (messageType, canonical?.JoinedKey ?? GroupsKey(materializedGroups));
 
@@ -272,6 +278,8 @@ internal sealed class PipelineExecutorCache(
             return GetExecutorSlow<TResult>(messageType);
         }
 
+        // Deliberate: groups is matched allocation-free first and only materialized on a slot miss.
+        // ReSharper disable once PossibleMultipleEnumeration
         if (_groupedResultSlotsByType.TryGetValue(messageType, out var groupedSlot)
             && ReferenceEquals(groupedSlot.ResultType, typeof(TResult))
             && SlotMatches(groups, groupedSlot.Groups, groupedSlot.Canonical))
@@ -282,6 +290,7 @@ internal sealed class PipelineExecutorCache(
         }
 
         var canonical = groups as GroupSet;
+        // ReSharper disable once PossibleMultipleEnumeration
         var materializedGroups = canonical?.Names ?? MaterializeGroups(groups);
         var key = (messageType, typeof(TResult), canonical?.JoinedKey ?? GroupsKey(materializedGroups));
 
@@ -464,7 +473,7 @@ internal sealed class PipelineExecutorCache(
         public static readonly GeneratedVoidExecutorVisitor Instance = new();
 
         public IPipelineExecutor Visit<TMessage, THandler>(ExecutorState state)
-            where TMessage : notnull, IMessage
+            where TMessage : IMessage
             where THandler : class, IAsyncHandler<TMessage>
             => new GeneratedVoidPipelineExecutor<TMessage, THandler>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
@@ -482,7 +491,7 @@ internal sealed class PipelineExecutorCache(
         public static readonly GeneratedResultExecutorVisitor Instance = new();
 
         public object Visit<TMessage, TResult, THandler>(ExecutorState state)
-            where TMessage : notnull, IMessage
+            where TMessage : IMessage
             where THandler : class, IAsyncHandler<TMessage, TResult>
             => new GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
@@ -499,7 +508,7 @@ internal sealed class PipelineExecutorCache(
         public static readonly StagedVoidExecutorVisitor Instance = new();
 
         public IPipelineExecutor Visit<TMessage>(ExecutorState state)
-            where TMessage : notnull, IMessage
+            where TMessage : IMessage
             => new StagedVoidPipelineExecutor<TMessage>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
                 (StagedVoidPlan<TMessage>)state.StagedPlan!);
@@ -511,7 +520,7 @@ internal sealed class PipelineExecutorCache(
         public static readonly StagedResultExecutorVisitor Instance = new();
 
         public object Visit<TMessage, TResult>(ExecutorState state)
-            where TMessage : notnull, IMessage
+            where TMessage : IMessage
             => new StagedResultPipelineExecutor<TMessage, TResult>(
                 state.Descriptor, state.DependenciesFactory, state.ResultAdapterService, state.Groups,
                 (StagedResultPlan<TMessage, TResult>)state.StagedPlan!);

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions;
+﻿using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -69,9 +69,12 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            if (cached is not null && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -81,7 +84,7 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
             var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
             _cachedFastDependencies = dependencies as MessageDependencies;
             _cachedDependencies = dependencies;
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedPlanGate.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedPlanGate.cs
@@ -1,6 +1,7 @@
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.StagedPlans;
+using Stella.Ergosfare.Core.Internal.Factories;
 
 namespace Stella.Ergosfare.Core.Internal.Mediator;
 
@@ -34,6 +35,33 @@ internal static class StagedPlanGate
         for (var i = 0; i < baked.Length; i++)
         {
             if (stage[i].HandlerType != baked[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The direct-construction gate on top of a composition match: every participant's
+    /// effective DI registration must be the module's own plain transient one — the
+    /// single shape where a plan constructing participants with <c>new</c> is observably
+    /// identical to container resolution. Any override (user factory, lifetime change)
+    /// routes the plan back to its provider-resolving variant.
+    /// </summary>
+    internal static bool AllPlainTransient(MessageDependenciesFactory factory, StagedPlanComposition composition)
+        => factory.IsPlainTransientRegistration(composition.HandlerType)
+           && StagePlainTransient(factory, composition.PreInterceptorTypeArray)
+           && StagePlainTransient(factory, composition.PostInterceptorTypeArray)
+           && StagePlainTransient(factory, composition.ExceptionInterceptorTypeArray)
+           && StagePlainTransient(factory, composition.FinalInterceptorTypeArray);
+
+    private static bool StagePlainTransient(MessageDependenciesFactory factory, Type[] participants)
+    {
+        foreach (var participant in participants)
+        {
+            if (!factory.IsPlainTransientRegistration(participant))
             {
                 return false;
             }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedResultPipelineExecutor[TMessage,TResult].cs
@@ -17,7 +17,7 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
     IResultAdapterService? resultAdapterService,
     string[] groups,
     StagedResultPlan<TMessage, TResult> plan) : IPipelineExecutor<TResult>
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
 {
     private readonly SingleAsyncHandlerMediationStrategy<TMessage, TResult> _strategy = new(resultAdapterService);
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedResultPipelineExecutor[TMessage,TResult].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions;
+﻿using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.StagedPlans;
@@ -27,6 +27,7 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
     private IMessageDependencies? _cachedDependencies;
     private int _cachedVersion = int.MinValue;
     private bool _useStagedPlan;
+    private bool _useDirectConstruction;
 
     public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -34,7 +35,9 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
 
         if (_useStagedPlan)
         {
-            return plan.Execute((TMessage)message, context, serviceProvider);
+            return _useDirectConstruction
+                ? plan.ExecuteDirect((TMessage)message, context, serviceProvider)
+                : plan.Execute((TMessage)message, context, serviceProvider);
         }
 
         return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
@@ -44,9 +47,12 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            if (cached is not null && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -57,11 +63,15 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
                 && (_concreteAdapters is null || _concreteAdapters.IsEmpty)
                 && dependencies is MessageDependencies { MemoizedInstances: false } fastDependencies
                 && StagedPlanGate.Matches(fastDependencies, plan.Composition);
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _useDirectConstruction = _useStagedPlan
+                && plan.SupportsDirectConstruction
+                && StagedPlanGate.AllPlainTransient(typedFactory, plan.Composition);
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 
         _useStagedPlan = false;
+        _useDirectConstruction = false;
         return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedVoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedVoidPipelineExecutor[TMessage].cs
@@ -24,7 +24,7 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
     IResultAdapterService? resultAdapterService,
     string[] groups,
     StagedVoidPlan<TMessage> plan) : IPipelineExecutor
-    where TMessage : notnull, IMessage
+    where TMessage : IMessage
 {
     private readonly SingleAsyncHandlerMediationStrategy<TMessage> _strategy = new(resultAdapterService);
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedVoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedVoidPipelineExecutor[TMessage].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions;
+﻿using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.StagedPlans;
@@ -34,6 +34,7 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
     private IMessageDependencies? _cachedDependencies;
     private int _cachedVersion = int.MinValue;
     private bool _useStagedPlan;
+    private bool _useDirectConstruction;
 
     public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -41,7 +42,9 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
 
         if (_useStagedPlan)
         {
-            return plan.Execute((TMessage)message, context, serviceProvider);
+            return _useDirectConstruction
+                ? plan.ExecuteDirect((TMessage)message, context, serviceProvider)
+                : plan.Execute((TMessage)message, context, serviceProvider);
         }
 
         return _strategy.Mediate((TMessage)message, dependencies, context, serviceProvider);
@@ -51,9 +54,12 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            if (cached is not null && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -64,11 +70,15 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
                 && (_concreteAdapters is null || _concreteAdapters.IsEmpty)
                 && dependencies is MessageDependencies { MemoizedInstances: false } fastDependencies
                 && StagedPlanGate.Matches(fastDependencies, plan.Composition);
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _useDirectConstruction = _useStagedPlan
+                && plan.SupportsDirectConstruction
+                && StagedPlanGate.AllPlainTransient(typedFactory, plan.Composition);
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 
         _useStagedPlan = false;
+        _useDirectConstruction = false;
         return dependenciesFactory.Create(typeof(TMessage), descriptor, groups);
     }
 }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions;
+﻿using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -56,9 +56,12 @@ internal sealed class VoidPipelineExecutor<TMessage>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == typedFactory.CurrentRegistryVersion)
+            if (cached is not null && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -66,7 +69,7 @@ internal sealed class VoidPipelineExecutor<TMessage>(
             var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
             _cachedFastDependencies = dependencies as MessageDependencies;
             _cachedDependencies = dependencies;
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Registry/Descriptors/MessageDescriptor.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/Descriptors/MessageDescriptor.cs
@@ -106,7 +106,7 @@ internal class MessageDescriptor(Type messageType) : IMessageDescriptor
     /// <summary>
     /// Adds a single handler descriptor to this message descriptor.
     /// Direct or indirect placement depends on whether the descriptor's
-    /// <see cref="IHandlerDescriptor.MessageType"/> exactly matches or is assignable to the message type.
+    /// <see cref="IHasMessageType.MessageType"/> exactly matches or is assignable to the message type.
     /// </summary>
     /// <param name="descriptor">The descriptor to add.</param>
     public void AddDescriptor(IHandlerDescriptor descriptor)

--- a/src/Stella.Ergosfare.Core/Internal/Registry/MessageRegistry.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Registry/MessageRegistry.cs
@@ -146,6 +146,7 @@ internal sealed class MessageRegistry(
 
         // Lock-free fast path: already-processed types (every dispatch-time re-registration
         // attempt after the first) never touch the gate.
+        // ReSharper disable once InconsistentlySynchronizedField
         if (_processedTypes.ContainsKey(type))
         {
             return;
@@ -227,6 +228,7 @@ internal sealed class MessageRegistry(
     private void Publish()
     {
         Interlocked.Increment(ref _version);
+        // ReSharper disable once InconsistentlySynchronizedField
         _snapshot = _messages.ToArray();
     }
 
@@ -336,6 +338,8 @@ internal sealed class MessageRegistry(
         // Create a new MessageDescriptor and stage it in the newMessages list
         var descriptor = new MessageDescriptor(messageType);
         _messageIndex[messageType] = descriptor;
+        // Only reachable from registration paths that already hold _gate.
+        // ReSharper disable once InconsistentlySynchronizedField
         _newMessages.Add(descriptor);
     }
 }

--- a/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
+++ b/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
@@ -122,7 +122,7 @@ public sealed class MessageDispatchEngine
     /// <param name="cancellationToken">Cancellation token for the dispatch.</param>
     public ValueTask DispatchVoidAsync<TMessage>(TMessage message, IServiceProvider serviceProvider,
         IDictionary<object, object?>? items = null, CancellationToken cancellationToken = default)
-        where TMessage : notnull, IMessage
+        where TMessage : IMessage
     {
         ArgumentNullException.ThrowIfNull(message);
 

--- a/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
@@ -10,7 +10,7 @@ public sealed class EventMediationSettings
     /// Gets or sets a value indicating whether an exception should be thrown
     /// if no handlers are found for a published event.
     /// </summary>
-    public bool ThrowIfNoHandlerFound { get; init; } = false;
+    public bool ThrowIfNoHandlerFound { get; init; }
 
 
     /// <summary>

--- a/src/Stella.Ergosfare.Events.Abstractions/PreInterceptors/IEventPreInterceptor[TEvent,TEvent].cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/PreInterceptors/IEventPreInterceptor[TEvent,TEvent].cs
@@ -38,10 +38,6 @@ public interface IEventPreInterceptor<in TEvent,  TModifiedEvent>: IAsyncPreInte
     /// Represents a type-safe pre-interceptor for events that can optionally modify
     /// the event before it reaches its handlers.
     /// </summary>
-    /// <typeparam name="TEvent">The type of the original event being intercepted. Must implement <see cref="IEvent"/>.</typeparam>
-    /// <typeparam name="TModifiedEvent">
-    /// The type of event returned after pre-processing. Must be the same or derived from <typeparamref name="TEvent"/>.
-    /// </typeparam>
     /// <remarks>
     /// <para>
     /// Implementing this interface allows pre-processing logic to run before the event

--- a/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
+++ b/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
@@ -13,6 +13,8 @@ namespace Stella.Ergosfare.Events;
 internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     where TEvent : notnull
 {
+    // One copy per closed event type is deliberate — the invoker itself is per-event-type.
+    // ReSharper disable once StaticMemberInGenericType
     private static readonly string[] EmptyGroups = [];
 
     /// <summary>
@@ -20,6 +22,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     /// settings instance is private and never mutated, and the strategy keeps all
     /// per-publish state in locals — one instance serves concurrent publishes.
     /// </summary>
+    // ReSharper disable once StaticMemberInGenericType
     private static readonly EventMediationSettings DefaultSettings = new();
     private static readonly AsyncBroadcastMediationStrategy<TEvent> DefaultStrategy = new(DefaultSettings);
 
@@ -301,6 +304,8 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             var registryVersion = typedFactory.CurrentRegistryVersion;
             var slot = _cachedGroupedPlan;
 
+            // Deliberate: groups is matched allocation-free first and only materialized on a slot miss.
+            // ReSharper disable once PossibleMultipleEnumeration
             if (slot is not null
                 && ReferenceEquals(slot.Factory, typedFactory)
                 && slot.Version == registryVersion
@@ -311,6 +316,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
 
             // A canonical set contributes its immutable name array directly.
             var canonical = groups as GroupSet;
+            // ReSharper disable once PossibleMultipleEnumeration
             var materialized = canonical?.Names ?? [.. groups];
             var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
             _cachedGroupedPlan = new GroupedPlanSlot(
@@ -400,7 +406,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     /// broadcast strategy applies.
     /// </summary>
     private static ValueTask Invoke(
-        Core.Abstractions.IHandlerReference<Core.Abstractions.Handlers.IHandler, Core.Abstractions.Registry.Descriptors.IMainHandlerDescriptor> reference,
+        IHandlerReference<Core.Abstractions.Handlers.IHandler, Core.Abstractions.Registry.Descriptors.IMainHandlerDescriptor> reference,
         TEvent @event,
         IExecutionContext context,
         IServiceProvider serviceProvider)

--- a/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
+++ b/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
@@ -234,6 +234,9 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
             // The invoker is process-wide (one per event type) while factories are
@@ -244,7 +247,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             // factory's own per-container cache keeps that cheap.
             if (cached is not null
                 && ReferenceEquals(_cachedFactory, typedFactory)
-                && _cachedVersion == typedFactory.CurrentRegistryVersion)
+                && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -252,7 +255,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
             _cachedDependencies = dependencies;
             _cachedFactory = typedFactory;
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 
@@ -293,11 +296,14 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var slot = _cachedGroupedPlan;
 
             if (slot is not null
                 && ReferenceEquals(slot.Factory, typedFactory)
-                && slot.Version == typedFactory.CurrentRegistryVersion
+                && slot.Version == registryVersion
                 && PipelineExecutorCache.SlotMatches(groups, slot.Groups, slot.Canonical))
             {
                 return slot.Dependencies;
@@ -308,7 +314,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             var materialized = canonical?.Names ?? [.. groups];
             var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
             _cachedGroupedPlan = new GroupedPlanSlot(
-                typedFactory, materialized, canonical, dependencies, typedFactory.CurrentRegistryVersion);
+                typedFactory, materialized, canonical, dependencies, registryVersion);
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Queries.Abstractions/IQueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/IQueryMediator.cs
@@ -37,7 +37,7 @@ public interface IQueryMediator: IMessage
     /// <param name="context">The externally owned execution context to dispatch under.</param>
     /// <param name="queryMediationSettings">Optional mediation settings (groups etc.).</param>
     ValueTask<TQueryResult> QueryAsync<TQueryResult>(IQuery<TQueryResult> query,
-                                                Core.Abstractions.IExecutionContext context,
+                                                IExecutionContext context,
                                                 QueryMediationSettings? queryMediationSettings = null);
 
     /// <summary>

--- a/src/Stella.Ergosfare.Queries.Abstractions/PostInterceptors/IQueryPostInterceptor[TQuery,TResult].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/PostInterceptors/IQueryPostInterceptor[TQuery,TResult].cs
@@ -27,7 +27,7 @@ public interface IQueryPostInterceptor<in TQuery, TResult> : IQuery, IAsyncPostI
     /// <inheritdoc />
     async ValueTask<object> IAsyncPostInterceptor<TQuery, TResult>.HandleAsync(
         TQuery query, TResult messageResult, IExecutionContext context)
-        => (await HandleAsync(query, messageResult, context))!;
+        => await HandleAsync(query, messageResult, context);
 
     /// <summary>
     /// Handles the post-processing of a query asynchronously.

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/EngineBackedQueryMediator.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/EngineBackedQueryMediator.cs
@@ -1,6 +1,5 @@
 using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
-using Stella.Ergosfare.Queries;
 
 namespace Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
@@ -1,5 +1,4 @@
 ﻿using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
-using Stella.Ergosfare.Queries;
 using Stella.Ergosfare.Queries.Abstractions;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModuleRegistryExtensions.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModuleRegistryExtensions.cs
@@ -10,7 +10,7 @@ public static class QueryModuleRegistryExtensions
     
     /// <summary>
     /// Adds the query module to the specified module registry, allowing registration
-    /// of query types and enabling the <see cref="IQueryMediator"/> for dispatching queries.
+    /// of query types and enabling the <see cref="Abstractions.IQueryMediator"/> for dispatching queries.
     /// </summary>
     /// <param name="registry">The module registry to which the query module will be added.</param>
     /// <param name="builder">

--- a/src/Stella.Ergosfare.Queries/QueryStreamInvoker[TQuery,TResult].cs
+++ b/src/Stella.Ergosfare.Queries/QueryStreamInvoker[TQuery,TResult].cs
@@ -11,6 +11,8 @@ namespace Stella.Ergosfare.Queries;
 internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<TResult>
     where TQuery : notnull
 {
+    // One copy per closed query type is deliberate — the invoker itself is per-query-type.
+    // ReSharper disable once StaticMemberInGenericType
     private static readonly string[] EmptyGroups = [];
 
     /// <summary>
@@ -18,6 +20,7 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
     /// carries none); a single shared empty instance preserves that behavior without the
     /// per-call allocation. Never exposed, so it cannot be mutated.
     /// </summary>
+    // ReSharper disable once StaticMemberInGenericType
     private static readonly ResultAdapterService SharedEmptyAdapters = new();
 
     public IAsyncEnumerable<TResult> Stream(object query, QueryMediationSettings? settings, CancellationToken cancellationToken,
@@ -130,6 +133,8 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
             var registryVersion = typedFactory.CurrentRegistryVersion;
             var slot = _cachedGroupedPlan;
 
+            // Deliberate: groups is matched allocation-free first and only materialized on a slot miss.
+            // ReSharper disable once PossibleMultipleEnumeration
             if (slot is not null
                 && ReferenceEquals(slot.Factory, typedFactory)
                 && slot.Version == registryVersion
@@ -139,6 +144,7 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
             }
 
             var canonical = groups as GroupSet;
+            // ReSharper disable once PossibleMultipleEnumeration
             string[] materialized = [.. groups];
             var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
             _cachedGroupedPlan = new GroupedPlanSlot(

--- a/src/Stella.Ergosfare.Queries/QueryStreamInvoker[TQuery,TResult].cs
+++ b/src/Stella.Ergosfare.Queries/QueryStreamInvoker[TQuery,TResult].cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core;
+﻿using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
@@ -73,11 +73,14 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var cached = _cachedDependencies;
 
             if (cached is not null
                 && ReferenceEquals(_cachedFactory, typedFactory)
-                && _cachedVersion == typedFactory.CurrentRegistryVersion)
+                && _cachedVersion == registryVersion)
             {
                 return cached;
             }
@@ -85,7 +88,7 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
             var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
             _cachedDependencies = dependencies;
             _cachedFactory = typedFactory;
-            _cachedVersion = typedFactory.CurrentRegistryVersion;
+            _cachedVersion = registryVersion;
             return dependencies;
         }
 
@@ -122,11 +125,14 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
+            // Read before the build: a registration completing mid-build must land as a
+            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
+            var registryVersion = typedFactory.CurrentRegistryVersion;
             var slot = _cachedGroupedPlan;
 
             if (slot is not null
                 && ReferenceEquals(slot.Factory, typedFactory)
-                && slot.Version == typedFactory.CurrentRegistryVersion
+                && slot.Version == registryVersion
                 && Core.Internal.Mediator.PipelineExecutorCache.SlotMatches(groups, slot.Groups, slot.Canonical))
             {
                 return slot.Dependencies;
@@ -136,7 +142,7 @@ internal sealed class QueryStreamInvoker<TQuery, TResult> : IQueryStreamInvoker<
             string[] materialized = [.. groups];
             var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
             _cachedGroupedPlan = new GroupedPlanSlot(
-                typedFactory, materialized, canonical, dependencies, typedFactory.CurrentRegistryVersion);
+                typedFactory, materialized, canonical, dependencies, registryVersion);
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Stella.Ergosfare.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,5 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ERGOSG001 | Usage | Warning | Registrable type is not accessible from generated registration code
 ERGOSG002 | Usage | Warning | Registrable type in a referenced assembly is not visible to generated registration code
+ERGOSG003 | Performance | Info | Multiple public constructors keep the handler on the container path
+ERGOSG004 | Usage | Info | [FromServices] has no effect on constructor parameters

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
+
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -69,7 +67,6 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private const string StagedVoidPlanMetadataName = "Stella.Ergosfare.Core.Abstractions.StagedPlans.StagedVoidPlan";
     private const string ServiceProviderExtensionsMetadataName = "Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions";
     private const string KeyedServiceExtensionsMetadataName = "Microsoft.Extensions.DependencyInjection.ServiceProviderKeyedServiceExtensions";
-    private const string DependencyInjectionNamespace = "Microsoft.Extensions.DependencyInjection";
 
     private const string ScanReferencesBuildProperty = "build_property.ErgosfareSourceGeneratorScanReferences";
     private const string ErgosfareAssemblyNamePrefix = "Stella.Ergosfare";

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -66,6 +66,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private const string ValueTaskExpression = "global::System.Threading.Tasks.ValueTask";
     private const string DescriptorCatalogMetadataName = "Stella.Ergosfare.Core.Abstractions.GeneratedDescriptorCatalog";
 
+    private const string StagedVoidPlanMetadataName = "Stella.Ergosfare.Core.Abstractions.StagedPlans.StagedVoidPlan";
     private const string ServiceProviderExtensionsMetadataName = "Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions";
     private const string KeyedServiceExtensionsMetadataName = "Microsoft.Extensions.DependencyInjection.ServiceProviderKeyedServiceExtensions";
     private const string DependencyInjectionNamespace = "Microsoft.Extensions.DependencyInjection";
@@ -121,6 +122,9 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 DispatchRootsHasStagedPlans: dispatchRoots is not null
                     && !dispatchRoots.GetMembers("AddStagedPlan").IsEmpty
                     && compilation.GetTypeByMetadataName(ServiceProviderExtensionsMetadataName) is not null,
+                StagedPlansSupportDirectConstruction:
+                    compilation.GetTypeByMetadataName(StagedVoidPlanMetadataName) is { } stagedVoidPlan
+                    && !stagedVoidPlan.GetMembers("SupportsDirectConstruction").IsEmpty,
                 HasDescriptorCatalog: compilation.GetTypeByMetadataName(DescriptorCatalogMetadataName) is not null);
         });
 
@@ -270,6 +274,30 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         IAssemblySymbol? currentAssembly,
         out bool usesKeyedServices)
     {
+        var construction = TryBuildConstructionExpression(
+            symbol, handlerTypeExpression, currentAssembly, "provider", allowParameterless: false, out usesKeyedServices);
+
+        return construction is null ? null : "static provider => " + construction;
+    }
+
+    /// <summary>
+    ///     Builds the bare <c>new T(...)</c> expression for a participant whose
+    ///     construction is provably identical to container activation (see
+    ///     <see cref="GetProviderConstructionExpression"/> for the gate), resolving
+    ///     constructor dependencies from the given provider identifier. The staged plans'
+    ///     direct-construction emission consumes it with <c>serviceProvider</c>; the
+    ///     provider factories wrap it in a lambda. Parameterless constructions are only
+    ///     produced when asked for — the plan factories keep those on the cheaper
+    ///     <c>Func&lt;THandler&gt;</c> shape.
+    /// </summary>
+    private static string? TryBuildConstructionExpression(
+        INamedTypeSymbol symbol,
+        string typeExpression,
+        IAssemblySymbol? currentAssembly,
+        string providerIdentifier,
+        bool allowParameterless,
+        out bool usesKeyedServices)
+    {
         usesKeyedServices = false;
 
         if (!HasDirectConstructionShape(symbol))
@@ -295,10 +323,14 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             publicConstructor = constructor;
         }
 
-        // Parameterless construction stays on the cheaper Func<THandler> shape.
-        if (publicConstructor is null || publicConstructor.Parameters.IsEmpty)
+        if (publicConstructor is null)
         {
             return null;
+        }
+
+        if (publicConstructor.Parameters.IsEmpty)
+        {
+            return allowParameterless ? "new " + typeExpression + "()" : null;
         }
 
         var arguments = new List<string>(publicConstructor.Parameters.Length);
@@ -344,16 +376,16 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 return null;
             }
 
-            var typeExpression = parameterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            var parameterTypeExpression = parameterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
             arguments.Add(keyLiteral is null
-                ? "global::" + ServiceProviderExtensionsMetadataName + ".GetRequiredService<" + typeExpression + ">(provider)"
-                : "global::" + KeyedServiceExtensionsMetadataName + ".GetRequiredKeyedService<" + typeExpression + ">(provider, " + keyLiteral + ")");
+                ? "global::" + ServiceProviderExtensionsMetadataName + ".GetRequiredService<" + parameterTypeExpression + ">(" + providerIdentifier + ")"
+                : "global::" + KeyedServiceExtensionsMetadataName + ".GetRequiredKeyedService<" + parameterTypeExpression + ">(" + providerIdentifier + ", " + keyLiteral + ")");
 
             usesKeyedServices |= keyLiteral is not null;
         }
 
-        return "static provider => new " + handlerTypeExpression + "(" + string.Join(", ", arguments) + ")";
+        return "new " + typeExpression + "(" + string.Join(", ", arguments) + ")";
     }
 
     /// <summary>
@@ -503,6 +535,17 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             ? GetProviderConstructionExpression(symbol, typeofExpression, symbol.ContainingAssembly, out usesKeyedServices)
             : null;
 
+        // Informational diagnostics apply to pipeline participants declared in source —
+        // the only place the user can act on them.
+        var hasMultipleCtors = !descriptors.IsEmpty && HasMultiplePublicInstanceConstructors(symbol);
+        var hasFromServices = !descriptors.IsEmpty && HasFromServicesOnConstructor(symbol);
+
+        var stagedKeyedServices = false;
+        var stagedConstruction = isAccessible && !descriptors.IsEmpty
+            ? TryBuildConstructionExpression(symbol, typeofExpression, symbol.ContainingAssembly,
+                "serviceProvider", allowParameterless: true, out stagedKeyedServices)
+            : null;
+
         return new RegistrableTypeModel
         {
             TypeofExpression = typeofExpression,
@@ -527,7 +570,46 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsNestedType = symbol.ContainingType is not null,
             AssignableKeys = isDispatchable ? GetAssignableKeys(symbol) : ImmutableArray<string>.Empty,
             ContractShapes = isAccessible ? BuildContractShapes(symbol) : ImmutableArray<ContractShapeModel>.Empty,
+            StagedConstructionExpression = stagedConstruction,
+            StagedConstructionUsesKeyedServices = stagedKeyedServices,
+            HasMultiplePublicConstructors = hasMultipleCtors,
+            HasFromServicesConstructorParameter = hasFromServices,
+            InfoLocation = hasMultipleCtors || hasFromServices ? LocationInfo.From(symbol) : null,
         };
+    }
+
+    private static bool HasMultiplePublicInstanceConstructors(INamedTypeSymbol symbol)
+    {
+        var count = 0;
+
+        foreach (var constructor in symbol.InstanceConstructors)
+        {
+            if (constructor.DeclaredAccessibility == Accessibility.Public && ++count > 1)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasFromServicesOnConstructor(INamedTypeSymbol symbol)
+    {
+        foreach (var constructor in symbol.InstanceConstructors)
+        {
+            foreach (var parameter in constructor.Parameters)
+            {
+                foreach (var attribute in parameter.GetAttributes())
+                {
+                    if (attribute.AttributeClass is { Name: "FromServicesAttribute" })
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -1005,6 +1087,12 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             ? GetProviderConstructionExpression(symbol, typeofExpression, currentAssembly: null, out usesKeyedServices)
             : null;
 
+        var referencedStagedKeyedServices = false;
+        var referencedStagedConstruction = isAccessible && !descriptors.IsEmpty
+            ? TryBuildConstructionExpression(symbol, typeofExpression, currentAssembly: null,
+                "serviceProvider", allowParameterless: true, out referencedStagedKeyedServices)
+            : null;
+
         return new RegistrableTypeModel
         {
             TypeofExpression = typeofExpression,
@@ -1029,6 +1117,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             IsNestedType = symbol.ContainingType is not null,
             AssignableKeys = isDispatchable ? GetAssignableKeys(symbol) : ImmutableArray<string>.Empty,
             ContractShapes = isAccessible ? BuildContractShapes(symbol) : ImmutableArray<ContractShapeModel>.Empty,
+            StagedConstructionExpression = referencedStagedConstruction,
+            StagedConstructionUsesKeyedServices = referencedStagedKeyedServices,
+            HasMultiplePublicConstructors = false,
+            HasFromServicesConstructorParameter = false,
+            InfoLocation = null,
         };
     }
 
@@ -1111,7 +1204,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             : (IReadOnlyList<ResultPlanModel>)Array.Empty<ResultPlanModel>();
 
         var stagedPlans = availability.DispatchRootsHasStagedPlans
-            ? ComputeStagedPlans(types)
+            ? ComputeStagedPlans(types, availability.HasKeyedServiceExtensions)
             : (IReadOnlyList<StagedPlanModel>)Array.Empty<StagedPlanModel>();
 
         var source = RegistrationEmitter.Emit(types, availability, voidPlans, resultPlans, stagedPlans, GeneratorVersion);
@@ -1130,7 +1223,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     ///     advisory regardless: the hosting executor re-validates the composition per
     ///     registry version.
     /// </summary>
-    private static List<StagedPlanModel> ComputeStagedPlans(List<RegistrableTypeModel> types)
+    private static List<StagedPlanModel> ComputeStagedPlans(List<RegistrableTypeModel> types, bool hasKeyedServiceExtensions)
     {
         CollectPipelineFacts(types, out var handlerCounts, out var soleHandlers, out _);
 
@@ -1186,7 +1279,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 continue;
             }
 
-            if (!TryAssembleStagedStages(type, types, resultTypeExpression, resultIsValueType,
+            if (!TryAssembleStagedStages(type, types, resultTypeExpression, resultIsValueType, hasKeyedServiceExtensions,
                     out var pre, out var post, out var exceptionCalls, out var finalCalls))
             {
                 continue;
@@ -1203,6 +1296,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 resultTypeExpression,
                 resultIsValueType,
                 handler.TypeofExpression,
+                GatedConstructionExpression(handler, hasKeyedServiceExtensions),
                 pre, post, exceptionCalls, finalCalls));
         }
 
@@ -1218,11 +1312,22 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     ///     pipeline result with an inexactly-typed contract (runtime result variance the
     ///     string model cannot verify).
     /// </summary>
+    /// <summary>
+    ///     The participant's staged construction expression, or <c>null</c> when keyed
+    ///     resolutions are needed but the keyed-service extensions are not resolvable in
+    ///     the consuming compilation.
+    /// </summary>
+    private static string? GatedConstructionExpression(RegistrableTypeModel participant, bool hasKeyedServiceExtensions)
+        => participant.StagedConstructionUsesKeyedServices && !hasKeyedServiceExtensions
+            ? null
+            : participant.StagedConstructionExpression;
+
     private static bool TryAssembleStagedStages(
         RegistrableTypeModel message,
         List<RegistrableTypeModel> types,
         string? resultTypeExpression,
         bool resultIsValueType,
+        bool hasKeyedServiceExtensions,
         out ImmutableArray<StagedCallModel> preCalls,
         out ImmutableArray<StagedCallModel> postCalls,
         out ImmutableArray<StagedCallModel> exceptionCalls,
@@ -1316,10 +1421,10 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             }
         }
 
-        preCalls = OrderStage(stages[0]);
-        postCalls = OrderStage(stages[1]);
-        exceptionCalls = OrderStage(stages[2]);
-        finalCalls = OrderStage(stages[3]);
+        preCalls = OrderStage(stages[0], hasKeyedServiceExtensions);
+        postCalls = OrderStage(stages[1], hasKeyedServiceExtensions);
+        exceptionCalls = OrderStage(stages[2], hasKeyedServiceExtensions);
+        finalCalls = OrderStage(stages[3], hasKeyedServiceExtensions);
         return true;
     }
 
@@ -1442,7 +1547,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     ///     non-generic, so the display name equals the runtime <c>Type.FullName</c>).
     /// </summary>
     private static ImmutableArray<StagedCallModel> OrderStage(
-        List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct)>? entries)
+        List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct)>? entries,
+        bool hasKeyedServiceExtensions)
     {
         if (entries is null)
         {
@@ -1469,7 +1575,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
 
         foreach (var (type, arm, _) in entries)
         {
-            calls.Add(new StagedCallModel(type.TypeofExpression, arm));
+            calls.Add(new StagedCallModel(
+                type.TypeofExpression, arm, GatedConstructionExpression(type, hasKeyedServiceExtensions)));
         }
 
         return calls.MoveToImmutable();
@@ -1672,6 +1779,22 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                         model.Location?.ToLocation(),
                         model.DisplayName));
                 continue;
+            }
+
+            if (model.HasMultiplePublicConstructors)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GeneratorDiagnostics.MultiplePublicConstructors,
+                    model.InfoLocation?.ToLocation(),
+                    model.DisplayName));
+            }
+
+            if (model.HasFromServicesConstructorParameter)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GeneratorDiagnostics.FromServicesOnConstructor,
+                    model.InfoLocation?.ToLocation(),
+                    model.DisplayName));
             }
 
             types.Add(model);

--- a/src/Stella.Ergosfare.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/GeneratorDiagnostics.cs
@@ -41,4 +41,38 @@ internal static class GeneratorDiagnostics
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    /// <summary>
+    ///     A handler with several public constructors keeps the container's greedy,
+    ///     content-dependent constructor selection in play, so the generated plans cannot
+    ///     prove direct construction identical to container activation and leave the
+    ///     handler on the container path. Informational: everything still works, only the
+    ///     construction fast path is lost.
+    /// </summary>
+    public static readonly DiagnosticDescriptor MultiplePublicConstructors = new(
+        id: "ERGOSG003",
+        title: "Multiple public constructors keep the handler on the container path",
+        messageFormat:
+            "Handler '{0}' has more than one public constructor, so generated plans cannot prove which one the " +
+            "container would pick and skip its direct-construction fast path. Collapse to a single public " +
+            "constructor to enable it.",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    ///     <c>[FromServices]</c> is an ASP.NET Core action-parameter attribute; on a
+    ///     constructor parameter it does nothing — constructor injection resolves services
+    ///     regardless. Informational so the stray attribute does not suggest behavior that
+    ///     is not there.
+    /// </summary>
+    public static readonly DiagnosticDescriptor FromServicesOnConstructor = new(
+        id: "ERGOSG004",
+        title: "[FromServices] has no effect on constructor parameters",
+        messageFormat:
+            "Type '{0}' carries [FromServices] on a constructor parameter, where it has no effect — constructor " +
+            "injection resolves services regardless. Remove the attribute; for keyed services use [FromKeyedServices].",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
 }

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ModuleBuilderAvailability.cs
@@ -40,6 +40,11 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     Whether the store exposes <c>AddStagedPlan</c> (staged pipeline plans for
 ///     interceptor-bearing messages); older packages simply skip the staged emission.
 /// </param>
+/// <param name="StagedPlansSupportDirectConstruction">
+///     Whether the staged plan bases expose the direct-construction surface
+///     (<c>SupportsDirectConstruction</c>/<c>ExecuteDirect</c>); against older packages
+///     the emission skips the direct variant and plans resolve through the provider.
+/// </param>
 /// <param name="HasDescriptorCatalog">
 ///     Whether <c>GeneratedDescriptorCatalog</c> is resolvable — the lookup that makes
 ///     runtime <c>Register&lt;THandler&gt;()</c> reflection-free for generator-modeled
@@ -61,4 +66,5 @@ internal readonly record struct ModuleBuilderAvailability(
     bool DispatchRootsHasProviderPlanFactories,
     bool HasKeyedServiceExtensions,
     bool DispatchRootsHasStagedPlans,
+    bool StagedPlansSupportDirectConstruction,
     bool HasDescriptorCatalog);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -1,4 +1,4 @@
-using System;
+
 using System.Collections.Immutable;
 
 namespace Stella.Ergosfare.SourceGenerator.Models;

--- a/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/RegistrableTypeModel.cs
@@ -149,6 +149,40 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
     /// </summary>
     public required ImmutableArray<ContractShapeModel> ContractShapes { get; init; }
 
+    /// <summary>
+    ///     The bare <c>new T(...)</c> construction expression for a pipeline participant
+    ///     whose construction is provably identical to container activation, resolving
+    ///     constructor dependencies from the <c>serviceProvider</c> identifier — the
+    ///     staged plans' direct-construction (<c>ExecuteDirect</c>) emission input.
+    ///     <c>null</c> when the participant does not qualify.
+    /// </summary>
+    public required string? StagedConstructionExpression { get; init; }
+
+    /// <summary>
+    ///     Whether <see cref="StagedConstructionExpression"/> resolves any dependency
+    ///     through the keyed-service extensions.
+    /// </summary>
+    public required bool StagedConstructionUsesKeyedServices { get; init; }
+
+    /// <summary>
+    ///     Whether a pipeline participant declares more than one public constructor —
+    ///     the ERGOSG003 info: the container's constructor selection stays in play, so
+    ///     generated plans skip the direct-construction fast path.
+    /// </summary>
+    public required bool HasMultiplePublicConstructors { get; init; }
+
+    /// <summary>
+    ///     Whether any constructor parameter carries <c>[FromServices]</c> — the
+    ///     ERGOSG004 info: the attribute has no effect on constructors.
+    /// </summary>
+    public required bool HasFromServicesConstructorParameter { get; init; }
+
+    /// <summary>
+    ///     Declaration location for the informational diagnostics above; captured only
+    ///     when one of them applies (source-declared types only).
+    /// </summary>
+    public required LocationInfo? InfoLocation { get; init; }
+
     public bool Equals(RegistrableTypeModel other)
     {
         if (TypeofExpression != other.TypeofExpression
@@ -168,6 +202,11 @@ internal readonly struct RegistrableTypeModel : IEquatable<RegistrableTypeModel>
             || HasPipelineExclusion != other.HasPipelineExclusion
             || IsValueType != other.IsValueType
             || IsNestedType != other.IsNestedType
+            || StagedConstructionExpression != other.StagedConstructionExpression
+            || StagedConstructionUsesKeyedServices != other.StagedConstructionUsesKeyedServices
+            || HasMultiplePublicConstructors != other.HasMultiplePublicConstructors
+            || HasFromServicesConstructorParameter != other.HasFromServicesConstructorParameter
+            || !Nullable.Equals(InfoLocation, other.InfoLocation)
             || Descriptors.Length != other.Descriptors.Length
             || DiscoveryKeys.Length != other.DiscoveryKeys.Length
             || DispatchResults.Length != other.DispatchResults.Length

--- a/src/Stella.Ergosfare.SourceGenerator/Models/StagedCallModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/StagedCallModel.cs
@@ -1,4 +1,8 @@
 namespace Stella.Ergosfare.SourceGenerator.Models;
 
-/// <summary>One staged interceptor call: the concrete type to resolve and the arm to invoke it through.</summary>
-internal readonly record struct StagedCallModel(string TypeExpression, StagedCallArm Arm);
+/// <summary>
+/// One staged interceptor call: the concrete type to resolve, the arm to invoke it
+/// through, and — when the participant qualifies — the bare <c>new T(...)</c> expression
+/// the direct-construction variant substitutes for the container resolution.
+/// </summary>
+internal readonly record struct StagedCallModel(string TypeExpression, StagedCallArm Arm, string? ConstructionExpression);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/StagedPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/StagedPlanModel.cs
@@ -16,7 +16,34 @@ internal sealed record StagedPlanModel(
     string? ResultTypeExpression,
     bool ResultIsValueType,
     string HandlerTypeExpression,
+    string? HandlerConstructionExpression,
     ImmutableArray<StagedCallModel> PreCalls,
     ImmutableArray<StagedCallModel> PostCalls,
     ImmutableArray<StagedCallModel> ExceptionCalls,
-    ImmutableArray<StagedCallModel> FinalCalls);
+    ImmutableArray<StagedCallModel> FinalCalls)
+{
+    /// <summary>
+    ///     Whether every participant — the handler and each interceptor — carries a
+    ///     construction expression, making the plan eligible for the emitted
+    ///     direct-construction variant (<c>ExecuteDirect</c>).
+    /// </summary>
+    public bool SupportsDirectConstruction
+        => HandlerConstructionExpression is not null
+           && AllConstructible(PreCalls)
+           && AllConstructible(PostCalls)
+           && AllConstructible(ExceptionCalls)
+           && AllConstructible(FinalCalls);
+
+    private static bool AllConstructible(ImmutableArray<StagedCallModel> calls)
+    {
+        foreach (var call in calls)
+        {
+            if (call.ConstructionExpression is null)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Stella.Ergosfare.SourceGenerator.Models;
@@ -106,7 +106,7 @@ internal static class RegistrationEmitter
                 builders.DispatchRootsHasProviderPlanFactories,
                 builders.HasKeyedServiceExtensions);
 
-            EmitStagedPlanClasses(sb, ref wroteMember, stagedPlans);
+            EmitStagedPlanClasses(sb, ref wroteMember, stagedPlans, builders.StagedPlansSupportDirectConstruction);
         }
 
         if (builders.HasDescriptorCatalog && useDescriptors && HasDescriptors(types))
@@ -364,12 +364,14 @@ internal static class RegistrationEmitter
     private static void EmitStagedPlanClasses(
         StringBuilder sb,
         ref bool wroteMember,
-        IReadOnlyList<StagedPlanModel> stagedPlans)
+        IReadOnlyList<StagedPlanModel> stagedPlans,
+        bool supportsDirectConstruction)
     {
         for (var i = 0; i < stagedPlans.Count; i++)
         {
             var plan = stagedPlans[i];
             var isVoid = plan.ResultTypeExpression is null;
+            var emitDirect = supportsDirectConstruction && plan.SupportsDirectConstruction;
 
             StartMember(sb, ref wroteMember);
             sb.Append("        private sealed class StagedPlan").Append(i).Append(" : global::Stella.Ergosfare.Core.Abstractions.StagedPlans.");
@@ -426,14 +428,51 @@ internal static class RegistrationEmitter
 
             if (isVoid)
             {
-                EmitVoidExecuteBody(sb, plan);
+                EmitVoidExecuteBody(sb, plan, direct: false);
             }
             else
             {
-                EmitResultExecuteBody(sb, plan);
+                EmitResultExecuteBody(sb, plan, direct: false);
             }
 
             sb.AppendLine("            }");
+
+            // The direct-construction variant: the same pipeline with every participant
+            // constructed via `new` — used by the hosting executor only after it verified
+            // every participant's plain transient registration.
+            if (emitDirect)
+            {
+                sb.AppendLine();
+                sb.AppendLine("            public override bool SupportsDirectConstruction");
+                sb.AppendLine("            {");
+                sb.AppendLine("                get { return true; }");
+                sb.AppendLine("            }");
+                sb.AppendLine();
+                sb.Append("            public override async ").Append(ValueTaskFullName);
+
+                if (!isVoid)
+                {
+                    sb.Append('<').Append(plan.ResultTypeExpression).Append('>');
+                }
+
+                sb.AppendLine(" ExecuteDirect(");
+                sb.Append("                ").Append(plan.MessageTypeExpression).AppendLine(" message,");
+                sb.Append("                ").Append(ExecutionContextFullName).AppendLine(" context,");
+                sb.AppendLine("                global::System.IServiceProvider serviceProvider)");
+                sb.AppendLine("            {");
+
+                if (isVoid)
+                {
+                    EmitVoidExecuteBody(sb, plan, direct: true);
+                }
+                else
+                {
+                    EmitResultExecuteBody(sb, plan, direct: true);
+                }
+
+                sb.AppendLine("            }");
+            }
+
             sb.AppendLine("        }");
         }
     }
@@ -464,13 +503,29 @@ internal static class RegistrationEmitter
     private static void AppendResolve(StringBuilder sb, string typeExpression)
         => sb.Append(GetRequiredServiceFullName).Append('<').Append(typeExpression).Append(">(serviceProvider)");
 
+    /// <summary>
+    ///     A participant expression: the container resolution, or — in the
+    ///     direct-construction variant — the participant's <c>new</c> expression.
+    /// </summary>
+    private static void AppendParticipant(StringBuilder sb, string typeExpression, string? constructionExpression)
+    {
+        if (constructionExpression is null)
+        {
+            AppendResolve(sb, typeExpression);
+        }
+        else
+        {
+            sb.Append(constructionExpression);
+        }
+    }
+
     /// <summary>The strategy/invoker-parity cast of the chained object result back to the pipeline result type.</summary>
     private static string ResultCast(string resultExpression, bool resultIsValueType, string operand)
         => resultIsValueType
             ? "(" + resultExpression + ")" + operand + "!"
             : "(" + resultExpression + "?)" + operand;
 
-    private static void EmitPreCalls(StringBuilder sb, StagedPlanModel plan, string indent)
+    private static void EmitPreCalls(StringBuilder sb, StagedPlanModel plan, bool direct, string indent)
     {
         foreach (var call in plan.PreCalls)
         {
@@ -479,13 +534,13 @@ internal static class RegistrationEmitter
             if (call.Arm == StagedCallArm.Sync)
             {
                 sb.Append("((").Append(HandlersNamespace).Append("IPreInterceptor<").Append(plan.MessageTypeExpression).Append(">)");
-                AppendResolve(sb, call.TypeExpression);
+                AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.AppendLine(").Handle(message, context);");
             }
             else
             {
                 sb.Append("await ((").Append(HandlersNamespace).Append("IAsyncPreInterceptor<").Append(plan.MessageTypeExpression).Append(">)");
-                AppendResolve(sb, call.TypeExpression);
+                AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.AppendLine(").HandleAsync(message, context);");
             }
         }
@@ -499,6 +554,7 @@ internal static class RegistrationEmitter
         StringBuilder sb,
         StagedPlanModel plan,
         StagedCallModel call,
+        bool direct,
         string stageInterface,
         string chainVariable,
         string? exceptionArgument,
@@ -515,7 +571,7 @@ internal static class RegistrationEmitter
             case StagedCallArm.AsyncTyped:
                 sb.Append("await ((").Append(HandlersNamespace).Append("IAsync").Append(stageInterface)
                   .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
-                AppendResolve(sb, call.TypeExpression);
+                AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").HandleAsync(message, ")
                   .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
                   .Append(extraArgument).AppendLine(", context);");
@@ -523,7 +579,7 @@ internal static class RegistrationEmitter
             case StagedCallArm.AsyncAgnostic:
                 sb.Append("await ((").Append(HandlersNamespace).Append("IAsync").Append(stageInterface)
                   .Append('<').Append(plan.MessageTypeExpression).Append(">)");
-                AppendResolve(sb, call.TypeExpression);
+                AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").HandleAsync(message, ").Append(chainVariable)
                   .Append(exceptionArgument is null ? "!" : string.Empty)
                   .Append(extraArgument).AppendLine(", context);");
@@ -531,7 +587,7 @@ internal static class RegistrationEmitter
             default:
                 sb.Append("((").Append(HandlersNamespace).Append('I').Append(stageInterface)
                   .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
-                AppendResolve(sb, call.TypeExpression);
+                AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").Handle(message, ")
                   .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
                   .Append(extraArgument).AppendLine(", context);");
@@ -539,7 +595,7 @@ internal static class RegistrationEmitter
         }
     }
 
-    private static void EmitFinalCalls(StringBuilder sb, StagedPlanModel plan, string resultExpressionText, string indent)
+    private static void EmitFinalCalls(StringBuilder sb, StagedPlanModel plan, bool direct, string resultExpressionText, string indent)
     {
         var pipelineResult = plan.ResultTypeExpression ?? ValueTaskFullName;
         var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
@@ -551,7 +607,7 @@ internal static class RegistrationEmitter
                 case StagedCallArm.AsyncTyped:
                     sb.Append(indent).Append("await ((").Append(HandlersNamespace).Append("IAsyncFinalInterceptor<")
                       .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
-                    AppendResolve(sb, call.TypeExpression);
+                    AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").HandleAsync(message, ")
                       .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
                       .AppendLine(", exception, context);");
@@ -559,13 +615,13 @@ internal static class RegistrationEmitter
                 case StagedCallArm.AsyncAgnostic:
                     sb.Append(indent).Append("await ((").Append(HandlersNamespace).Append("IAsyncFinalInterceptor<")
                       .Append(plan.MessageTypeExpression).Append(">)");
-                    AppendResolve(sb, call.TypeExpression);
+                    AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").HandleAsync(message, ").Append(resultExpressionText).AppendLine(", exception, context);");
                     break;
                 default:
                     sb.Append(indent).Append("((").Append(HandlersNamespace).Append("IFinalInterceptor<")
                       .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
-                    AppendResolve(sb, call.TypeExpression);
+                    AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").Handle(message, ")
                       .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
                       .AppendLine(", exception, context);");
@@ -574,7 +630,7 @@ internal static class RegistrationEmitter
         }
     }
 
-    private static void EmitVoidExecuteBody(StringBuilder sb, StagedPlanModel plan)
+    private static void EmitVoidExecuteBody(StringBuilder sb, StagedPlanModel plan, bool direct)
     {
         var needsResult = !plan.PostCalls.IsEmpty || !plan.ExceptionCalls.IsEmpty || !plan.FinalCalls.IsEmpty;
         var needsGuards = needsResult;
@@ -583,9 +639,9 @@ internal static class RegistrationEmitter
         {
             // Pre-only pipeline: with zero exception and final stages the strategy's
             // try/catch/finally is a no-op shell — exceptions propagate unchanged.
-            EmitPreCalls(sb, plan, "                ");
+            EmitPreCalls(sb, plan, direct, "                ");
             sb.Append("                await ");
-            AppendResolve(sb, plan.HandlerTypeExpression);
+            AppendParticipant(sb, plan.HandlerTypeExpression, direct ? plan.HandlerConstructionExpression : null);
             sb.AppendLine(".HandleAsync(message, context);");
             return;
         }
@@ -594,9 +650,9 @@ internal static class RegistrationEmitter
         sb.AppendLine("                global::System.Exception? exception = null;");
         sb.AppendLine("                try");
         sb.AppendLine("                {");
-        EmitPreCalls(sb, plan, "                    ");
+        EmitPreCalls(sb, plan, direct, "                    ");
         sb.Append("                    await ");
-        AppendResolve(sb, plan.HandlerTypeExpression);
+        AppendParticipant(sb, plan.HandlerTypeExpression, direct ? plan.HandlerConstructionExpression : null);
         sb.AppendLine(".HandleAsync(message, context);");
         sb.AppendLine("                    result = CompletedVoidResult;");
 
@@ -604,7 +660,7 @@ internal static class RegistrationEmitter
         {
             foreach (var call in plan.PostCalls)
             {
-                EmitChainCall(sb, plan, call, "PostInterceptor", "result", null, "                    ");
+                EmitChainCall(sb, plan, call, direct, "PostInterceptor", "result", null, "                    ");
             }
 
             // The strategy's post epilogue: a null post result restores the completed
@@ -629,7 +685,7 @@ internal static class RegistrationEmitter
 
             foreach (var call in plan.ExceptionCalls)
             {
-                EmitChainCall(sb, plan, call, "ExceptionInterceptor", "result", "e", "                    ");
+                EmitChainCall(sb, plan, call, direct, "ExceptionInterceptor", "result", "e", "                    ");
             }
 
             sb.Append("                    var invokedExceptionResult = (").Append(ValueTaskFullName).AppendLine("?) result;");
@@ -639,20 +695,20 @@ internal static class RegistrationEmitter
         sb.AppendLine("                }");
         sb.AppendLine("                finally");
         sb.AppendLine("                {");
-        EmitFinalCalls(sb, plan, "result", "                    ");
+        EmitFinalCalls(sb, plan, direct, "result", "                    ");
         sb.AppendLine("                }");
     }
 
-    private static void EmitResultExecuteBody(StringBuilder sb, StagedPlanModel plan)
+    private static void EmitResultExecuteBody(StringBuilder sb, StagedPlanModel plan, bool direct)
     {
         var resultExpression = plan.ResultTypeExpression!;
         var needsGuards = !plan.PostCalls.IsEmpty || !plan.ExceptionCalls.IsEmpty || !plan.FinalCalls.IsEmpty;
 
         if (!needsGuards)
         {
-            EmitPreCalls(sb, plan, "                ");
+            EmitPreCalls(sb, plan, direct, "                ");
             sb.Append("                return await ");
-            AppendResolve(sb, plan.HandlerTypeExpression);
+            AppendParticipant(sb, plan.HandlerTypeExpression, direct ? plan.HandlerConstructionExpression : null);
             sb.AppendLine(".HandleAsync(message, context);");
             return;
         }
@@ -661,9 +717,9 @@ internal static class RegistrationEmitter
         sb.AppendLine("                global::System.Exception? exception = null;");
         sb.AppendLine("                try");
         sb.AppendLine("                {");
-        EmitPreCalls(sb, plan, "                    ");
+        EmitPreCalls(sb, plan, direct, "                    ");
         sb.Append("                    result = await ");
-        AppendResolve(sb, plan.HandlerTypeExpression);
+        AppendParticipant(sb, plan.HandlerTypeExpression, direct ? plan.HandlerConstructionExpression : null);
         sb.AppendLine(".HandleAsync(message, context);");
 
         if (!plan.PostCalls.IsEmpty)
@@ -672,7 +728,7 @@ internal static class RegistrationEmitter
 
             foreach (var call in plan.PostCalls)
             {
-                EmitChainCall(sb, plan, call, "PostInterceptor", "postChain", null, "                    ");
+                EmitChainCall(sb, plan, call, direct, "PostInterceptor", "postChain", null, "                    ");
             }
 
             if (plan.ResultIsValueType)
@@ -703,7 +759,7 @@ internal static class RegistrationEmitter
 
             foreach (var call in plan.ExceptionCalls)
             {
-                EmitChainCall(sb, plan, call, "ExceptionInterceptor", "exceptionChain", "e", "                    ");
+                EmitChainCall(sb, plan, call, direct, "ExceptionInterceptor", "exceptionChain", "e", "                    ");
             }
 
             if (plan.ResultIsValueType)
@@ -720,7 +776,7 @@ internal static class RegistrationEmitter
         sb.AppendLine("                }");
         sb.AppendLine("                finally");
         sb.AppendLine("                {");
-        EmitFinalCalls(sb, plan, "result", "                    ");
+        EmitFinalCalls(sb, plan, direct, "result", "                    ");
         sb.AppendLine("                }");
         sb.AppendLine();
         sb.AppendLine("                return result;");

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Stella.Ergosfare.SourceGenerator.Models;
@@ -124,7 +124,7 @@ internal static class RegistrationEmitter
 
     private static List<RegistrableTypeModel> Filter(
         IReadOnlyList<RegistrableTypeModel> types,
-        System.Func<RegistrableTypeModel, bool> predicate)
+        Func<RegistrableTypeModel, bool> predicate)
     {
         var filtered = new List<RegistrableTypeModel>(types.Count);
 
@@ -1016,7 +1016,7 @@ internal static class RegistrationEmitter
 
     private static List<Cluster> BuildClusters(IReadOnlyList<RegistrableTypeModel> types)
     {
-        var bySignature = new Dictionary<string, Cluster>(System.StringComparer.Ordinal);
+        var bySignature = new Dictionary<string, Cluster>(StringComparer.Ordinal);
         var clusters = new List<Cluster>();
 
         foreach (var type in types)

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -15,7 +15,7 @@ using Stella.Ergosfare.Queries.Abstractions;
 using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 using MediatR;
 
-namespace Stella.Ergosfare.Benchmarks;
+namespace Stella.Ergosfare.Benchmarking;
 
 public class Program
 {
@@ -30,7 +30,7 @@ public class Program
 // Ergosfare messages & handlers
 // ---------------------------------------------------------------------------
 
-public sealed class VoidCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+public sealed class VoidCommand : ICommand { }
 
 public sealed class VoidCommandHandler : ICommandHandler<VoidCommand>
 {
@@ -60,7 +60,7 @@ public sealed class SecondPingEventHandler : IEventHandler<PingEvent>
 // lane without changing the default rows' pipelines (a second handler on VoidCommand
 // would suppress its compile-time plan, for instance).
 
-public sealed class GroupedCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+public sealed class GroupedCommand : ICommand { }
 
 [Group("bench")]
 public sealed class GroupedCommandHandler : ICommandHandler<GroupedCommand>
@@ -87,7 +87,7 @@ public sealed class SecondGroupedPingEventHandler : IEventHandler<GroupedPingEve
 // strategy path — the staged-plans epic baseline — without disturbing the default
 // rows' interceptor-free fast lanes (interceptors bind to their message type only).
 
-public sealed class InterceptedCommand : Stella.Ergosfare.Commands.Abstractions.ICommand { }
+public sealed class InterceptedCommand : ICommand { }
 
 public sealed class InterceptedCommandHandler : ICommandHandler<InterceptedCommand>
 {

--- a/test/Stella.Ergosfare.Command.Test/CommandMediatorTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandMediatorTests.cs
@@ -1,7 +1,5 @@
 ﻿using Stella.Ergosfare.Commands;
-using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Stella.Ergosfare.Command.Test.__stubs__;
@@ -67,7 +65,7 @@ public class CommandMediatorTests
             }).BuildServiceProvider();
 
         var messageMediator = serviceCollection.GetRequiredService<IMessageMediator>();
-        var mediator = new CommandMediator(messageMediator!);
+        var mediator = new CommandMediator(messageMediator);
 
         var result = mediator.SendAsync(new StubNonGenericCommandStringResult(), StubDefaultMediationSetting.CommandDefaultSetting, CancellationToken.None);
 

--- a/test/Stella.Ergosfare.Command.Test/CommandModuleTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandModuleTests.cs
@@ -52,7 +52,7 @@ public class CommandModuleTests
             )).BuildServiceProvider();
         var mediator = serviceCollection.GetRequiredService<ICommandMediator>();
         await mediator.SendAsync(new TestCommand());
-        var stringResult = mediator.SendAsync<string>(new TestCommandStringResult());
+        var stringResult = mediator.SendAsync(new TestCommandStringResult());
 
         Assert.Equal(string.Empty, await stringResult);
         

--- a/test/Stella.Ergosfare.Command.Test/EngineBackedFacadeTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/EngineBackedFacadeTests.cs
@@ -123,7 +123,7 @@ public class EngineBackedFacadeTests
         {
             var settings = new CommandMediationSettings();
 
-            var result = await mediator.SendAsync<string>(
+            var result = await mediator.SendAsync(
                 new EchoCommand { Payload = "hi" }, settings);
 
             Assert.Equal("hi!", result);

--- a/test/Stella.Ergosfare.Command.Test/FlavoredExceptionInterceptorTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/FlavoredExceptionInterceptorTests.cs
@@ -34,7 +34,7 @@ public class FlavoredExceptionInterceptorTests
         public ValueTask<object> HandleAsync(VoidFailingCommand command, object? messageResult, Exception exception, IExecutionContext context)
         {
             context.Set("observed", exception.Message);
-            return ValueTask.FromResult<object>(messageResult!);
+            return ValueTask.FromResult(messageResult!);
         }
     }
 

--- a/test/Stella.Ergosfare.Command.Test/GeneratedPlanDirectConstructionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedPlanDirectConstructionTests.cs
@@ -1,8 +1,8 @@
 ﻿using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/test/Stella.Ergosfare.Command.Test/GeneratedPlanProviderConstructionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedPlanProviderConstructionTests.cs
@@ -1,8 +1,8 @@
 ﻿using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/test/Stella.Ergosfare.Command.Test/GeneratedResultPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedResultPlanExecutionTests.cs
@@ -1,8 +1,8 @@
 ﻿using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
@@ -11,7 +11,7 @@ namespace Stella.Ergosfare.Command.Test;
 
 /// <summary>
 /// Runtime behavior of generated void pipeline plans, installed here through the public
-/// <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}"/> surface exactly as
+/// <see cref="GeneratedDispatchRoots.AddVoidPlan{TMessage, THandler}()"/> surface exactly as
 /// generated code would: the plan-closed executor dispatches the handler, runtime
 /// registrations still invalidate the cached pipeline, and a plan whose handler type does
 /// not match the actual registration falls back to the runtime dispatch shape without any

--- a/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
@@ -1,8 +1,8 @@
 ﻿using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Stella.Ergosfare.Command.Test/HandlerLifetimeResolutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/HandlerLifetimeResolutionTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Stella.Ergosfare.Commands;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;

--- a/test/Stella.Ergosfare.Command.Test/NestedDispatchScopeTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/NestedDispatchScopeTests.cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Command.Test.__stubs__;
+
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;

--- a/test/Stella.Ergosfare.Command.Test/StagedPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/StagedPlanExecutionTests.cs
@@ -337,6 +337,158 @@ public class StagedPlanExecutionTests
     }
 
     [ExcludeFromDiscovery]
+    public sealed class DirectStagedCommand : ICommand
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class DirectStagedCommandHandler : ICommandHandler<DirectStagedCommand>
+    {
+        public ValueTask HandleAsync(DirectStagedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class DirectStagedCommandPreInterceptor : ICommandPreInterceptor<DirectStagedCommand>
+    {
+        public ValueTask<DirectStagedCommand> HandleAsync(DirectStagedCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    private sealed class DirectStagedCommandPlan : StagedVoidPlan<DirectStagedCommand>
+    {
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(DirectStagedCommandHandler),
+            [typeof(DirectStagedCommandPreInterceptor)],
+            [],
+            [],
+            []);
+
+        public override bool SupportsDirectConstruction => true;
+
+        public override async ValueTask Execute(DirectStagedCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            message = await serviceProvider.GetRequiredService<DirectStagedCommandPreInterceptor>().HandleAsync(message, context);
+            await serviceProvider.GetRequiredService<DirectStagedCommandHandler>().HandleAsync(message, context);
+        }
+
+        public override async ValueTask ExecuteDirect(DirectStagedCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged-direct");
+            message = await new DirectStagedCommandPreInterceptor().HandleAsync(message, context);
+            await new DirectStagedCommandHandler().HandleAsync(message, context);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task PlainTransientParticipants_ExecuteThroughTheDirectVariant()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new DirectStagedCommandPlan());
+
+        var provider = new ServiceCollection()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<DirectStagedCommandHandler>();
+                c.Register<DirectStagedCommandPreInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var command = new DirectStagedCommand();
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.Equal(["staged-direct", "pre", "handler"], command.Order);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class OverriddenDirectCommand : ICommand
+    {
+        public List<string> Order { get; } = [];
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class OverriddenDirectCommandHandler : ICommandHandler<OverriddenDirectCommand>
+    {
+        public ValueTask HandleAsync(OverriddenDirectCommand command, IExecutionContext context)
+        {
+            command.Order.Add("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class OverriddenDirectCommandPreInterceptor : ICommandPreInterceptor<OverriddenDirectCommand>
+    {
+        public ValueTask<OverriddenDirectCommand> HandleAsync(OverriddenDirectCommand command, IExecutionContext context)
+        {
+            command.Order.Add("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    private sealed class OverriddenDirectCommandPlan : StagedVoidPlan<OverriddenDirectCommand>
+    {
+        public override StagedPlanComposition Composition { get; } = new(
+            typeof(OverriddenDirectCommandHandler),
+            [typeof(OverriddenDirectCommandPreInterceptor)],
+            [],
+            [],
+            []);
+
+        public override bool SupportsDirectConstruction => true;
+
+        public override async ValueTask Execute(OverriddenDirectCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged");
+            message = await serviceProvider.GetRequiredService<OverriddenDirectCommandPreInterceptor>().HandleAsync(message, context);
+            await serviceProvider.GetRequiredService<OverriddenDirectCommandHandler>().HandleAsync(message, context);
+        }
+
+        public override ValueTask ExecuteDirect(OverriddenDirectCommand message, IExecutionContext context, IServiceProvider serviceProvider)
+        {
+            message.Order.Add("staged-direct");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task LifetimeOverride_KeepsTheProviderResolvingVariant()
+    {
+        GeneratedDispatchRoots.AddStagedPlan(new OverriddenDirectCommandPlan());
+
+        // The user's singleton registration (before AddErgosfare, so the module's
+        // TryAddTransient defers to it) breaks the per-participant plain-transient
+        // proof — the composition still matches, so the plan runs, but through its
+        // provider-resolving variant, which honors the override.
+        var provider = new ServiceCollection()
+            .AddSingleton<OverriddenDirectCommandHandler>()
+            .AddErgosfare(x => x.AddCommandModule(c =>
+            {
+                c.Register<OverriddenDirectCommandHandler>();
+                c.Register<OverriddenDirectCommandPreInterceptor>();
+            }))
+            .BuildServiceProvider();
+        await using var _ = provider;
+
+        var command = new OverriddenDirectCommand();
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.Equal(["staged", "pre", "handler"], command.Order);
+    }
+
+    [ExcludeFromDiscovery]
     public sealed class StagedResultCommand : ICommand<int>
     {
         public List<string> Order { get; } = [];

--- a/test/Stella.Ergosfare.Command.Test/TypedEngineDispatchTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/TypedEngineDispatchTests.cs
@@ -145,7 +145,7 @@ public class TypedEngineDispatchTests
         // exception an unhandled message produces. The contract under test is exception
         // parity: the typed overload fails exactly like the erased one.
         var erased = await Record.ExceptionAsync(async () =>
-            await engine.DispatchAsync((object)new UnregisteredCommand(), provider));
+            await engine.DispatchAsync(new UnregisteredCommand(), provider));
         var typed = await Record.ExceptionAsync(async () =>
             await engine.DispatchVoidAsync(new UnregisteredCommand(), provider));
 

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/IModuleBuilderTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/IModuleBuilderTests.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Stella.Ergosfare.Core.Abstractions;
-using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 
 namespace Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test;
 

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ModuleConfigurationTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ModuleConfigurationTests.cs
@@ -71,7 +71,7 @@ public class ModuleConfigurationTests
             .AddErgosfare(options =>
             {
                 options.ConfigureResultAdapters(adapter => adapter.Register<TestAdapter>())
-                    .AddCoreModule( b => {});
+                    .AddCoreModule( _ => {});
             })
             .BuildServiceProvider();
 
@@ -94,7 +94,7 @@ public class ModuleConfigurationTests
         var serviceProvier = new ServiceCollection()
             .AddErgosfare(options => options
                     .ConfigureResultAdapters(adapter => adapter.RegisterFromAssembly(Assembly.GetExecutingAssembly()))
-                    .AddCoreModule( b => {}))
+                    .AddCoreModule( _ => {}))
             .BuildServiceProvider();
 
         var resultAdapterService = serviceProvier.GetService<IResultAdapterService>();

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ResultAdapterBuilderTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ResultAdapterBuilderTests.cs
@@ -46,7 +46,8 @@ public class ResultAdapterBuilderTests
     /// <summary>
     /// A class that does not implement <see cref="IResultAdapter"/>.
     /// Used to verify that <see cref="ResultAdapterBuilder.Register(Type)"/>
-    /// ignores non-a
+    /// ignores non-adapter types.
+    /// </summary>
     private class NotAnAdapter { }
 
     /// <summary>
@@ -67,7 +68,7 @@ public class ResultAdapterBuilderTests
             throw new NotImplementedException();
         }
 
-        public Exception? LookupException(object? result)
+        public Exception LookupException(object? result)
         {
             throw new NotImplementedException();
         }

--- a/test/Stella.Ergosfare.Core.Test/Caching/MessageDescriptorCacheVersionStampTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Caching/MessageDescriptorCacheVersionStampTests.cs
@@ -1,0 +1,97 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Caching;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Internal.Caching;
+
+namespace Stella.Ergosfare.Core.Test.Caching;
+
+/// <summary>
+/// The dependency cache's version stamps close a check-clear-add race: a dependency build
+/// that read the registry at version N can finish — and store its result — after another
+/// dispatch already invalidated the cache for version N+1. Before the stamps, that late
+/// add was served to every subsequent dispatch as a fresh entry, freezing a stale
+/// pipeline until the next (possibly never-coming) registry bump. These tests replay the
+/// interleaving deterministically through the cache API.
+/// </summary>
+public class MessageDescriptorCacheVersionStampTests
+{
+    private sealed class NullCacheStrategy : IDescriptorCacheStrategy
+    {
+        public bool TryGet(string key, out object? value)
+        {
+            value = null;
+            return false;
+        }
+
+        public void Add(string key, object value)
+        {
+        }
+
+        public void Clear()
+        {
+        }
+
+        public void Evict(string key)
+        {
+        }
+
+        public int Count => 0;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubDependencies : IMessageDependencies
+    {
+        public IReadOnlyList<IHandlerReference<IHandler, IMainHandlerDescriptor>> Handlers => [];
+        public IReadOnlyList<IHandlerReference<IHandler, IMainHandlerDescriptor>> IndirectHandlers => [];
+        public IReadOnlyList<IHandlerReference<IPreInterceptor, IPreInterceptorDescriptor>> PreInterceptors => [];
+        public IReadOnlyList<IHandlerReference<IPostInterceptor, IPostInterceptorDescriptor>> PostInterceptors => [];
+        public IReadOnlyList<IHandlerReference<IExceptionInterceptor, IExceptionInterceptorDescriptor>> ExceptionInterceptors => [];
+        public IReadOnlyList<IHandlerReference<IFinalInterceptor, IFinalInterceptorDescriptor>> FinalInterceptors => [];
+    }
+
+    private sealed class ProbeMessage;
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void LateAddFromAnOlderVersion_IsInvisibleToTheNewVersion()
+    {
+        var cache = new MessageDescriptorCache(new NullCacheStrategy());
+        var staleDependencies = new StubDependencies();
+
+        // Dispatch A reads registry version 1 and starts building.
+        cache.InvalidateIfRegistryChanged(1);
+
+        // A registration bumps the registry; dispatch B invalidates for version 2.
+        cache.InvalidateIfRegistryChanged(2);
+
+        // Dispatch A's build finishes late and stores its version-1 result.
+        cache.AddDependencies(typeof(ProbeMessage), [], staleDependencies, 1);
+
+        // A version-2 reader must rebuild, not serve the stale entry.
+        Assert.False(cache.TryGetDependencies(typeof(ProbeMessage), [], 2, out _));
+
+        // The same interleaving through the grouped store.
+        cache.AddDependencies(typeof(ProbeMessage), ["reporting"], staleDependencies, 1);
+        Assert.False(cache.TryGetDependencies(typeof(ProbeMessage), ["reporting"], 2, out _));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public void MatchingVersion_ServesTheCachedEntry()
+    {
+        var cache = new MessageDescriptorCache(new NullCacheStrategy());
+        var dependencies = new StubDependencies();
+
+        cache.InvalidateIfRegistryChanged(1);
+        cache.AddDependencies(typeof(ProbeMessage), [], dependencies, 1);
+
+        Assert.True(cache.TryGetDependencies(typeof(ProbeMessage), [], 1, out var cached));
+        Assert.Same(dependencies, cached);
+    }
+}

--- a/test/Stella.Ergosfare.Core.Test/Common/Descriptors/DescriptorImplementationTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Common/Descriptors/DescriptorImplementationTests.cs
@@ -29,7 +29,7 @@ public class DescriptorImplementationTests
     
     /// <summary>
     /// Ensures that all descriptors correctly expose 
-    /// their <see cref="IHandlerDescriptor.MessageType"/>,
+    /// their <see cref="IHasMessageType.MessageType"/>,
     /// <see cref="IHandlerDescriptor.HandlerType"/>,
     /// and (if applicable) <see cref="IHasResultType.ResultType"/>.
     /// </summary>

--- a/test/Stella.Ergosfare.Core.Test/Common/Descriptors/MessageDescriptorTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Common/Descriptors/MessageDescriptorTests.cs
@@ -17,7 +17,7 @@ public class MessageDescriptorTests(
     
     /// <summary>
     /// Ensures that <see cref="DescriptorFixture.CreateMessageDescriptor{TMessage}"/>
-    /// produces a descriptor with the correct <see cref="IMessageDescriptor.MessageType"/>.
+    /// produces a descriptor with the correct <see cref="IHasMessageType.MessageType"/>.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]

--- a/test/Stella.Ergosfare.Core.Test/GeneratedDispatchRootsTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/GeneratedDispatchRootsTests.cs
@@ -40,8 +40,8 @@ public class GeneratedDispatchRootsTests
 
         Assert.NotNull(classRoot);
         Assert.NotNull(structRoot);
-        Assert.Equal(typeof(ClassMessage), classRoot!.Accept(TypeProbeVisitor.Instance, state: false));
-        Assert.Equal(typeof(StructMessage), structRoot!.Accept(TypeProbeVisitor.Instance, state: false));
+        Assert.Equal(typeof(ClassMessage), classRoot.Accept(TypeProbeVisitor.Instance, state: false));
+        Assert.Equal(typeof(StructMessage), structRoot.Accept(TypeProbeVisitor.Instance, state: false));
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class GeneratedDispatchRootsTests
         var resultRoot = GeneratedDispatchRoots.FindResult(typeof(ClassMessage), typeof(string));
 
         Assert.NotNull(resultRoot);
-        Assert.Equal((typeof(ClassMessage), typeof(string)), resultRoot!.Accept(PairProbeVisitor.Instance, state: false));
+        Assert.Equal((typeof(ClassMessage), typeof(string)), resultRoot.Accept(PairProbeVisitor.Instance, state: false));
 
         // Result and stream stores are independent; pairs don't leak across them.
         Assert.Null(GeneratedDispatchRoots.FindResult(typeof(ClassMessage), typeof(int)));

--- a/test/Stella.Ergosfare.Core.Test/Internal/MessageRegistryThreadSafetyTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Internal/MessageRegistryThreadSafetyTests.cs
@@ -46,6 +46,8 @@ public class MessageRegistryThreadSafetyTests
         var tasks = Enumerable.Range(0, ThreadCount)
             .Select(_ => Task.Run(() =>
             {
+                // All tasks are awaited before 'barrier' leaves the using scope; the shared capture is the point of the test.
+                // ReSharper disable once AccessToDisposedClosure
                 barrier.SignalAndWait();
                 foreach (var type in types)
                 {
@@ -74,6 +76,8 @@ public class MessageRegistryThreadSafetyTests
         var tasks = Enumerable.Range(0, ThreadCount)
             .Select(_ => Task.Run(() =>
             {
+                // All tasks are awaited before 'barrier' leaves the using scope; the shared capture is the point of the test.
+                // ReSharper disable once AccessToDisposedClosure
                 barrier.SignalAndWait();
                 registry.Register(typeof(ThreadMessageHandler));
             }))
@@ -123,6 +127,8 @@ public class MessageRegistryThreadSafetyTests
         var readers = Enumerable.Range(0, ThreadCount - 1)
             .Select(readerIndex => Task.Run(() =>
             {
+                // 'stop' is deliberately written by the outer scope while readers poll it; that interleaving is what the test exercises.
+                // ReSharper disable once AccessToModifiedClosure
                 while (Volatile.Read(ref stop) == 0)
                 {
                     var count = 0;

--- a/test/Stella.Ergosfare.Core.Test/MessageDependenciesTest.cs
+++ b/test/Stella.Ergosfare.Core.Test/MessageDependenciesTest.cs
@@ -8,7 +8,6 @@ using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
-using Xunit.Abstractions;
 // ReSharper disable ConvertToPrimaryConstructor
 
 namespace Stella.Ergosfare.Core.Test;
@@ -25,7 +24,6 @@ namespace Stella.Ergosfare.Core.Test;
 public class MessageDependenciesTest: 
     IClassFixture<MessageDependencyFixture>, IClassFixture<DescriptorFixture>
 {
-    private readonly ITestOutputHelper _testOutputHelper;
     private MessageDependencyFixture _messageDependencyFixture;
     private readonly DescriptorFixture _descriptorFixture;
     
@@ -35,14 +33,11 @@ public class MessageDependenciesTest:
     /// </summary>
     /// <param name="descriptorFixture">The descriptor fixture.</param>
     /// <param name="messageDependencyFixture">The message dependency fixture.</param>
-    /// <param name="testOutputHelper">The xUnit test output helper.</param>
     public MessageDependenciesTest(
         DescriptorFixture descriptorFixture,
-        MessageDependencyFixture messageDependencyFixture,
-        ITestOutputHelper testOutputHelper)
+        MessageDependencyFixture messageDependencyFixture)
     {
         _descriptorFixture = descriptorFixture;
-        _testOutputHelper = testOutputHelper;
         _messageDependencyFixture = messageDependencyFixture;
     }
     
@@ -83,11 +78,6 @@ public class MessageDependenciesTest:
         _messageDependencyFixture.Dispose();
     }
     
-    
-    /// <summary>
-    /// A test handler used for generic handler resolution tests.
-    /// </summary>
-    private class TestHandler: VoidStubGenericHandler<string> {}
     
     /// <summary>
     /// Tests that generic message dependencies resolve handler and interceptor types correctly.
@@ -302,9 +292,6 @@ public class MessageDependenciesTest:
              .AddTransient(typeof(VoidStubGenericHandler<>))
              .BuildServiceProvider();
          var messageType = typeof(StubGenericMessage<string>);
-         var handlerType = typeof(VoidStubGenericHandler<string>);
-         // register fake handler in service provider
-         var handlerInstance = new VoidStubGenericHandler<string>();
          var handlerDescriptor =
              new HandlerDescriptorBuilderFactory()
                  .BuildDescriptors(typeof(VoidStubGenericHandler<string>))

--- a/test/Stella.Ergosfare.Core.Test/MessageMediatorTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/MessageMediatorTests.cs
@@ -8,8 +8,6 @@ using Stella.Ergosfare.Core.Internal.Mediator;
 using Stella.Ergosfare.Core.Internal.Registry;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
 using Moq;
-using Stella.Ergosfare.Core.Abstractions.Caching;
-using Stella.Ergosfare.Core.Internal.Caching;
 
 namespace Stella.Ergosfare.Core.Test;
 
@@ -91,7 +89,7 @@ public class MessageMediatorTests
             RegisterPlainMessagesOnSpot = false,
             CancellationToken = CancellationToken.None,
             Items = new Dictionary<object, object?>(),
-            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry)!,
+            MessageResolveStrategy = new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(registry),
             MessageMediationStrategy = 
                 new SingleAsyncHandlerMediationStrategy<StubMessage>(new ResultAdapterService()),
             Groups = []

--- a/test/Stella.Ergosfare.Core.Test/MessageRegistryTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/MessageRegistryTests.cs
@@ -4,7 +4,6 @@ using Stella.Ergosfare.Core.Internal.Registry;
 using Stella.Ergosfare.Core.Internal.Registry.Descriptors;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
-using Xunit.Abstractions;
 
 namespace Stella.Ergosfare.Core.Test;
 
@@ -15,20 +14,15 @@ namespace Stella.Ergosfare.Core.Test;
 /// </summary>
 public class MessageRegistryTests: IClassFixture<MessageDependencyFixture>
 {
-    private readonly ITestOutputHelper _testOutputHelper;
     private MessageDependencyFixture _messageDependencyFixture;
-    
+
     /// <summary>
-    /// Initializes a new instance of <see cref="MessageRegistryTests"/> with the provided fixture and test output helper.
+    /// Initializes a new instance of <see cref="MessageRegistryTests"/> with the provided fixture.
     /// </summary>
     /// <param name="messageDependencyFixture">The fixture providing the <see cref="MessageRegistry"/> instance.</param>
-    /// <param name="testOutputHelper">The test output helper for logging.</param>
-    public MessageRegistryTests(
-        MessageDependencyFixture messageDependencyFixture,
-        ITestOutputHelper testOutputHelper)
+    public MessageRegistryTests(MessageDependencyFixture messageDependencyFixture)
     {
         _messageDependencyFixture = messageDependencyFixture;
-        _testOutputHelper = testOutputHelper;
     }
 
     /// <summary>
@@ -166,7 +160,7 @@ public class MessageRegistryTests: IClassFixture<MessageDependencyFixture>
         var messageRegistry = _messageDependencyFixture.MessageRegistry;
         
         // Act
-        messageRegistry.Register(typeof(System.Console)); 
+        messageRegistry.Register(typeof(Console));
 
         // Assert
         Assert.Empty(messageRegistry);
@@ -260,7 +254,7 @@ public class MessageRegistryTests: IClassFixture<MessageDependencyFixture>
             .GetField("_newMessages", BindingFlags.NonPublic | BindingFlags.Instance);
         var newMessagesList = (List<MessageDescriptor>)newMessagesField?.GetValue(messageRegistry)!;
        
-        newMessagesList!.Add(new MessageDescriptor(typeof(StubMessage)));
+        newMessagesList.Add(new MessageDescriptor(typeof(StubMessage)));
         messageRegistry.Register(typeof(StubMessage));
         Assert.DoesNotContain(
             newMessagesList,

--- a/test/Stella.Ergosfare.Core.Test/ResultAdapters/ResultAdapterServiceTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/ResultAdapters/ResultAdapterServiceTests.cs
@@ -75,7 +75,7 @@ public class ResultAdapterServiceTests : IClassFixture<ResultAdapterFixtures>
         var ex = _fixture.ResultAdapterService.LookupException("anything");
 
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("adapted", ex?.Message);
+        Assert.Equal("adapted", ex.Message);
     }
 
     /// <summary>

--- a/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
@@ -1,10 +1,9 @@
-using System.Reflection;
+
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Stella.Ergosfare.Core.Test.Strategies.InvocationStrategies;

--- a/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
@@ -4,7 +4,6 @@ using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
-using Xunit.Abstractions;
 
 namespace Stella.Ergosfare.Core.Test.Strategies.InvocationStrategies;
 
@@ -18,19 +17,13 @@ public class FinalInterceptorInvocationStrategyTests:
 {
     private MessageDependencyFixture _messageDependencyFixture;
     private readonly DescriptorFixture _descriptorFixture;
-    private ExecutionContextFixture _executionContextFixture;
-    private readonly ITestOutputHelper _testOutputHelper;
     // ReSharper disable once ConvertToPrimaryConstructor
     public FinalInterceptorInvocationStrategyTests(
-        ITestOutputHelper  testOutputHelper,
         MessageDependencyFixture messageDependencyFixture,
-        DescriptorFixture descriptorFixture,
-        ExecutionContextFixture executionContextFixture)
+        DescriptorFixture descriptorFixture)
     {
-        _testOutputHelper = testOutputHelper;
         _messageDependencyFixture = messageDependencyFixture;
         _descriptorFixture = descriptorFixture;
-        _executionContextFixture = executionContextFixture;
     }
 
     
@@ -67,7 +60,7 @@ public class FinalInterceptorInvocationStrategyTests:
         Assert.NotNull(descriptor);
         
         // Create dependencies from descriptor
-        var messageDependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor!);
+        var messageDependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor);
         
         // Direct and indirect final interceptors are merged into one list, direct first.
         Assert.NotEmpty(messageDependencies.FinalInterceptors);

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
@@ -2,7 +2,6 @@ using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
-using Xunit.Abstractions;
 
 namespace Stella.Ergosfare.Core.Test.Strategies;
 
@@ -18,7 +17,6 @@ public class SingleAsyncHandlerMediationStrategyTMessageTResultTests :
 
     // ReSharper disable once ConvertToPrimaryConstructor
     public SingleAsyncHandlerMediationStrategyTMessageTResultTests(
-        ITestOutputHelper testOutputHelper,
         MessageDependencyFixture messageDependencyFixture,
         ExecutionContextFixture executionContextFixture)
     {

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage]Test.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage]Test.cs
@@ -3,7 +3,6 @@ using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
-using Xunit.Abstractions;
 
 namespace Stella.Ergosfare.Core.Test.Strategies;
 
@@ -13,21 +12,18 @@ public class SingleAsyncHandlerMediationStrategyTMessageTests:
     IClassFixture<MessageDependencyFixture>,
     IClassFixture<DescriptorFixture>
 {
-    private readonly ITestOutputHelper _testOutputHelper;
     private MessageDependencyFixture _messageDependencyFixture;
     private DescriptorFixture _descriptorFixture;
     private readonly ExecutionContextFixture _executionContextFixture;
     // ReSharper disable once ConvertToPrimaryConstructor
     public SingleAsyncHandlerMediationStrategyTMessageTests(
-        ITestOutputHelper testOutputHelper,
         MessageDependencyFixture messageDependencyFixture,
         DescriptorFixture descriptorFixture,
         ExecutionContextFixture executionContextFixture)
     {
-        _testOutputHelper = testOutputHelper;
         _messageDependencyFixture = messageDependencyFixture;
         _descriptorFixture = descriptorFixture;
-        _executionContextFixture = executionContextFixture; 
+        _executionContextFixture = executionContextFixture;
     }
 
     public record TestMessage : IMessage;
@@ -58,7 +54,7 @@ public class SingleAsyncHandlerMediationStrategyTMessageTests:
         
         Assert.NotNull(descriptor);
         
-        var dependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor!);
+        var dependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor);
         var mediationStrategy = new SingleAsyncHandlerMediationStrategy<StubMessage>(null);
 
         Assert.NotNull(dependencies);
@@ -94,7 +90,7 @@ public class SingleAsyncHandlerMediationStrategyTMessageTests:
         
         Assert.NotNull(descriptor);
         
-        var dependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor!);
+        var dependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor);
         var mediationStrategy = new SingleAsyncHandlerMediationStrategy<StubMessage>(null);
         
         // act
@@ -116,20 +112,22 @@ public class SingleAsyncHandlerMediationStrategyTMessageTests:
         
         _messageDependencyFixture = _messageDependencyFixture.New;
         _descriptorFixture = _descriptorFixture.New;
-        var messageDependencies = _messageDependencyFixture
-            .RegisterHandler(
-                typeof(StubVoidHandlerThrows), // Handler that throws
-                typeof(StubVoidAsyncExceptionInterceptor), typeof(StubVoidAsyncFinalInterceptor));
-        
+
+        // The registration is the arrange's side effect — the returned dependencies are
+        // rebuilt from the descriptor below, so no local is kept.
+        _messageDependencyFixture.RegisterHandler(
+            typeof(StubVoidHandlerThrows), // Handler that throws
+            typeof(StubVoidAsyncExceptionInterceptor), typeof(StubVoidAsyncFinalInterceptor));
+
         _descriptorFixture.SetMessageRegistry(_messageDependencyFixture.MessageRegistry);
         var descriptor = _descriptorFixture.GetDescriptorFromRegistry(typeof(StubMessage));
-        
+
         Assert.NotNull(descriptor);
-        
-        var dependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor!);
+
+        var dependencies = _messageDependencyFixture.CreateDependenciesFromDescriptor<StubMessage>(descriptor);
         var mediationStrategy = new SingleAsyncHandlerMediationStrategy<StubMessage>(null);
-        
-        
+
+
 
         // Act
         await mediationStrategy.Mediate(message, dependencies, _executionContextFixture.Ctx, _messageDependencyFixture.ServiceProvider);

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage,TResult]TestS.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage,TResult]TestS.cs
@@ -2,7 +2,6 @@ using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Stream;
-using Xunit.Abstractions;
 
 namespace Stella.Ergosfare.Core.Test.Strategies;
 
@@ -18,7 +17,6 @@ public class SingleStreamHandlerMediationStrategyTMessageTResultTests :
 
     // ReSharper disable once ConvertToPrimaryConstructor
     public SingleStreamHandlerMediationStrategyTMessageTResultTests(
-        ITestOutputHelper testOutputHelper,
         MessageDependencyFixture messageDependencyFixture,
         ExecutionContextFixture executionContextFixture)
     {

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MessageResolveStrategies/ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest.cs
@@ -10,7 +10,7 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
 {
     /// <summary>
     /// Ensures that the <see cref="MessageRegistry"/> can correctly resolve
-    /// a <see cref="MessageDescriptor"/> for a registered message type,
+    /// a <see cref="Stella.Ergosfare.Core.Internal.Registry.Descriptors.MessageDescriptor"/> for a registered message type,
     /// including its associated handlers.
     /// </summary>
     [Fact]
@@ -37,10 +37,10 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
         Assert.Single(descriptor.Handlers);
 
         // Descriptor should match the requested message type
-        Assert.Equal(typeof(StubMessage), descriptor?.MessageType);
+        Assert.Equal(typeof(StubMessage), descriptor.MessageType);
 
         // Verify that the expected handler is registered for StubMessage
-        Assert.Contains(descriptor!.Handlers, h => h.HandlerType == typeof(StubVoidHandler));
+        Assert.Contains(descriptor.Handlers, h => h.HandlerType == typeof(StubVoidHandler));
     }
     
     
@@ -72,7 +72,7 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
 
         // assert
         Assert.NotNull(descriptor);
-        Assert.Equal(typeof(StubMessage), descriptor?.MessageType);
+        Assert.Equal(typeof(StubMessage), descriptor.MessageType);
     }
     
     
@@ -86,8 +86,6 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
         var registry = new MessageRegistry(
             new HandlerDescriptorBuilderFactory());
         
-        // dummy generic string arg
-        var mockGenericHandler = new VoidStubGenericHandler<string>();
         
         registry.Register(typeof(VoidStubGenericHandler<string>)); // handles BaseMessage
         
@@ -98,7 +96,7 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
         
         //assert
         Assert.NotNull(descriptor);
-        Assert.Equal(typeof(StubGenericMessage<>), descriptor?.MessageType);
+        Assert.Equal(typeof(StubGenericMessage<>), descriptor.MessageType);
     }
 
     /// <summary>
@@ -117,7 +115,7 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
 
         // Assert
         Assert.NotNull(descriptor);
-        Assert.Equal(typeof(StubMessage), descriptor?.MessageType);
+        Assert.Equal(typeof(StubMessage), descriptor.MessageType);
     }
 
     /// <summary>
@@ -137,7 +135,7 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
 
         // Assert
         Assert.NotNull(descriptor);
-        Assert.Equal(typeof(StubMessage), descriptor?.MessageType);
+        Assert.Equal(typeof(StubMessage), descriptor.MessageType);
     }
 
     /// <summary>
@@ -156,6 +154,6 @@ public class ActualTypeOrFirstAssignableTypeMessageResolveStrategyTest
 
         // Assert
         Assert.NotNull(descriptor);
-        Assert.Equal(typeof(StubGenericMessage<>), descriptor?.MessageType);
+        Assert.Equal(typeof(StubGenericMessage<>), descriptor.MessageType);
     }
 }

--- a/test/Stella.Ergosfare.Events.Test/AsyncBroadcastMediationStrategyTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/AsyncBroadcastMediationStrategyTests.cs
@@ -22,7 +22,7 @@ public class AsyncBroadcastMediationStrategyTests
 (ITestOutputHelper  testOutputHelper)
 {
     /// <summary>
-    /// Tests that <see cref="EventMediator.PublishAsync"/> throws an exception
+    /// Tests that <see cref="EventMediator.PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> throws an exception
     /// when <c>ThrowIfNoHandlerFound</c> is set to true and no handler is found.
     /// </summary>
     [Fact]
@@ -61,7 +61,7 @@ public class AsyncBroadcastMediationStrategyTests
     }
     
     /// <summary>
-    /// Tests that <see cref="EventMediator.PublishAsync"/> does not throw an exception
+    /// Tests that <see cref="EventMediator.PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> does not throw an exception
     /// when <c>ThrowIfNoHandlerFound</c> is false and no handler is found.
     /// </summary>
     [Fact]
@@ -101,7 +101,7 @@ public class AsyncBroadcastMediationStrategyTests
     }
 
     /// <summary>
-    /// Tests that <see cref="EventMediator.PublishAsync"/> correctly runs registered handlers.
+    /// Tests that <see cref="EventMediator.PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> correctly runs registered handlers.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
@@ -115,12 +115,11 @@ public class AsyncBroadcastMediationStrategyTests
             })
             .BuildServiceProvider();
         var mediator = services.GetRequiredService<IPublisher>();
-        var handler = services.GetRequiredService<StubNonGenericEventHandler1>();
         await mediator.PublishAsync(new StubNonGenericEvent());
     }
 
     /// <summary>
-    /// Tests that exceptions are correctly intercepted when a handler throws during <see cref="EventMediator.PublishAsync"/>.
+    /// Tests that exceptions are correctly intercepted when a handler throws during <see cref="EventMediator.PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/>.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]

--- a/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EngineBackedEventFacadeTests.cs
@@ -83,8 +83,13 @@ public class EngineBackedEventFacadeTests
 
         var mediator = provider.GetRequiredService<IEventMediator>();
 
-        var settings = new EventMediationSettings();
-        settings.Filters.Groups = ["audit"];
+        var settings = new EventMediationSettings
+        {
+            Filters =
+            {
+                Groups = ["audit"]
+            }
+        };
 
         await mediator.PublishAsync(new GroupedEvent(), settings);
 
@@ -110,7 +115,7 @@ public class EngineBackedEventFacadeTests
         var mediatorBacked = new EventMediator(
             strategy, adapters, provider.GetRequiredService<IMessageMediator>());
 
-        foreach (var mediator in new EventMediator[] { engineBacked, mediatorBacked })
+        foreach (var mediator in new [] { engineBacked, mediatorBacked })
         {
             var settings = new EventMediationSettings();
 

--- a/test/Stella.Ergosfare.Events.Test/EventMediationSettingsTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EventMediationSettingsTests.cs
@@ -10,7 +10,7 @@ public class EventMediationSettingsTests
 {
     
     /// <summary>
-    /// Tests that the <see cref="EventMediationSettings.Filters.HandlerPredicate"/> 
+    /// Tests that the <see cref="EventMediationSettings.EventMediationFilters.HandlerPredicate"/>
     /// and other properties can be correctly set and retrieved.
     /// </summary>
     [Fact]

--- a/test/Stella.Ergosfare.Events.Test/EventMediatorTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EventMediatorTests.cs
@@ -13,7 +13,7 @@ namespace Stella.Ergosfare.Events.Test;
 public class EventMediatorTests
 {
     /// <summary>
-    /// Tests that <see cref="IEventMediator.PublishAsync"/> correctly publishes a <see cref="StubNonGenericEvent"/>
+    /// Tests that <see cref="IEventMediator.PublishAsync(IEvent, EventMediationSettings?, CancellationToken)"/> correctly publishes a <see cref="StubNonGenericEvent"/>
     /// both with default and custom group settings.
     /// </summary>
     [Fact]

--- a/test/Stella.Ergosfare.Events.Test/EventModuleTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EventModuleTests.cs
@@ -45,7 +45,7 @@ public class EventModuleTests
         var mediator = serviceCollection.GetRequiredService<IEventMediator>();
 
         await mediator.PublishAsync((IEvent) new StubNonGenericEvent());
-        await mediator.PublishAsync<StubNonGenericEvent>(new StubNonGenericEvent());
+        await mediator.PublishAsync(new StubNonGenericEvent());
         
     }
 

--- a/test/Stella.Ergosfare.Queries.Test/QueryMediatorTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/QueryMediatorTests.cs
@@ -1,4 +1,3 @@
-using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;

--- a/test/Stella.Ergosfare.SourceGenerator.Test/DiscoveryKeyTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/DiscoveryKeyTests.cs
@@ -47,6 +47,7 @@ public class DiscoveryKeyTests
     /// </summary>
     private sealed class DiscoveryHarness
     {
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly Assembly _assembly;
         private readonly Type _registrations;
         private readonly Type _recordingRegistry;

--- a/test/Stella.Ergosfare.SourceGenerator.Test/DispatchRootsTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/DispatchRootsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 
@@ -104,7 +103,7 @@ public class DispatchRootsTests
     {
         public int Count => 0;
 
-        public IEnumerator<Stella.Ergosfare.Core.Abstractions.Registry.Descriptors.IMessageDescriptor> GetEnumerator()
+        public IEnumerator<Core.Abstractions.Registry.Descriptors.IMessageDescriptor> GetEnumerator()
         {
             yield break;
         }
@@ -115,7 +114,7 @@ public class DispatchRootsTests
         {
         }
 
-        public void RegisterDescriptors(IEnumerable<Stella.Ergosfare.Core.Abstractions.Registry.Descriptors.IHandlerDescriptor> descriptors)
+        public void RegisterDescriptors(IEnumerable<Core.Abstractions.Registry.Descriptors.IHandlerDescriptor> descriptors)
         {
         }
     }

--- a/test/Stella.Ergosfare.SourceGenerator.Test/GeneratorTestHost.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/GeneratorTestHost.cs
@@ -74,6 +74,7 @@ internal static class GeneratorTestHost
         if (libraries is { Count: > 0 })
         {
             references = references.AddRange(libraries.Select(library =>
+                // ReSharper disable once AccessToModifiedClosure
                 CompileLibrary(library.AssemblyName, library.Source, references)));
         }
 

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
@@ -170,6 +170,117 @@ public class StagedPlanEmissionTests
     }
 
     [Fact]
+    public void ConstructibleParticipants_EmitTheDirectConstructionVariant()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public interface IGreeter { }
+
+                public sealed record DirectPing : ICommand;
+
+                public sealed class DirectPingHandler : ICommandHandler<DirectPing>
+                {
+                    public DirectPingHandler(IGreeter greeter) { }
+
+                    public ValueTask HandleAsync(DirectPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class DirectPingInterceptor : ICommandPreInterceptor<DirectPing>
+                {
+                    public ValueTask<DirectPing> HandleAsync(DirectPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains("public override bool SupportsDirectConstruction", result.GeneratedSource);
+        Assert.Contains("ExecuteDirect(", result.GeneratedSource);
+
+        // The direct variant constructs participants with `new` — the parameterless
+        // interceptor directly, the dependency-injected handler with its dependencies
+        // still resolved from the dispatching provider.
+        Assert.Contains("new global::TestApp.DirectPingInterceptor()", result.GeneratedSource);
+        Assert.Contains(
+            "new global::TestApp.DirectPingHandler(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::TestApp.IGreeter>(serviceProvider))",
+            result.GeneratedSource);
+    }
+
+    [Fact]
+    public void MultiConstructorParticipant_SkipsTheDirectVariantAndReportsTheInfo()
+    {
+        var result = GeneratorTestHost.Run("""
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                public sealed record PickyDirectPing : ICommand;
+
+                public sealed class PickyDirectPingHandler : ICommandHandler<PickyDirectPing>
+                {
+                    public PickyDirectPingHandler() { }
+
+                    public PickyDirectPingHandler(string dependency) { }
+
+                    public ValueTask HandleAsync(PickyDirectPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+
+                public sealed class PickyDirectPingInterceptor : ICommandPreInterceptor<PickyDirectPing>
+                {
+                    public ValueTask<PickyDirectPing> HandleAsync(PickyDirectPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(message);
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+
+        // The staged plan itself still emits — only the direct variant is withheld,
+        // and the ERGOSG003 info points at the reason.
+        Assert.Contains("AddStagedPlan<global::TestApp.PickyDirectPing>", result.GeneratedSource);
+        Assert.DoesNotContain("ExecuteDirect(", result.GeneratedSource);
+        Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "ERGOSG003");
+    }
+
+    [Fact]
+    public void FromServicesOnConstructor_ReportsTheInfo()
+    {
+        var result = GeneratorTestHost.Run("""
+            using System;
+            using Stella.Ergosfare.Commands.Abstractions;
+            using System.Threading.Tasks;
+
+            namespace TestApp
+            {
+                [AttributeUsage(AttributeTargets.Parameter)]
+                public sealed class FromServicesAttribute : Attribute;
+
+                public interface IGreeter { }
+
+                public sealed record AnnotatedPing : ICommand;
+
+                public sealed class AnnotatedPingHandler : ICommandHandler<AnnotatedPing>
+                {
+                    public AnnotatedPingHandler([FromServices] IGreeter greeter) { }
+
+                    public ValueTask HandleAsync(AnnotatedPing message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.CompilationErrors);
+        Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "ERGOSG004");
+    }
+
+    [Fact]
     public void ExcludeFromPipelineMessage_SuppressesTheStagedPlan()
     {
         var result = GeneratorTestHost.Run("""

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
-using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
@@ -360,7 +359,7 @@ public class StagedPlanExecutionParityTests
     [Trait("Category", "Coverage")]
     public async Task PostInterceptor_RewritesTheResult()
     {
-        var (assembly, provider) = Host.Value;
+        var (assembly, _) = Host.Value;
 
         var queryType = assembly.GetType("TestApp.GenRewriteQuery", throwOnError: true)!;
         Assert.NotNull(GeneratedDispatchRoots.FindStagedResultPlan(queryType, typeof(int)));

--- a/test/Stella.Ergosfare.Test.Fixtures/IFixture.cs
+++ b/test/Stella.Ergosfare.Test.Fixtures/IFixture.cs
@@ -9,7 +9,7 @@ namespace Stella.Ergosfare.Test.Fixtures;
 /// Provides methods for configuring services, accessing a service provider,
 /// and creating fresh instances for per-test isolation.
 /// </summary>
-/// <typeparam name="TFixture">The concrete type of the fixture implementing this interface.</typeparam
+/// <typeparam name="TFixture">The concrete type of the fixture implementing this interface.</typeparam>
 public interface IFixture<out TFixture> : IDisposable
     where TFixture : IFixture<TFixture>
 {

--- a/test/Stella.Ergosfare.Test.Fixtures/MessageDependencyFixture.cs
+++ b/test/Stella.Ergosfare.Test.Fixtures/MessageDependencyFixture.cs
@@ -130,7 +130,7 @@ public class MessageDependencyFixture : IFixture<MessageDependencyFixture>
     /// <summary>
     /// Creates <see cref="IMessageDependencies"/> for a generic message type.
     /// </summary>
-    /// <typeparam name="TMessage">The message type to resolve dependencies for.</typeparam>
+    /// <param name="messageType">The message type to resolve dependencies for.</param>
     /// <returns>An instance of <see cref="IMessageDependencies"/>.</returns>
     public IMessageDependencies CreateDependencies(Type messageType)
     {

--- a/test/Stella.Ergosfare.Test.Fixtures/ResultAdapterFixture.cs
+++ b/test/Stella.Ergosfare.Test.Fixtures/ResultAdapterFixture.cs
@@ -129,7 +129,7 @@ public class ResultAdapterFixtures : IFixture<ResultAdapterFixtures>
                 return false;
 
             // Explicitly check if it's an error state
-            exception = new AdaptedException(errorOr.Description ?? "Unknown error", result);
+            exception = new AdaptedException(errorOr.Description , result);
             return true;
         }
     }

--- a/test/Stella.Ergosfare.Test.Fixtures/Stubs/Basic/VoidStubAsyncHandler.cs
+++ b/test/Stella.Ergosfare.Test.Fixtures/Stubs/Basic/VoidStubAsyncHandler.cs
@@ -58,7 +58,7 @@ public class StubVoidAsyncExceptionInterceptor: IAsyncExceptionInterceptor<StubM
     /// <inheritdoc />
     public ValueTask<object> HandleAsync(StubMessage message, object? messageResult, Exception exception, IExecutionContext context)
     {
-        return ValueTask.FromResult<object>(messageResult!);
+        return ValueTask.FromResult(messageResult!);
     }
 }
 

--- a/test/Stella.Ergosfare.Test.Fixtures/Stubs/Basic/VoidStubHandler.cs
+++ b/test/Stella.Ergosfare.Test.Fixtures/Stubs/Basic/VoidStubHandler.cs
@@ -1,6 +1,5 @@
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
-using Stella.Ergosfare.Core.Internal.Contexts;
 
 // ReSharper disable ClassNeverInstantiated.Global
 


### PR DESCRIPTION
Closes #121
Closes #122

The staged-plans epic's closing trio plus the solution-wide inspection sweep. Board entries: [invoker allocations](https://github.com/orgs/stellayazilim/projects/10?pane=item&itemId=225367370) · [staged generated plans](https://github.com/orgs/stellayazilim/projects/10?pane=item&itemId=225367377).

## 1. Thread-safety (TOCTOU)

Dependency/shape cache entries are now stamped with the registry version their build **started** at, and readers match on the stamp — a build racing a registration lands with the old version and the next dispatch rebuilds, instead of a stale pipeline being served until a (possibly never-coming) next version bump. The same pre-read pattern lands in all six version-guarded executors and the broadcast/stream invoker slots, which previously stamped the version *after* the build. Deterministic interleaving tests replay the race through the cache API.

## 2. Analyzer infos

- **ERGOSG003** (Info): a handler with multiple public constructors keeps the container's greedy selection in play, so generated plans skip its direct-construction fast path — collapse to one public constructor to enable it.
- **ERGOSG004** (Info): `[FromServices]` has no effect on constructor parameters — constructor injection resolves services regardless.

## 3. Staged activation fusion

Staged plans gain a direct-construction variant: the bases expose virtual `SupportsDirectConstruction`/`ExecuteDirect` (default-forwarding — hand-written plans unaffected), the generator emits the variant when **every** participant passes the construction gate (single public constructor, plain/keyed service parameters, not disposable), constructing participants with visible `new` while dependencies still resolve from the dispatching provider. The hosting executor uses it only after verifying at runtime that every composition participant's DI registration is the module's own plain transient one; any override falls back to the provider-resolving variant, and the advisory composition gate stays above both.

The visible `new` has a second payoff: the JIT's escape analysis can stack-allocate non-escaping participants — something `GetRequiredService` structurally hides.

| Row | Strategy baseline | Staged (PR #119) | **Staged + fusion** |
|---|---|---|---|
| Command_Void_Intercepted | 196.2 ns / 104 B | 73.7 ns / 72 B | **48.6 ns / 24 B — 4.2×** |
| Query_Result_Intercepted | 189.9 ns / 144 B | 102.6 ns / 96 B | **83.5 ns / 72 B — 2.3×** |

## 4. Inspection sweep (final commit)

292 Rider warnings → 0 under the agreed policy — cost-free fixes applied (ambiguous/broken doc crefs, unused usings/fields/locals, redundant suppressions and qualifiers, dead constant, benchmark namespace), deliberate patterns suppressed at the site with rationale (`InconsistentlySynchronizedField` on the registry's gate-writer/lock-free-reader design, static-generic holder slots, allocation-free group matching, the thread-safety test's intentional closure captures). A documentation-enabled build is now completely silent.

## Verification

Build 0 warnings on net9.0 + net10.0; full suite green (Core 141, Command 59, SourceGenerator 57, Events 41, Queries 23, MSDI 12 per TFM). New coverage: cache version-stamp interleaving tests, ERGOSG003/004 emission tests, fusion runtime tests (direct variant under plain transient, provider-variant fallback under a lifetime override) and fusion emission tests; the staged parity matrix now exercises the fused lane end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
