### PR TITLE
docs: v2.6.0-preview changelog + benchmark section refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,105 @@
+## v2.6.0-preview – '2026-08-08'
+
+Preview release. The theme: **interceptor-bearing pipelines go compile-time.** The plan
+work so far stopped where interceptors began — a message with a single handler dispatched
+through a compile-time plan, but one interceptor pushed the whole dispatch onto the runtime
+strategy's generic machinery. This release bakes the entire pipeline: the source generator
+now emits one bespoke plan class per interceptor-bearing message, running
+pre → handler → post (with exception and final semantics) as straight-line typed calls,
+participants constructed directly where that is provably identical to container activation.
+Every plan stays advisory: the executor re-validates the baked composition against the
+registry per version and falls back to the runtime strategy on any mismatch — behavior
+never changes, a stale plan only loses its speedup. Three defective flavored interceptor
+contracts and two registry-cache races are also fixed.
+
+### Staged pipeline plans
+
+* A message whose discovered pipeline is one async handler plus interceptors gets a sealed
+  `StagedVoidPlan<TMessage>`/`StagedResultPlan<TMessage, TResult>` emitted: stage order is
+  baked exactly as the runtime shape builder computes it (direct segment first, weight
+  descending, ordinal type-name tie-break), and each call's contract arm — the invocation
+  strategy's pattern match — is resolved at compile time, variance-aware. Anything
+  unmodelable (grouped/keyed participants, multi-registrations, contracts no arm serves)
+  disqualifies the message rather than risking divergence.
+* The hosting executor's advisory gate compares the baked `StagedPlanComposition` against
+  the live pipeline once per registry version — an ordered type-reference comparison,
+  never on the dispatch path — and requires unmemoized instances and no result adapters.
+* A strategy-parity matrix executes emitted plans end to end: message rewrite by
+  pre-interceptors, stage order, exception capture with strategy-identical swallowing,
+  propagation without an exception stage, `context.Abort()` skipping the exception stage
+  while finals still run, and post-interceptor result rewrite.
+
+### Direct construction, now for whole pipelines
+
+* Plan factories accept dependency-injected handlers: `AddVoidPlan`/`AddResultPlan` gain
+  `Func<IServiceProvider, THandler>` overloads, and the generator emits
+  `static provider => new THandler(provider.GetRequiredService<TDep>(), ...)` under a
+  strict gate — exactly one public constructor (the single shape where the container's
+  selection has no choice), plain or `[FromKeyedServices]` service parameters, nothing
+  optional, nothing disposable.
+* Staged plans fuse the same idea across the whole pipeline: an emitted `ExecuteDirect`
+  variant constructs every participant with a visible `new` (dependencies still resolve
+  from the dispatching provider). The executor uses it only after verifying at runtime
+  that every participant's registration is the module's own plain transient one; any
+  override falls back to the provider-resolving variant, with the composition gate above
+  both. The visible `new` also lets the JIT stack-allocate non-escaping participants —
+  something a container resolution structurally hides.
+* Measured (7800X3D, .NET 9.0.11): an intercepted void command (one pre- and one
+  post-interceptor) drops from **198.2 ns / 104 B** on the strategy path to
+  **49.2 ns / 24 B** through the fused staged plan — 4× faster with the pre/post/handler
+  transients stack-allocated; an intercepted `IQuery<int>` drops from
+  **198.3 ns / 144 B to 83.5 ns / 72 B**. Plain planned dispatches are unchanged
+  (void 21.0 ns, memoized 23.8 ns / 0 B).
+
+### Interceptor contract fixes
+
+* `ICommandExceptionInterceptor<TCommand>` extended the result-typed
+  `IAsyncExceptionInterceptor<TCommand, object>`, which no invocation-strategy arm can
+  match on a void pipeline (its internal `ValueTask` result carrier is a value type — no
+  variance): the exception stage itself threw `NotSupportedException`, burying the
+  handler's exception. Re-based on the result-agnostic contract; implementors compile
+  unchanged (the erased member signature is identical).
+* `IQueryFinalInterceptor` (non-generic) had the same defect via
+  `IAsyncFinalInterceptor<IQuery, object>` — the final stage failed for every value-typed
+  query result. Re-based likewise.
+* `IQueryPostInterceptor<TQuery>` closed its base over `IQuery` instead of `TQuery`,
+  silently applying the interceptor to **every** query in the application. It now targets
+  `TQuery` — see Notes.
+
+### Registry race stamps
+
+* Dependency and shape cache entries are stamped with the registry version their build
+  started at, and reads match on the stamp: a dependency build racing a runtime
+  registration can no longer be served as fresh after the invalidation clear — previously
+  a stale pipeline could stick until the next (possibly never-coming) version bump. Every
+  version-guarded executor and the broadcast/stream plan slots now read the version before
+  building, for the same reason.
+
+### Analyzer infos
+
+* **ERGOSG003** (info): a handler with multiple public constructors keeps the container's
+  constructor selection in play, so generated plans skip its direct-construction fast
+  path — collapse to one public constructor to enable it.
+* **ERGOSG004** (info): `[FromServices]` has no effect on constructor parameters —
+  constructor injection resolves services regardless.
+
+### Notes
+
+* **Behavioral fix worth auditing:** code that (knowingly or not) relied on an
+  `IQueryPostInterceptor<TQuery>` running for *other* queries must move that interceptor
+  to the non-generic `IQueryPostInterceptor`. The typed form now does what its name says.
+* **Source-compat:** the dispatch-root and staged-plan types moved into dedicated
+  namespaces (`Stella.Ergosfare.Core.Abstractions.DispatchRoots` / `.StagedPlans`);
+  code referencing `GeneratedDispatchRoots` or the plan bases directly needs a using
+  update. Generated code and the generator's version probes were updated in lockstep —
+  against older packages emission degrades gracefully, as always.
+* Per-dispatch invoker allocations in the strategy layer are gone (the four interceptor
+  invokers became static); the interceptor-bearing strategy path itself is otherwise
+  unchanged and remains the permanent fallback.
+* Housekeeping: one type per file across the runtime, and a solution-wide inspection
+  sweep — deliberate patterns (lock-free readers, static-generic slots, allocation-free
+  group matching) now carry explicit suppressions with rationale.
+
 ## v2.5.0-preview – '2026-08-08'
 
 Preview release. The theme: **group filtering becomes first-class, and manual registration

--- a/readme.md
+++ b/readme.md
@@ -164,49 +164,63 @@ dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking
 ```
 
 Environment: BenchmarkDotNet v0.15.8 · Windows 11 · AMD Ryzen 7 7800X3D · .NET 9.0.11
-(RyuJIT x86-64-v4). Measured 2026-07-28, on the tree released as v2.2.0-preview.
+(RyuJIT x86-64-v4). Measured 2026-08-08, on the tree released as v2.6.0-preview. Every row
+is a **single dispatch** of a no-op handler through the public mediator interfaces.
 
-Two shapes are measured, for three mediators:
+Two shapes are measured:
 
-- **Typical usage** — how an application normally sends messages: the library's public
-  mediator interface, one shared DI scope for the whole loop.
-- **Web-server shape** — a fresh DI scope for every dispatch, mimicking one scope per
-  HTTP request (the shape ASP.NET Core gives you).
+- **Typical usage** — the mediators resolved once from a shared scope (background workers,
+  message-pump loops).
+- **Web-server shape** — a fresh DI scope and mediator resolution for every dispatch,
+  mimicking one scope per HTTP request (the shape ASP.NET Core gives you).
 
-| Scenario (100k dispatches/op) | Mean | Allocated | Gen0/1k ops |
+Typical usage:
+
+| Scenario (per dispatch) | Mean | Allocated |
+|---|---:|---:|
+| Command — runtime registration | 33.2 ns | 24 B |
+| Command — generated plan (`RegisterGenerated`) | **21.0 ns** | 24 B |
+| Command — memoized handlers | 23.8 ns | **0 B** |
+| Command + 2 interceptors — runtime strategy | 198.2 ns | 104 B |
+| Command + 2 interceptors — **staged plan** | **49.2 ns** | **24 B** |
+| Query (`IQuery<int>`) — generated plan | 25.3 ns | 24 B |
+| Query + 2 interceptors — **staged plan** | **83.5 ns** | 72 B |
+| Event publish (two handlers) | 52.1 ns | 48 B |
+| Grouped command (`GroupSet`) | 35.1 ns | 24 B |
+| MediatR — command / query / publish | 61.1 / 55.2 / 92.3 ns | 192 / 192 / 440 B |
+| Mediator (martinothamar) — command / query / publish | 8.0 / 8.0 / 16.1 ns | 0 B |
+
+Web-server shape (scope creation included in every row):
+
+| Per dispatch | Ergosfare | MediatR | Mediator (martinothamar) |
 |---|---:|---:|---:|
-| **Ergosfare** — typical usage | **2.97 ms** | **2.29 MB** | 47 |
-| **MediatR** — typical usage | 5.79 ms | 18.31 MB | 375 |
-| **LiteBus** — typical usage | 139.62 ms | 714.87 MB | 14 750 |
-| **Ergosfare** — web-server shape | **8.46 ms** | **21.36 MB** | 438 |
-| **MediatR** — web-server shape | 10.28 ms | 33.57 MB | 688 |
-| Ergosfare — internal engine path (reference row) | 6.31 ms | 5.34 MB | 109 |
+| Command | 95.0 ns / 192 B | 114.2 ns / 352 B | 54.8 ns / 128 B |
+| Query | 96.6 ns / 200 B | 105.8 ns / 352 B | 54.2 ns / 128 B |
+| Publish | 100.5 ns / 232 B | 139.1 ns / 600 B | 59.2 ns / 128 B |
 
 Scenario notes:
 
-- The typical-usage rows are the headline: Ergosfare runs the loop in **about half
-  MediatR's time** while allocating **an eighth of its garbage**, with Gen0 collection
-  pressure down accordingly — pooled execution contexts and the `ValueTask`-first
-  pipeline for the allocation, straight-through dispatch and the executor's cached plan
-  for the time.
-- The web-server shape is the closer race. Ergosfare leads on both axes, but by ~18% on
-  time against ~36% on allocation, and that row is dominated by DI scope creation, which
-  both libraries pay identically. It read 18.81 ms / 38.91 MB before v2.2.0-preview.
-- The *internal engine path* row drives `IMessageMediator.Mediate` with pre-built
-  `MediateOptions` — a separate entry point that runs its own resolve and mediation
-  strategies, so it reaches neither the executor's cached plan nor the straight-through
-  path. That is why it now trails the public facade. It remains supported for custom
-  mediation strategies; you would not write ordinary application code this way.
-- LiteBus is included as a reference point: Ergosfare's API surface was heavily inspired
-  by it, but the runtime is an independent implementation.
-- Transient handlers intentionally allocate one instance per dispatch (that is what a
-  transient registration declares). Dispatch-heavy single-scope loops that want instance
-  reuse should register handlers as singletons or call `ForceMemoizedHandlers()`.
+- Against **MediatR**, Ergosfare leads every row on both axes — roughly 2–3× on time and
+  2–8× on allocation in typical usage, and it stays ahead in the scope-dominated
+  web-server shape.
+- **Mediator** (martinothamar's source-generated library) is faster on raw nanoseconds by
+  design: it carries no execution context, no runtime registry, and resolves its
+  singleton handlers without touching the container per dispatch. Ergosfare's default
+  24 B is the transient handler instance itself — what a transient registration
+  declares — and drops to 0 B with singleton handlers or `ForceMemoizedHandlers()`.
+- The **staged plan** rows are the interceptor story: an interceptor-bearing pipeline
+  used to cost ~6× a bare dispatch on the runtime strategy; the source-generated staged
+  plan runs the same pipeline — same order, same exception and final semantics,
+  re-validated against the registry per version — in straight-line code at ~1.5× the
+  bare dispatch, with the participant instances stack-allocated by the JIT where they
+  do not escape.
+- Everything above uses default, out-of-the-box settings for all three libraries.
 
 Row ↔ BenchmarkDotNet method mapping, for matching against your own runs:
-`StellaErgosfare_PublicApi` / `MediatR` / `LiteBus_PublicApi` (typical usage),
-`StellaErgosfare_PublicApi_ScopePerDispatch` / `MediatR_ScopePerDispatch` (web-server
-shape), `StellaErgosfare` (internal engine path).
+`Command_Void`, `Command_Void_Generated`, `Command_Void_Memoized`,
+`Command_Void_Intercepted`, `Command_Void_Intercepted_Generated`, `Query_Result_Generated`,
+`Query_Result_Intercepted_Generated`, `Event_Publish`, `Command_Void_Grouped_GroupSet`,
+`MediatR_*`, `MediatorSg_*`, and the `*_Scoped` variants for the web-server shape.
 
 ## Dispatch architecture
 


### PR DESCRIPTION
The closing docs for the staged-plans epic, ahead of the preview-dev → preview promotion:

- **CHANGELOG**: the v2.6.0-preview entry — staged pipeline plans, whole-pipeline direct construction (and why the visible `new` lets the JIT stack-allocate participants), the three flavored interceptor contract repairs (with the behavioral note on `IQueryPostInterceptor<TQuery>` now actually targeting `TQuery`), the registry race stamps, ERGOSG003/004, and the namespace-move source-compat note. Numbers measured today on the merged tree.
- **README**: the benchmark section still described the retired 100k-loop program with method names that no longer exist. Rewritten around the current per-dispatch suite: typical-usage and web-server tables, the staged-plan interceptor story (198 → 49 ns, 104 → 24 B), and honest comparisons (MediatR led on every row; Mediator's raw-ns lead and why, stated plainly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
