### PR TITLE
test: wire the contract suite into the solution and CI, capture the phase-0 baselines

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Restore Dependencies
         run: dotnet restore Stella.Ergosfare.slnx
 
+      # Category=Contract is the core-modernization safety net
+      # (test/Stella.Ergosfare.Contract.Test): it runs both registration axes on both
+      # TFMs and is named here explicitly so it can never fall out of CI unnoticed.
       - name: Run Unit Tests
         run: |
           dotnet test Stella.Ergosfare.slnx \
             --logger "trx;LogFileName=unit-tests.trx" \
-            --filter "Category=Unit"
+            --filter "Category=Unit|Category=Contract"

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,12 @@ changelog/**
 changelog/**/
 docs/**
 docs/**
-BenchmarkDotNet.Artifacts/
+# Benchmark output is per-run and throwaway — except the dated baselines the
+# modernization phases re-run and compare against, which are committed. Excluding the
+# directory's contents rather than the directory itself is what makes that re-inclusion
+# possible: git never descends into an excluded directory.
+**/BenchmarkDotNet.Artifacts/*
+!**/BenchmarkDotNet.Artifacts/baselines/
 
 # docfx output — the API reference is generated on demand (see
 # .github/workflows/api_reference.yml) and consumed by the docs site, never committed.

--- a/Stella.Ergosfare.slnx
+++ b/Stella.Ergosfare.slnx
@@ -27,6 +27,7 @@
     <File Path="coverlet.runsettings" />
     <Project Path="test/Stella.Ergosfare.Benchmarking/Stella.Ergosfare.Benchmarking.csproj" />
     <Project Path="test\Stella.Ergosfare.Command.Test\Stella.Ergosfare.Command.Test.csproj" />
+    <Project Path="test\Stella.Ergosfare.Contract.Test\Stella.Ergosfare.Contract.Test.csproj" />
     <Project Path="test\Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test\Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test.csproj" />
     <Project Path="test\Stella.Ergosfare.Core.Test\Stella.Ergosfare.Core.Test.csproj" />
     <Project Path="test\Stella.Ergosfare.Events.Test\Stella.Ergosfare.Events.Test.csproj" />

--- a/test/Stella.Ergosfare.Benchmarking/BenchmarkDotNet.Artifacts/baselines/2026-08-09-cache-pressure-baseline.md
+++ b/test/Stella.Ergosfare.Benchmarking/BenchmarkDotNet.Artifacts/baselines/2026-08-09-cache-pressure-baseline.md
@@ -1,0 +1,81 @@
+# Cache-pressure baseline — 2026-08-09
+
+The "before" picture for the core modernization, captured from `CachePressureBenchmark`
+on the day Phase 0 wired the safety net, before any surgery. Re-run it after every large
+merge and compare against this file.
+
+```bash
+dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking -- --filter '*CachePressure*'
+```
+
+## How to read it
+
+- **Rows are lanes, not libraries.** Ergosfare appears three times — `Command_Void` /
+  `Query_Result` is the runtime-registered default (transient handler per dispatch),
+  `*_Generated` is the compile-time dispatch root and plan, `*_Memoized` resolves the
+  handler graph once. MediatR and martinothamar/Mediator run their own defaults.
+- **The baseline of each group is Ergosfare's default lane**, so `Ratio` reads as "what
+  does this lane, or this library, cost relative to a plain runtime-registered dispatch".
+- **Numbers here are not comparable to `MediationBenchmark`'s rows.** Everything below is
+  pinned to one logical core; the mediation table runs free-floating. Compare this file
+  only against later runs of this same benchmark.
+
+## Hardware counters: NOT collected in this run
+
+The counter columns (cache misses, branch mispredictions, retired instructions) are
+absent because the capture ran from an **unelevated** console. BenchmarkDotNet reads them
+through ETW kernel sessions, which need administrator rights on Windows; `CachePressureConfig`
+attaches the counters only when the process can actually open that session, so an
+unelevated run still yields the timing and allocation columns instead of failing
+validation with nothing to show.
+
+**To fill in the counter columns, run the same command from an administrator console.**
+That capture is the one that answers the question this gate exists for — whether a
+redesign paid for its speed with instruction-cache footprint or an extra unpredictable
+branch — and it should be taken before the surgery starts.
+
+## Machine caveat
+
+The capture host is an AMD Ryzen 7 7800X3D: 96 MB of stacked L3. A working set that
+thrashes on a typical single-core server can sit comfortably in this cache, so the
+absolute miss rates measured here are optimistic. Deltas between rows on the same host
+are still the signal; absolute numbers are not a claim about production hardware.
+
+## Result
+
+```
+
+BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8973/25H2/2025Update/HudsonValley2)
+AMD Ryzen 7 7800X3D 4.20GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 10.0.100
+  [Host]     : .NET 9.0.11 (9.0.11, 9.0.1125.51716), X64 RyuJIT x86-64-v4
+  SingleCore : .NET 9.0.11 (9.0.11, 9.0.1125.51716), X64 RyuJIT x86-64-v4
+
+Job=SingleCore  Affinity=0000000000000001  
+
+```
+| Method                 | Categories   | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|----------------------- |------------- |----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| Command_Void           | Command_Void | 36.312 ns | 0.7547 ns | 2.0914 ns | 35.717 ns |  1.00 |    0.08 | 0.0005 |      24 B |        1.00 |
+| Command_Void_Generated | Command_Void | 22.654 ns | 0.4759 ns | 1.1493 ns | 22.309 ns |  0.63 |    0.05 | 0.0005 |      24 B |        1.00 |
+| Command_Void_Memoized  | Command_Void | 23.799 ns | 0.3128 ns | 0.2773 ns | 23.792 ns |  0.66 |    0.04 |      - |         - |        0.00 |
+| MediatR_Send_Void      | Command_Void | 65.468 ns | 1.5189 ns | 4.3581 ns | 64.638 ns |  1.81 |    0.15 | 0.0038 |     192 B |        8.00 |
+| MediatorSg_Send_Void   | Command_Void |  8.417 ns | 0.1882 ns | 0.2092 ns |  8.366 ns |  0.23 |    0.01 |      - |         - |        0.00 |
+|                        |              |           |           |           |           |       |         |        |           |             |
+| Query_Result           | Query_Result | 40.052 ns | 0.8225 ns | 2.3600 ns | 39.832 ns |  1.00 |    0.08 | 0.0005 |      24 B |        1.00 |
+| Query_Result_Generated | Query_Result | 26.476 ns | 0.5733 ns | 1.6356 ns | 26.270 ns |  0.66 |    0.06 | 0.0005 |      24 B |        1.00 |
+| Query_Result_Memoized  | Query_Result | 34.816 ns | 0.2926 ns | 0.2594 ns | 34.757 ns |  0.87 |    0.05 |      - |         - |        0.00 |
+| MediatR_Send_Result    | Query_Result | 56.405 ns | 1.1104 ns | 0.9273 ns | 56.321 ns |  1.41 |    0.08 | 0.0038 |     192 B |        8.00 |
+| MediatorSg_Send_Result | Query_Result |  8.789 ns | 0.2018 ns | 0.5888 ns |  8.573 ns |  0.22 |    0.02 |      - |         - |        0.00 |
+
+## What the "before" picture says
+
+- Both compiled lanes land ~35 % under the runtime-registered default on one core, which
+  is the modernization's starting margin: whatever replaces the six dispatch generations
+  has to keep at least this.
+- `Query_Result_Memoized` (34.8 ns) is barely under the default (40.1 ns) and well over
+  the generated lane (26.5 ns) — the memoized gate closing over the faster lane, the same
+  inversion the five-participant pipeline rows show. It is a target, not noise.
+- The gap to martinothamar/Mediator (~8.5 ns, both shapes) is unchanged by core pinning,
+  so it is structural — execution context, registry and DI resolution — not a scheduling
+  artefact.

--- a/test/Stella.Ergosfare.Benchmarking/CachePressureBenchmark.cs
+++ b/test/Stella.Ergosfare.Benchmarking/CachePressureBenchmark.cs
@@ -1,0 +1,223 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Benchmarking;
+
+/// <summary>
+/// What a dispatch costs the CPU, not just the clock: cache misses, branch
+/// mispredictions and retired instructions for the two elementary shapes — a void command
+/// and a result-bearing query — pinned to one core.
+/// </summary>
+/// <remarks>
+/// <para>This is the core modernization's measurement gate. Nanoseconds and bytes already
+/// have a home in <see cref="MediationBenchmark"/>; they cannot say whether a redesign
+/// paid for its speed with instruction-cache footprint or an extra unpredictable branch,
+/// which is exactly what a single-core deployment feels first. A baseline is captured
+/// before the surgery and re-run after every large merge.</para>
+/// <para>Each shape carries the same five rows: Ergosfare's three registration lanes —
+/// default (runtime-registered, transient handlers), generated (compile-time dispatch
+/// roots and plans) and memoized (handler graph resolved once) — against MediatR and
+/// martinothamar/Mediator on their own defaults, the two competitors
+/// <see cref="MediationBenchmark"/> already tracks. Ergosfare's default lane is the
+/// per-shape baseline, so the Ratio column reads as "what does this lane, or this
+/// library, cost relative to a plain runtime-registered Ergosfare dispatch".</para>
+/// <para>The generated and memoized lanes install process-wide state
+/// (<c>RegisterGenerated()</c> writes the dispatch roots; <c>ForceMemoizedHandlers()</c>
+/// changes how every handler resolves), so each gets a targeted setup and therefore its
+/// own benchmark process — the same isolation <see cref="MediationBenchmark"/> uses.</para>
+/// <para>Counter collection needs an elevated console on Windows; see
+/// <see cref="CachePressureConfig"/> for what an unelevated run still reports.</para>
+/// </remarks>
+[MemoryDiagnoser]
+[Config(typeof(CachePressureConfig))]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class CachePressureBenchmark
+{
+    private const string VoidShape = "Command_Void";
+    private const string ResultShape = "Query_Result";
+
+    private ServiceProvider _ergosfare = null!;
+    private ServiceProvider _ergosfareGenerated = null!;
+    private ServiceProvider _ergosfareMemoized = null!;
+    private ServiceProvider _mediatr = null!;
+    private ServiceProvider _mediatorSg = null!;
+
+    private ICommandMediator _commands = null!;
+    private IQueryMediator _queries = null!;
+    private ICommandMediator _generatedCommands = null!;
+    private IQueryMediator _generatedQueries = null!;
+    private ICommandMediator _memoizedCommands = null!;
+    private IQueryMediator _memoizedQueries = null!;
+    private IMediator _mediator = null!;
+    private Mediator.IMediator _martinMediator = null!;
+
+    private readonly VoidCommand _voidCommand = new();
+    private readonly IntQuery _intQuery = new();
+    private readonly MediatrVoidRequest _mediatrVoid = new();
+    private readonly MediatrIntRequest _mediatrInt = new();
+    private readonly MediatorSgVoidCommand _mediatorSgVoid = new();
+    private readonly MediatorSgIntQuery _mediatorSgInt = new();
+
+    /// <summary>Builds the runtime-registered lane and both competitors.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ergosfare = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+                options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
+            })
+            .BuildServiceProvider();
+
+        _commands = _ergosfare.GetRequiredService<ICommandMediator>();
+        _queries = _ergosfare.GetRequiredService<IQueryMediator>();
+
+        _mediatr = new ServiceCollection()
+            .AddMediatR(configuration =>
+                configuration.RegisterServicesFromAssembly(typeof(CachePressureBenchmark).Assembly))
+            .BuildServiceProvider();
+
+        _mediator = _mediatr.GetRequiredService<IMediator>();
+
+        _mediatorSg = new ServiceCollection()
+            .AddMediator()
+            .BuildServiceProvider();
+
+        _martinMediator = _mediatorSg.GetRequiredService<Mediator.IMediator>();
+
+        AssertQueryAnswers(() => _queries.QueryAsync(_intQuery).AsTask().GetAwaiter().GetResult(), "Ergosfare");
+        AssertQueryAnswers(() => _mediator.Send(_mediatrInt).GetAwaiter().GetResult(), "MediatR");
+        AssertQueryAnswers(() => _martinMediator.Send(_mediatorSgInt).AsTask().GetAwaiter().GetResult(), "Mediator");
+    }
+
+    /// <summary>Releases the providers built by <see cref="Setup"/>.</summary>
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _ergosfare.Dispose();
+        _mediatr.Dispose();
+        _mediatorSg.Dispose();
+    }
+
+    /// <summary>Builds the source-generated lane in its own benchmark process.</summary>
+    [GlobalSetup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
+    public void SetupGenerated()
+    {
+        _ergosfareGenerated = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.AddCommandModule(commands => commands.RegisterGenerated());
+                options.AddQueryModule(queries => queries.RegisterGenerated());
+            })
+            .BuildServiceProvider();
+
+        _generatedCommands = _ergosfareGenerated.GetRequiredService<ICommandMediator>();
+        _generatedQueries = _ergosfareGenerated.GetRequiredService<IQueryMediator>();
+
+        AssertQueryAnswers(
+            () => _generatedQueries.QueryAsync(_intQuery).AsTask().GetAwaiter().GetResult(),
+            "Ergosfare (generated)");
+    }
+
+    /// <summary>Releases the source-generated lane's provider.</summary>
+    [GlobalCleanup(Targets = [nameof(Command_Void_Generated), nameof(Query_Result_Generated)])]
+    public void CleanupGenerated() => _ergosfareGenerated.Dispose();
+
+    /// <summary>Builds the memoized lane in its own benchmark process.</summary>
+    [GlobalSetup(Targets = [nameof(Command_Void_Memoized), nameof(Query_Result_Memoized)])]
+    public void SetupMemoized()
+    {
+        _ergosfareMemoized = new ServiceCollection()
+            .AddErgosfare(options =>
+            {
+                options.ForceMemoizedHandlers();
+                options.AddCommandModule(commands => commands.Register<VoidCommandHandler>());
+                options.AddQueryModule(queries => queries.Register<IntQueryHandler>());
+            })
+            .BuildServiceProvider();
+
+        _memoizedCommands = _ergosfareMemoized.GetRequiredService<ICommandMediator>();
+        _memoizedQueries = _ergosfareMemoized.GetRequiredService<IQueryMediator>();
+
+        AssertQueryAnswers(
+            () => _memoizedQueries.QueryAsync(_intQuery).AsTask().GetAwaiter().GetResult(),
+            "Ergosfare (memoized)");
+    }
+
+    /// <summary>Releases the memoized lane's provider.</summary>
+    [GlobalCleanup(Targets = [nameof(Command_Void_Memoized), nameof(Query_Result_Memoized)])]
+    public void CleanupMemoized() => _ergosfareMemoized.Dispose();
+
+    // ------------------------------------------------------------------
+    // Void command — nothing comes back; the shape every fast lane targets first
+    // ------------------------------------------------------------------
+
+    /// <summary>Runtime-registered handler, resolved transiently per dispatch.</summary>
+    [Benchmark(Baseline = true), BenchmarkCategory(VoidShape)]
+    public ValueTask Command_Void() => _commands.SendAsync(_voidCommand);
+
+    /// <summary>The compile-time dispatch root and plan emitted by the generator.</summary>
+    [Benchmark, BenchmarkCategory(VoidShape)]
+    public ValueTask Command_Void_Generated() => _generatedCommands.SendAsync(_voidCommand);
+
+    /// <summary>The handler graph resolved once and reused — no per-dispatch allocation.</summary>
+    [Benchmark, BenchmarkCategory(VoidShape)]
+    public ValueTask Command_Void_Memoized() => _memoizedCommands.SendAsync(_voidCommand);
+
+    /// <summary>MediatR on its defaults: reflection-based dispatch, transient handlers.</summary>
+    [Benchmark, BenchmarkCategory(VoidShape)]
+    public Task MediatR_Send_Void() => _mediator.Send(_mediatrVoid);
+
+    /// <summary>martinothamar/Mediator on its defaults: generated dispatch, singletons.</summary>
+    [Benchmark, BenchmarkCategory(VoidShape)]
+    public ValueTask<Mediator.Unit> MediatorSg_Send_Void() => _martinMediator.Send(_mediatorSgVoid);
+
+    // ------------------------------------------------------------------
+    // Result query — the same five lanes with a value travelling back
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc cref="Command_Void" />
+    [Benchmark(Baseline = true), BenchmarkCategory(ResultShape)]
+    public ValueTask<int> Query_Result() => _queries.QueryAsync(_intQuery);
+
+    /// <inheritdoc cref="Command_Void_Generated" />
+    [Benchmark, BenchmarkCategory(ResultShape)]
+    public ValueTask<int> Query_Result_Generated() => _generatedQueries.QueryAsync(_intQuery);
+
+    /// <inheritdoc cref="Command_Void_Memoized" />
+    [Benchmark, BenchmarkCategory(ResultShape)]
+    public ValueTask<int> Query_Result_Memoized() => _memoizedQueries.QueryAsync(_intQuery);
+
+    /// <inheritdoc cref="MediatR_Send_Void" />
+    [Benchmark, BenchmarkCategory(ResultShape)]
+    public Task<int> MediatR_Send_Result() => _mediator.Send(_mediatrInt);
+
+    /// <inheritdoc cref="MediatorSg_Send_Void" />
+    [Benchmark, BenchmarkCategory(ResultShape)]
+    public ValueTask<int> MediatorSg_Send_Result() => _martinMediator.Send(_mediatorSgInt);
+
+    /// <summary>
+    /// A lane that silently stops dispatching still benchmarks beautifully. Every setup
+    /// proves its provider answers before any measurement runs.
+    /// </summary>
+    private static void AssertQueryAnswers(Func<int> dispatch, string library)
+    {
+        var result = dispatch();
+
+        if (result != 7)
+        {
+            throw new InvalidOperationException(
+                $"{library} query returned {result}, expected 7 — the handler did not run.");
+        }
+    }
+}

--- a/test/Stella.Ergosfare.Benchmarking/CachePressureConfig.cs
+++ b/test/Stella.Ergosfare.Benchmarking/CachePressureConfig.cs
@@ -1,0 +1,62 @@
+using System.Security.Principal;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace Stella.Ergosfare.Benchmarking;
+
+/// <summary>
+/// The measurement gate for <see cref="CachePressureBenchmark"/>: one logical core, plus
+/// the hardware counters that say what a dispatch costs beyond its wall clock.
+/// </summary>
+/// <remarks>
+/// <para><b>Single-core affinity.</b> Every case runs pinned to logical core 0. The
+/// deployment this library is tuned for is a single-core server, where a dispatch shares
+/// one L1/L2 with everything else the process does — a free-floating benchmark spreads
+/// its working set over several caches and reports a hit rate that machine never sees.
+/// Pinning also stops the scheduler from migrating the run mid-iteration, which is what
+/// makes cache-miss counts comparable between rows at all.</para>
+/// <para><b>Hardware counters require an elevated console on Windows.</b> BenchmarkDotNet
+/// reads them through ETW kernel sessions, which a non-elevated process may not open. The
+/// counters are therefore attached only when this process can actually collect them;
+/// without elevation the same run still produces the timing and allocation columns, and
+/// the counter columns are simply absent. Run it from an administrator console —
+/// <c>dotnet run -c Release -f net9.0 --project test\Stella.Ergosfare.Benchmarking -- --filter *CachePressure*</c>
+/// — to fill them in. On Linux the equivalent is <c>perf</c> and root/perf_event_paranoid
+/// permissions; the gate below reports no counters there.</para>
+/// </remarks>
+public sealed class CachePressureConfig : ManualConfig
+{
+    /// <summary>Creates the configuration.</summary>
+    public CachePressureConfig()
+    {
+        // Affinity is a bitmask over logical processors; bit 0 is core 0.
+        AddJob(Job.Default
+            .WithAffinity((nint)1)
+            .WithId("SingleCore"));
+
+        if (CanCollectHardwareCounters())
+        {
+            AddHardwareCounters(
+                HardwareCounter.CacheMisses,
+                HardwareCounter.BranchMispredictions,
+                HardwareCounter.InstructionRetired);
+        }
+    }
+
+    /// <summary>
+    /// Whether this process can open the counter session — Windows, elevated. Asking
+    /// first keeps an unelevated run useful (timings and allocations) instead of failing
+    /// validation with nothing to show.
+    /// </summary>
+    private static bool CanCollectHardwareCounters()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        using var identity = WindowsIdentity.GetCurrent();
+        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+    }
+}

--- a/test/Stella.Ergosfare.Benchmarking/Program.cs
+++ b/test/Stella.Ergosfare.Benchmarking/Program.cs
@@ -21,8 +21,19 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        // Args flow through so filtered runs work, e.g. `-- --filter *Intercepted`.
-        BenchmarkRunner.Run<MediationBenchmark>(args: args);
+        // A bare run keeps its historical meaning: the whole MediationBenchmark table.
+        if (args.Length == 0)
+        {
+            BenchmarkRunner.Run<MediationBenchmark>();
+            return;
+        }
+
+        // With arguments the switcher selects across the benchmark classes, so
+        // `-- --filter *CachePressure*` reaches the measurement gate while
+        // `-- --filter *Intercepted*` still reaches the mediation rows.
+        BenchmarkSwitcher
+            .FromTypes([typeof(MediationBenchmark), typeof(CachePressureBenchmark)])
+            .Run(args);
     }
 }
 

--- a/test/Stella.Ergosfare.Contract.Test/Context/ExecutionContextDataFlowTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Context/ExecutionContextDataFlowTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Context;
+
+/// <summary>
+/// What the execution context carries: values written by one stage reaching the later
+/// stages of the same dispatch, the caller's cancellation token reaching the handler, and
+/// nothing surviving into the next dispatch.
+/// </summary>
+public sealed class ExecutionContextDataFlowTests
+{
+    private const string Key = "contract.context";
+    private const string WrittenByPre = "written-by-pre";
+    private const string WrittenByHandler = "written-by-handler";
+
+    [DiscoveryKey(Key)]
+    public sealed class Carrier : ICommand
+    {
+        /// <summary>Whether the handler saw the pre-interceptor's write.</summary>
+        public bool HandlerSawPreValue;
+
+        /// <summary>Whether the handler saw a value left behind by an earlier dispatch.</summary>
+        public bool HandlerSawStaleValue;
+
+        /// <summary>Whether the final interceptor saw the pre-interceptor's write.</summary>
+        public bool FinalSawPreValue;
+
+        /// <summary>The token the handler was given.</summary>
+        public CancellationToken SeenToken;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class CarrierPre : ICommandPreInterceptor<Carrier>
+    {
+        public ValueTask<Carrier> HandleAsync(Carrier command, IExecutionContext context)
+        {
+            context.Set(WrittenByPre, "yes");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class CarrierHandler : ICommandHandler<Carrier>
+    {
+        public ValueTask HandleAsync(Carrier command, IExecutionContext context)
+        {
+            command.HandlerSawPreValue = context.Has(WrittenByPre);
+            command.HandlerSawStaleValue = context.Has(WrittenByHandler);
+            command.SeenToken = context.CancellationToken;
+            context.Set(WrittenByHandler, "yes");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class CarrierFinal : ICommandFinalInterceptor<Carrier>
+    {
+        public ValueTask HandleAsync(Carrier command, object? result, Exception? exception, IExecutionContext context)
+        {
+            command.FinalSawPreValue = context.Has(WrittenByPre);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_written_by_a_pre_interceptor_reaches_the_handler_and_the_final_interceptor()
+    {
+        await using var provider = CreateProvider();
+        var command = new Carrier();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.True(command.HandlerSawPreValue);
+        Assert.True(command.FinalSawPreValue);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_callers_cancellation_token_is_the_one_the_pipeline_observes()
+    {
+        await using var provider = CreateProvider();
+        using var cancellation = new CancellationTokenSource();
+        var command = new Carrier();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(command, commandMediationSettings: null, cancellation.Token);
+
+        Assert.Equal(cancellation.Token, command.SeenToken);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Context_state_does_not_leak_from_one_dispatch_into_the_next()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new Carrier();
+        await mediator.SendAsync(first);
+
+        var second = new Carrier();
+        await mediator.SendAsync(second);
+
+        Assert.False(first.HandlerSawStaleValue);
+        Assert.False(second.HandlerSawStaleValue);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_callers_settings_items_survive_the_dispatch_and_expose_what_stages_wrote()
+    {
+        await using var provider = CreateProvider();
+        var settings = new CommandMediationSettings();
+        settings.Items["caller-owned"] = "kept";
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(new Carrier(), settings);
+
+        Assert.Equal("kept", settings.Items["caller-owned"]);
+        Assert.Equal("yes", settings.Items[WrittenByHandler]);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_second_dispatch_does_not_see_the_first_callers_items()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var first = new CommandMediationSettings();
+        first.Items["secret"] = "data";
+        await mediator.SendAsync(new Carrier(), first);
+
+        var second = new CommandMediationSettings();
+        await mediator.SendAsync(new Carrier(), second);
+
+        Assert.False(second.Items.ContainsKey("secret"));
+        Assert.Equal("data", first.Items["secret"]);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Dispatch/BasicDispatchTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Dispatch/BasicDispatchTests.cs
@@ -1,0 +1,174 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Dispatch;
+
+/// <summary>
+/// What a dispatch does when nothing but a handler is in the way: the handler runs, its
+/// value comes back, and it is handed the caller's own message instance together with a
+/// live execution context.
+/// </summary>
+public sealed class BasicDispatchTests
+{
+    private const string Key = "contract.dispatch";
+
+    [DiscoveryKey(Key)]
+    public sealed class Greet : ICommand
+    {
+        /// <summary>Set by the handler so the test can prove it ran.</summary>
+        public bool Handled;
+
+        /// <summary>The context instance the handler was handed.</summary>
+        public IExecutionContext? SeenContext;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class GreetHandler : ICommandHandler<Greet>
+    {
+        public ValueTask HandleAsync(Greet command, IExecutionContext context)
+        {
+            command.Handled = true;
+            command.SeenContext = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>The instance the handler was handed, so identity can be compared.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class Echo : ICommand<string>
+    {
+        public string Word = string.Empty;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class EchoHandler : ICommandHandler<Echo, string>
+    {
+        /// <summary>The message instance the last dispatch handed this handler.</summary>
+        public static Echo? LastSeen;
+
+        public ValueTask<string> HandleAsync(Echo command, IExecutionContext context)
+        {
+            LastSeen = command;
+            return ValueTask.FromResult(command.Word + "!");
+        }
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class Sum : IQuery<int>
+    {
+        public int Left;
+        public int Right;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class SumHandler : IQueryHandler<Sum, int>
+    {
+        public ValueTask<int> HandleAsync(Sum query, IExecutionContext context)
+            => ValueTask.FromResult(query.Left + query.Right);
+    }
+
+    /// <summary>Never registered anywhere: the no-handler scenarios dispatch these.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class NeverRegisteredCommand : ICommand;
+
+    /// <inheritdoc cref="NeverRegisteredCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class NeverRegisteredQuery : IQuery<int>;
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated(Key))
+                .AddQueryModule(queries => queries.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_command_reaches_its_handler()
+    {
+        await using var provider = CreateProvider();
+        var command = new Greet();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.True(command.Handled);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_handler_is_given_a_live_execution_context()
+    {
+        await using var provider = CreateProvider();
+        var command = new Greet();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.NotNull(command.SeenContext);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_result_command_returns_the_value_its_handler_produced()
+    {
+        await using var provider = CreateProvider();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(new Echo { Word = "hello" });
+
+        Assert.Equal("hello!", result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_handler_receives_the_callers_own_message_instance()
+    {
+        await using var provider = CreateProvider();
+        var command = new Echo { Word = "same" };
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.Same(command, EchoHandler.LastSeen);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_query_returns_the_value_its_handler_produced()
+    {
+        await using var provider = CreateProvider();
+
+        var result = await provider.GetRequiredService<IQueryMediator>()
+            .QueryAsync(new Sum { Left = 20, Right = 22 });
+
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_command_with_no_registered_handler_throws_NoHandlerFoundException()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.SendAsync(new NeverRegisteredCommand()));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_query_with_no_registered_handler_throws_NoHandlerFoundException()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.QueryAsync(new NeverRegisteredQuery()));
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Events;
+
+/// <summary>
+/// Publish semantics: fan-out to every matching handler, what an audience of nobody does,
+/// and group filtering behaving exactly as it does for commands.
+/// </summary>
+public sealed class EventPublishTests
+{
+    private const string Key = "contract.events";
+    private const string Reporting = "reporting";
+
+    [DiscoveryKey(Key)]
+    public sealed class OrderPlaced : IEvent;
+
+    [DiscoveryKey(Key)]
+    public sealed class OrderPlacedInvoiceHandler : IEventHandler<OrderPlaced>
+    {
+        public ValueTask HandleAsync(OrderPlaced @event, IExecutionContext context)
+        {
+            context.Mark("invoice");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class OrderPlacedWarehouseHandler : IEventHandler<OrderPlaced>
+    {
+        public ValueTask HandleAsync(OrderPlaced @event, IExecutionContext context)
+        {
+            context.Mark("warehouse");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Registered as a message, but nothing handles it.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class NobodyListens : IEvent;
+
+    /// <summary>Never registered at all — a different situation from <see cref="NobodyListens"/>.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class UnknownEvent : IEvent;
+
+    [DiscoveryKey(Key)]
+    public sealed class StockChanged : IEvent;
+
+    [DiscoveryKey(Key)]
+    public sealed class StockChangedDefaultHandler : IEventHandler<StockChanged>
+    {
+        public ValueTask HandleAsync(StockChanged @event, IExecutionContext context)
+        {
+            context.Mark("default");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [DiscoveryKey(Key)]
+    [Group(Reporting)]
+    public sealed class StockChangedReportingHandler : IEventHandler<StockChanged>
+    {
+        public ValueTask HandleAsync(StockChanged @event, IExecutionContext context)
+        {
+            context.Mark("reporting");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options.AddEventModule(events => events.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publish_reaches_every_registered_handler()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new OrderPlaced(), recorder.Events());
+
+        recorder.AssertStages("invoice", "warehouse");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publishing_a_registered_event_nobody_handles_is_a_no_op()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new NobodyListens(), recorder.Events());
+
+        recorder.AssertStages();
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publishing_a_registered_event_nobody_handles_throws_when_the_caller_asks_it_to()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings { ThrowIfNoHandlerFound = true };
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.PublishAsync(new NobodyListens(), settings));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publishing_an_unregistered_event_type_throws_even_without_asking()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+
+        // Unlike NobodyListens, this type is not in the registry at all — see the README.
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.PublishAsync(new UnknownEvent()));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_default_publish_skips_grouped_handlers()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new StockChanged(), recorder.Events());
+
+        recorder.AssertStages("default");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_grouped_publish_reaches_only_the_grouped_handlers()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+        var settings = recorder.Events();
+        settings.Filters.Groups = [Reporting];
+
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new StockChanged(), settings);
+
+        recorder.AssertStages("reporting");
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Groups/GroupFilteringTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Groups/GroupFilteringTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Groups;
+
+/// <summary>
+/// Group filtering is exclusive in both directions: a default dispatch sees only
+/// ungrouped participants, and a filtered dispatch sees only participants carrying one of
+/// the requested groups.
+/// </summary>
+public sealed class GroupFilteringTests
+{
+    private const string Key = "contract.groups";
+    private const string Reporting = "reporting";
+
+    /// <summary>The canonical filter form, interned and reused as the API intends.</summary>
+    private static readonly GroupSet ReportingSet = GroupSet.Of(Reporting);
+
+    [DiscoveryKey(Key)]
+    public sealed class Mixed : ICommand;
+
+    [DiscoveryKey(Key)]
+    public sealed class MixedHandler : ICommandHandler<Mixed>
+    {
+        public ValueTask HandleAsync(Mixed command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Only a filtered dispatch may see this pre-interceptor.</summary>
+    [DiscoveryKey(Key)]
+    [Group(Reporting)]
+    public sealed class MixedReportingPre : ICommandPreInterceptor<Mixed>
+    {
+        public ValueTask<Mixed> HandleAsync(Mixed command, IExecutionContext context)
+        {
+            context.Mark("pre:reporting");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    /// <summary>A command whose only handler is grouped.</summary>
+    [DiscoveryKey(Key)]
+    [Group(Reporting)]
+    public sealed class ReportingOnly : ICommand
+    {
+        /// <summary>Set by the handler — the only observation the settings-less overloads leave.</summary>
+        public bool Handled;
+    }
+
+    [DiscoveryKey(Key)]
+    [Group(Reporting)]
+    public sealed class ReportingOnlyHandler : ICommandHandler<ReportingOnly>
+    {
+        public ValueTask HandleAsync(ReportingOnly command, IExecutionContext context)
+        {
+            command.Handled = true;
+            context.Mark("handler:reporting");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_default_dispatch_skips_grouped_participants()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(new Mixed(), recorder.Commands());
+
+        recorder.AssertStages("handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_grouped_handler_is_unreachable_from_a_default_dispatch()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // A registered message whose handlers are all filtered out reports differently
+        // from a message type that was never registered at all — see the README.
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.SendAsync(new ReportingOnly()));
+
+        Assert.Contains(nameof(ReportingOnly), thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_grouped_dispatch_reaches_the_grouped_handler()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+        var settings = recorder.Commands();
+        settings.Filters.Groups = [Reporting];
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(new ReportingOnly(), settings);
+
+        recorder.AssertStages("handler:reporting");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_grouped_dispatch_excludes_the_ungrouped_handler()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var settings = new CommandMediationSettings { Filters = { Groups = new[] { Reporting } } };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.SendAsync(new Mixed(), settings));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_plain_group_sequence_and_a_canonical_GroupSet_select_the_same_participants()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var viaSequence = new PipelineRecorder();
+        var sequenceSettings = viaSequence.Commands();
+        sequenceSettings.Filters.Groups = new[] { Reporting };
+        await mediator.SendAsync(new ReportingOnly(), sequenceSettings);
+
+        var viaGroupSet = new PipelineRecorder();
+        var groupSetSettings = viaGroupSet.Commands();
+        groupSetSettings.Filters.Groups = ReportingSet;
+        await mediator.SendAsync(new ReportingOnly(), groupSetSettings);
+
+        Assert.Equal(viaSequence.Stages, viaGroupSet.Stages);
+        viaGroupSet.AssertStages("handler:reporting");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_GroupSet_overload_dispatches_the_grouped_pipeline()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var command = new ReportingOnly();
+
+        await mediator.SendAsync(command, ReportingSet);
+
+        Assert.True(command.Handled);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_empty_GroupSet_dispatches_the_default_pipeline()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.SendAsync(new ReportingOnly(), GroupSet.Empty));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_string_array_extension_selects_the_grouped_pipeline_too()
+    {
+        await using var provider = CreateProvider();
+        var command = new ReportingOnly();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command, new[] { Reporting });
+
+        Assert.True(command.Handled);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Harness/ContractDiagnostics.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Harness/ContractDiagnostics.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace Stella.Ergosfare.Contract.Test.Harness;
+
+/// <summary>
+/// Opt-in diagnostics for the modernization work: with
+/// <c>ERGOSFARE_CONTRACT_STACKDUMP=1</c> in the environment, every passing scenario
+/// contributes its nested pipeline trace — which stage ran when, and the managed frames
+/// underneath it — to one dump file, so a redesigned core can be diffed against the
+/// current one frame by frame.
+/// </summary>
+/// <remarks>
+/// Off by default and never asserted on: capturing stacks changes nothing the tests
+/// observe, and the suite's contract stays the stage ordering alone. The dump lands in
+/// <c>ERGOSFARE_CONTRACT_DUMP_PATH</c> when set, otherwise next to the test assembly as
+/// <c>contract-stackdump.txt</c>, and is flushed at process exit with its sections in a
+/// stable order — two dumps of an unchanged core diff empty.
+/// </remarks>
+public static class ContractDiagnostics
+{
+    private static readonly ConcurrentQueue<string> Sections = new();
+
+    /// <summary>Whether pipeline marks capture their managed frames.</summary>
+    public static readonly bool CaptureStacks =
+        Environment.GetEnvironmentVariable("ERGOSFARE_CONTRACT_STACKDUMP") is "1" or "true";
+
+    static ContractDiagnostics()
+    {
+        if (CaptureStacks)
+        {
+            AppDomain.CurrentDomain.ProcessExit += static (_, _) => Flush();
+        }
+    }
+
+    /// <summary>Contributes a scenario's trace to the dump. No-op unless capture is on.</summary>
+    public static void Publish(PipelineRecorder recorder, IReadOnlyList<string> expected)
+    {
+        if (!CaptureStacks)
+        {
+            return;
+        }
+
+        var scenario = recorder.Label is null ? string.Empty : $"{recorder.Label} — ";
+        Sections.Enqueue(recorder.Dump($"{scenario}stages: [{string.Join(", ", expected)}]"));
+    }
+
+    private static void Flush()
+    {
+        if (Sections.IsEmpty)
+        {
+            return;
+        }
+
+        var path = Environment.GetEnvironmentVariable("ERGOSFARE_CONTRACT_DUMP_PATH")
+                   ?? Path.Combine(AppContext.BaseDirectory, "contract-stackdump.txt");
+
+        var sections = new List<string>();
+
+        while (Sections.TryDequeue(out var section))
+        {
+            sections.Add(section);
+        }
+
+        // Scenarios finish in whatever order xunit's parallelism gives them, so the queue
+        // order changes from run to run. The dump is meant to be diffed against a stored
+        // baseline, and only a stable order makes that diff mean anything.
+        sections.Sort(StringComparer.Ordinal);
+
+        var builder = new StringBuilder();
+
+        foreach (var section in sections)
+        {
+            builder.AppendLine(section);
+        }
+
+        File.WriteAllText(path, builder.ToString());
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Harness/PipelineRecorder.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Harness/PipelineRecorder.cs
@@ -1,0 +1,213 @@
+using System.Diagnostics;
+using System.Text;
+using Stella.Ergosfare.Core.Abstractions;
+
+namespace Stella.Ergosfare.Contract.Test.Harness;
+
+/// <summary>
+/// The suite's single observation instrument: every pipeline participant marks its own
+/// entry through it, so a scenario's expectation is one ordered list of stage names.
+/// </summary>
+/// <remarks>
+/// The recorder travels on the mediation settings' <c>Items</c> dictionary — the public
+/// way to hand data to a dispatch — and is read back off the caller's own settings object
+/// when the dispatch returns. Nothing here reaches below the public surface.
+/// <para>
+/// When <see cref="ContractDiagnostics.CaptureStacks"/> is on, each mark also captures the
+/// managed frames between the mediator entry point and the marking stage, and
+/// <see cref="Dump"/> renders them as a nested per-stage trace. That capture is diagnostic
+/// only: no test asserts on it, and it is off unless the environment asks for it, so
+/// stage ordering stays the only pinned observation.
+/// </para>
+/// </remarks>
+public sealed class PipelineRecorder
+{
+    /// <summary>The mediation-settings item key the recorder travels under.</summary>
+    public const string ItemsKey = "ergosfare.contract.recorder";
+
+    /// <summary>
+    /// Names the scenario in the dump. Shared scenario code runs under more than one
+    /// registration axis, and the captured frames alone cannot tell them apart.
+    /// </summary>
+    public string? Label { get; init; }
+
+    private static readonly PipelineRecorder Silent = new();
+
+    private readonly List<StageMark> _marks = [];
+    private readonly Lock _gate = new();
+
+    /// <summary>The stage names in the order they ran — what scenarios assert on.</summary>
+    public IReadOnlyList<string> Stages
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _marks.ConvertAll(static m => m.Stage);
+            }
+        }
+    }
+
+    /// <summary>The details recorded alongside a stage, in order.</summary>
+    public IReadOnlyList<string?> Details
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _marks.ConvertAll(static m => m.Detail);
+            }
+        }
+    }
+
+    /// <summary>The detail recorded by the first mark of the named stage, or <c>null</c>.</summary>
+    public string? DetailOf(string stage)
+    {
+        lock (_gate)
+        {
+            return _marks.Find(m => m.Stage == stage).Detail;
+        }
+    }
+
+    /// <summary>The position of the named stage in the run, or <c>-1</c> when it never ran.</summary>
+    public int IndexOf(string stage)
+    {
+        lock (_gate)
+        {
+            return _marks.FindIndex(m => m.Stage == stage);
+        }
+    }
+
+    /// <summary>Records that <paramref name="stage"/> ran, optionally with what it saw.</summary>
+    public void Mark(string stage, string? detail = null)
+    {
+        var frames = ContractDiagnostics.CaptureStacks ? CaptureFrames() : null;
+
+        lock (_gate)
+        {
+            _marks.Add(new StageMark(stage, detail, frames));
+        }
+    }
+
+    /// <summary>
+    /// The recorder carried by the dispatch, or a shared silent one when the caller passed
+    /// no settings — so a participant can mark unconditionally.
+    /// </summary>
+    public static PipelineRecorder From(IExecutionContext context)
+        => context.TryGet<PipelineRecorder>(ItemsKey, out var recorder) && recorder is not null
+            ? recorder
+            : Silent;
+
+    /// <summary>A nested, human-readable rendering of everything the dispatch did.</summary>
+    public string Dump(string? title = null)
+    {
+        var builder = new StringBuilder();
+
+        if (title is not null)
+        {
+            builder.AppendLine(title);
+        }
+
+        lock (_gate)
+        {
+            for (var i = 0; i < _marks.Count; i++)
+            {
+                var mark = _marks[i];
+                builder.Append("  ").Append(i + 1).Append(". ").Append(mark.Stage);
+
+                if (mark.Detail is not null)
+                {
+                    builder.Append("  <- ").Append(mark.Detail);
+                }
+
+                builder.AppendLine();
+
+                if (mark.Frames is null)
+                {
+                    continue;
+                }
+
+                for (var depth = 0; depth < mark.Frames.Length; depth++)
+                {
+                    builder.Append("     ").Append(new string(' ', depth * 2))
+                           .Append("| ").AppendLine(mark.Frames[depth]);
+                }
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Asserts the recorded stages, failing with the full nested dump attached — the
+    /// ordering failures this suite exists to catch are unreadable without it.
+    /// </summary>
+    public void AssertStages(params string[] expected)
+    {
+        var actual = Stages;
+
+        if (actual.Count == expected.Length)
+        {
+            var equal = true;
+
+            for (var i = 0; i < expected.Length; i++)
+            {
+                if (!string.Equals(actual[i], expected[i], StringComparison.Ordinal))
+                {
+                    equal = false;
+                    break;
+                }
+            }
+
+            if (equal)
+            {
+                ContractDiagnostics.Publish(this, expected);
+                return;
+            }
+        }
+
+        Assert.Fail(
+            $"""
+             Pipeline stages did not match.
+               expected: [{string.Join(", ", expected)}]
+               actual:   [{string.Join(", ", actual)}]
+             {Dump("dispatch trace:")}
+             """);
+    }
+
+    private static string[] CaptureFrames()
+    {
+        var trace = new StackTrace(skipFrames: 2, fNeedFileInfo: false);
+        var frames = new List<string>();
+
+        foreach (var frame in trace.GetFrames())
+        {
+            var method = frame.GetMethod();
+
+            if (method?.DeclaringType is null)
+            {
+                continue;
+            }
+
+            var declaring = method.DeclaringType.FullName ?? method.DeclaringType.Name;
+
+            // The dispatch-relevant window: everything from the mediator facade down to
+            // the marking stage. Test-runner and async-machinery frames add noise only.
+            if (declaring.StartsWith("Xunit", StringComparison.Ordinal)
+                || declaring.StartsWith("System.Reflection", StringComparison.Ordinal)
+                || declaring.StartsWith("System.RuntimeMethodHandle", StringComparison.Ordinal)
+                || declaring.StartsWith("System.Runtime.CompilerServices", StringComparison.Ordinal)
+                || declaring.StartsWith("System.Threading", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            frames.Add($"{declaring}.{method.Name}");
+        }
+
+        frames.Reverse();
+        return frames.ToArray();
+    }
+
+    private readonly record struct StageMark(string Stage, string? Detail, string[]? Frames);
+}

--- a/test/Stella.Ergosfare.Contract.Test/Harness/Recording.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Harness/Recording.cs
@@ -1,0 +1,30 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Contract.Test.Harness;
+
+/// <summary>
+/// Hands a <see cref="PipelineRecorder"/> to a dispatch through the mediation settings'
+/// <c>Items</c> dictionary and reads the stage marks back off the caller's own object —
+/// the whole observation channel, built from public surface only.
+/// </summary>
+public static class Recording
+{
+    /// <summary>Settings that carry <paramref name="recorder"/> into a command dispatch.</summary>
+    public static CommandMediationSettings Commands(this PipelineRecorder recorder)
+        => new() { Items = { [PipelineRecorder.ItemsKey] = recorder } };
+
+    /// <summary>Settings that carry <paramref name="recorder"/> into a query dispatch.</summary>
+    public static QueryMediationSettings Queries(this PipelineRecorder recorder)
+        => new() { Items = { [PipelineRecorder.ItemsKey] = recorder } };
+
+    /// <summary>Settings that carry <paramref name="recorder"/> into a publish.</summary>
+    public static EventMediationSettings Events(this PipelineRecorder recorder)
+        => new() { Items = { [PipelineRecorder.ItemsKey] = recorder } };
+
+    /// <summary>Shorthand for a pipeline participant marking its own stage.</summary>
+    public static void Mark(this IExecutionContext context, string stage, string? detail = null)
+        => PipelineRecorder.From(context).Mark(stage, detail);
+}

--- a/test/Stella.Ergosfare.Contract.Test/Lifetime/HandlerLifetimeTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Lifetime/HandlerLifetimeTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Lifetime;
+
+/// <summary>
+/// How many times a pipeline participant is constructed, and who decides. Instance counts
+/// are contract because lifetime says so — the scenarios below never assert on pooling or
+/// caching, only on what a user's own DI registration promises.
+/// </summary>
+public sealed class HandlerLifetimeTests
+{
+    private const string Key = "contract.lifetime";
+
+    // --- default lifetime -----------------------------------------------------
+
+    [DiscoveryKey(Key)]
+    public sealed class Counted : ICommand;
+
+    [DiscoveryKey(Key)]
+    public sealed class CountedHandler : ICommandHandler<Counted>
+    {
+        /// <summary>Constructions since the last reset; the scenario resets before use.</summary>
+        public static int Constructions;
+
+        public CountedHandler() => Interlocked.Increment(ref Constructions);
+
+        public ValueTask HandleAsync(Counted command, IExecutionContext context) => ValueTask.CompletedTask;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class CountedPre : ICommandPreInterceptor<Counted>
+    {
+        /// <inheritdoc cref="CountedHandler.Constructions"/>
+        public static int Constructions;
+
+        public CountedPre() => Interlocked.Increment(ref Constructions);
+
+        public ValueTask<Counted> HandleAsync(Counted command, IExecutionContext context)
+            => ValueTask.FromResult(command);
+    }
+
+    // --- forced memoization ---------------------------------------------------
+
+    [DiscoveryKey(Key)]
+    public sealed class Memoized : ICommand;
+
+    [DiscoveryKey(Key)]
+    public sealed class MemoizedHandler : ICommandHandler<Memoized>
+    {
+        /// <inheritdoc cref="CountedHandler.Constructions"/>
+        public static int Constructions;
+
+        public MemoizedHandler() => Interlocked.Increment(ref Constructions);
+
+        public ValueTask HandleAsync(Memoized command, IExecutionContext context) => ValueTask.CompletedTask;
+    }
+
+    // --- user-owned registration ---------------------------------------------
+
+    [DiscoveryKey(Key)]
+    public sealed class Owned : ICommand
+    {
+        /// <summary>The tag of the handler instance that ran.</summary>
+        public string? Tag;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class OwnedHandler : ICommandHandler<Owned>
+    {
+        /// <summary>Distinguishes the user's instance from a container-built one.</summary>
+        public string Tag { get; init; } = "module-built";
+
+        public ValueTask HandleAsync(Owned command, IExecutionContext context)
+        {
+            command.Tag = Tag;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Handlers_are_constructed_once_per_dispatch_by_default()
+    {
+        CountedHandler.Constructions = 0;
+
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        await mediator.SendAsync(new Counted());
+        await mediator.SendAsync(new Counted());
+        await mediator.SendAsync(new Counted());
+
+        Assert.Equal(3, CountedHandler.Constructions);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Interceptors_are_constructed_once_per_dispatch_by_default()
+    {
+        CountedPre.Constructions = 0;
+
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        await mediator.SendAsync(new Counted());
+        await mediator.SendAsync(new Counted());
+
+        Assert.Equal(2, CountedPre.Constructions);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task ForceMemoizedHandlers_reuses_one_instance_across_dispatches()
+    {
+        MemoizedHandler.Constructions = 0;
+
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(options => options
+                .ForceMemoizedHandlers()
+                .AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        await mediator.SendAsync(new Memoized());
+        await mediator.SendAsync(new Memoized());
+        await mediator.SendAsync(new Memoized());
+
+        Assert.Equal(1, MemoizedHandler.Constructions);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_users_own_registration_of_a_handler_type_wins_over_the_modules()
+    {
+        var chosen = new OwnedHandler { Tag = "user-instance" };
+
+        await using var provider = new ServiceCollection()
+            .AddSingleton(chosen)
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+        var first = new Owned();
+        var second = new Owned();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        await mediator.SendAsync(first);
+        await mediator.SendAsync(second);
+
+        Assert.Equal("user-instance", first.Tag);
+        Assert.Equal("user-instance", second.Tag);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Lifetime/ScopeResolutionTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Lifetime/ScopeResolutionTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Lifetime;
+
+/// <summary>
+/// Which DI scope a handler's dependencies come from: the scope that resolved the
+/// mediator, not the container root.
+/// </summary>
+public sealed class ScopeResolutionTests
+{
+    private const string Key = "contract.scope";
+
+    /// <summary>Registered scoped, so its identity names the scope it came from.</summary>
+    public sealed class ScopedDependency
+    {
+        /// <summary>Unique per constructed instance.</summary>
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class NeedsScope : ICommand
+    {
+        /// <summary>The dependency identity the handler was given.</summary>
+        public Guid SeenId;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class NeedsScopeHandler(ScopedDependency dependency) : ICommandHandler<NeedsScope>
+    {
+        public ValueTask HandleAsync(NeedsScope command, IExecutionContext context)
+        {
+            command.SeenId = dependency.Id;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddScoped<ScopedDependency>()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    private static async Task<Guid> DispatchIn(IServiceScope scope)
+    {
+        var command = new NeedsScope();
+        await scope.ServiceProvider.GetRequiredService<ICommandMediator>().SendAsync(command);
+        return command.SeenId;
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Two_dispatches_in_one_scope_see_the_same_scoped_dependency()
+    {
+        await using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var first = await DispatchIn(scope);
+        var second = await DispatchIn(scope);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Dispatches_in_different_scopes_see_different_scoped_dependencies()
+    {
+        await using var provider = CreateProvider();
+
+        Guid first;
+        Guid second;
+
+        using (var scope = provider.CreateScope())
+        {
+            first = await DispatchIn(scope);
+        }
+
+        using (var scope = provider.CreateScope())
+        {
+            second = await DispatchIn(scope);
+        }
+
+        Assert.NotEqual(first, second);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/FallbackPipelineTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/FallbackPipelineTypes.cs
@@ -1,0 +1,182 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+// The pipeline scenarios' types for the runtime-registration axis — the fallback the
+// generated axis degrades to. Every type here is excluded from discovery, so the source
+// generator models none of them: no pre-computed descriptors, no dispatch roots, no
+// compile-time plans. The scenarios therefore exercise the reflective registration path
+// end to end, and any behavioral drift between it and the generated path shows up as one
+// axis failing while the other passes.
+namespace Stella.Ergosfare.Contract.Test.Pipeline.Fallback;
+
+// --- void command, full pipeline -------------------------------------------
+
+/// <inheritdoc cref="Generated.PipelineCommand"/>
+[ExcludeFromDiscovery]
+public sealed class PipelineCommand : IPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineCommandHandler : PayloadHandlerBase<PipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineCommandPre : PayloadPreBase<PipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineCommandPost : PayloadPostBase<PipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineCommandException : PayloadExceptionBase<PipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineCommandFinal : PayloadFinalBase<PipelineCommand>;
+
+// --- void command, handler only --------------------------------------------
+
+/// <inheritdoc cref="Generated.BarePipelineCommand"/>
+[ExcludeFromDiscovery]
+public sealed class BarePipelineCommand : IPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class BarePipelineCommandHandler : PayloadHandlerBase<BarePipelineCommand>;
+
+// --- string-result command, full pipeline ----------------------------------
+
+/// <inheritdoc cref="Generated.PipelineResultCommand"/>
+[ExcludeFromDiscovery]
+public sealed class PipelineResultCommand : IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineResultCommandHandler : PayloadResultHandlerBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineResultCommandPre : PayloadResultPreBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineResultCommandPost : PayloadResultPostBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineResultCommandException : PayloadResultExceptionBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineResultCommandFinal : PayloadResultFinalBase<PipelineResultCommand>;
+
+// --- string-result command, handler only -----------------------------------
+
+/// <inheritdoc cref="Generated.BarePipelineResultCommand"/>
+[ExcludeFromDiscovery]
+public sealed class BarePipelineResultCommand : IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class BarePipelineResultCommandHandler : PayloadResultHandlerBase<BarePipelineResultCommand>;
+
+// --- value-typed query, full pipeline --------------------------------------
+
+/// <inheritdoc cref="Generated.PipelineValueQuery"/>
+[ExcludeFromDiscovery]
+public sealed class PipelineValueQuery : IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineValueQueryHandler : PayloadValueHandlerBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineValueQueryPre : PayloadValuePreBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineValueQueryPost : PayloadValuePostBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineValueQueryException : PayloadValueExceptionBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class PipelineValueQueryFinal : PayloadValueFinalBase<PipelineValueQuery>;
+
+// --- value-typed query, handler only ---------------------------------------
+
+/// <inheritdoc cref="Generated.BarePipelineValueQuery"/>
+[ExcludeFromDiscovery]
+public sealed class BarePipelineValueQuery : IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class BarePipelineValueQueryHandler : PayloadValueHandlerBase<BarePipelineValueQuery>;
+
+// --- stage ordering ---------------------------------------------------------
+
+/// <inheritdoc cref="Generated.OrderedCommand"/>
+[ExcludeFromDiscovery]
+public sealed class OrderedCommand : ICommand;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class OrderedCommandHandler : OrderedHandlerBase<OrderedCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(7)]
+public sealed class OrderedHeavyPre() : OrderedPreBase<OrderedCommand>("pre:heavy");
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(2)]
+public sealed class OrderedLightPre() : OrderedPreBase<OrderedCommand>("pre:light");
+
+/// <summary>Shares <see cref="OrderedTieOmegaPre"/>'s weight; its type name sorts first.</summary>
+[ExcludeFromDiscovery]
+[Weight(5)]
+public sealed class OrderedTieAlphaPre() : OrderedPreBase<OrderedCommand>("pre:tie-alpha");
+
+/// <summary>Shares <see cref="OrderedTieAlphaPre"/>'s weight; its type name sorts last.</summary>
+[ExcludeFromDiscovery]
+[Weight(5)]
+public sealed class OrderedTieOmegaPre() : OrderedPreBase<OrderedCommand>("pre:tie-omega");
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class OrderedHighPost() : OrderedPostBase<OrderedCommand>("post:high");
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(3)]
+public sealed class OrderedLowPost() : OrderedPostBase<OrderedCommand>("post:low");

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedPipelineTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedPipelineTypes.cs
@@ -1,0 +1,155 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Contract.Test.Pipeline.Generated;
+
+// The pipeline scenarios' types for the source-generated registration axis. They are the
+// assembly's ONLY default-discovery constructs — every other area's types carry a
+// [DiscoveryKey] or [ExcludeFromDiscovery] — so the pattern-less RegisterGenerated()
+// selects exactly this set.
+//
+// The default key is not a convenience here, it is the point: the generator disqualifies
+// keyed, grouped and nested types from its compile-time plans, so a keyed variant of this
+// axis would register through generated descriptors and still dispatch on the reflective
+// executors, testing nothing the fallback axis does not already cover. Keep these types
+// top-level, unkeyed and ungrouped, or the axis silently stops exercising the plan lanes.
+
+// --- void command, full pipeline -------------------------------------------
+
+/// <summary>Void command whose pipeline carries every interceptor stage.</summary>
+public sealed class PipelineCommand : IPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class PipelineCommandHandler : PayloadHandlerBase<PipelineCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineCommandPre : PayloadPreBase<PipelineCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineCommandPost : PayloadPostBase<PipelineCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineCommandException : PayloadExceptionBase<PipelineCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineCommandFinal : PayloadFinalBase<PipelineCommand>;
+
+// --- void command, handler only --------------------------------------------
+
+/// <summary>Void command with nothing but a handler, for unhandled-exception semantics.</summary>
+public sealed class BarePipelineCommand : IPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class BarePipelineCommandHandler : PayloadHandlerBase<BarePipelineCommand>;
+
+// --- string-result command, full pipeline ----------------------------------
+
+/// <summary>String-result command whose pipeline carries every interceptor stage.</summary>
+public sealed class PipelineResultCommand : IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class PipelineResultCommandHandler : PayloadResultHandlerBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineResultCommandPre : PayloadResultPreBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineResultCommandPost : PayloadResultPostBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineResultCommandException : PayloadResultExceptionBase<PipelineResultCommand>;
+
+/// <inheritdoc />
+public sealed class PipelineResultCommandFinal : PayloadResultFinalBase<PipelineResultCommand>;
+
+// --- string-result command, handler only -----------------------------------
+
+/// <summary>String-result command with nothing but a handler.</summary>
+public sealed class BarePipelineResultCommand : IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class BarePipelineResultCommandHandler : PayloadResultHandlerBase<BarePipelineResultCommand>;
+
+// --- value-typed query, full pipeline --------------------------------------
+
+/// <summary>Value-typed query whose pipeline carries every interceptor stage.</summary>
+public sealed class PipelineValueQuery : IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class PipelineValueQueryHandler : PayloadValueHandlerBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+public sealed class PipelineValueQueryPre : PayloadValuePreBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+public sealed class PipelineValueQueryPost : PayloadValuePostBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+public sealed class PipelineValueQueryException : PayloadValueExceptionBase<PipelineValueQuery>;
+
+/// <inheritdoc />
+public sealed class PipelineValueQueryFinal : PayloadValueFinalBase<PipelineValueQuery>;
+
+// --- value-typed query, handler only ---------------------------------------
+
+/// <summary>Value-typed query with nothing but a handler.</summary>
+public sealed class BarePipelineValueQuery : IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class BarePipelineValueQueryHandler : PayloadValueHandlerBase<BarePipelineValueQuery>;
+
+// --- stage ordering ---------------------------------------------------------
+
+/// <summary>Void command whose pipeline exists only to expose stage ordering.</summary>
+public sealed class OrderedCommand : ICommand;
+
+/// <inheritdoc />
+public sealed class OrderedCommandHandler : OrderedHandlerBase<OrderedCommand>;
+
+/// <inheritdoc />
+[Weight(7)]
+public sealed class OrderedHeavyPre() : OrderedPreBase<OrderedCommand>("pre:heavy");
+
+/// <inheritdoc />
+[Weight(2)]
+public sealed class OrderedLightPre() : OrderedPreBase<OrderedCommand>("pre:light");
+
+/// <summary>Shares <see cref="OrderedTieOmegaPre"/>'s weight; its type name sorts first.</summary>
+[Weight(5)]
+public sealed class OrderedTieAlphaPre() : OrderedPreBase<OrderedCommand>("pre:tie-alpha");
+
+/// <summary>Shares <see cref="OrderedTieAlphaPre"/>'s weight; its type name sorts last.</summary>
+[Weight(5)]
+public sealed class OrderedTieOmegaPre() : OrderedPreBase<OrderedCommand>("pre:tie-omega");
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class OrderedHighPost() : OrderedPostBase<OrderedCommand>("post:high");
+
+/// <inheritdoc />
+[Weight(3)]
+public sealed class OrderedLowPost() : OrderedPostBase<OrderedCommand>("post:low");

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedRegistrationPipelineTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedRegistrationPipelineTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Pipeline.Generated;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Pipeline;
+
+/// <summary>
+/// The pipeline contract under source-generated registration — the primary axis. The
+/// generator discovers these types at compile time and <c>RegisterGenerated()</c> installs
+/// pre-computed descriptors, dispatch roots and the compile-time pipeline plans.
+/// </summary>
+/// <remarks>
+/// The pattern-less overload is deliberate and is reserved for this axis: plan eligibility
+/// requires default-discovery types, so a keyed selection would quietly fall back to the
+/// reflective executors. It is safe because every other construct in the assembly is keyed
+/// or excluded from discovery.
+/// </remarks>
+public sealed class GeneratedRegistrationPipelineTests : PipelineSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated())
+                .AddQueryModule(queries => queries.RegisterGenerated()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IPayloadCommand NewCommand(string payload) => new PipelineCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadCommand NewBareCommand(string payload) => new BarePipelineCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadResultCommand NewResultCommand(string payload)
+        => new PipelineResultCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadResultCommand NewBareResultCommand(string payload)
+        => new BarePipelineResultCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadValueQuery NewValueQuery(string payload)
+        => new PipelineValueQuery { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadValueQuery NewBareValueQuery(string payload)
+        => new BarePipelineValueQuery { Payload = payload };
+
+    /// <inheritdoc />
+    protected override ICommand NewOrderedCommand() => new OrderedCommand();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineContracts.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineContracts.cs
@@ -1,0 +1,388 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Contract.Test.Pipeline;
+
+/// <summary>
+/// The pipeline scenarios' shared vocabulary and behavior. Each registration axis closes
+/// these bases over its own concrete message types; the axes therefore run byte-identical
+/// participant code and any difference the scenarios see is a difference in registration,
+/// not in the handlers.
+/// </summary>
+/// <remarks>
+/// Everything in this file is excluded from discovery: these are shapes, not registrable
+/// constructs, and the generated axis must register only the concrete types it declares.
+/// Exclusion is not inherited (<c>Inherited = false</c>), so the closing types stay
+/// discoverable.
+/// </remarks>
+public static class PipelineVocabulary
+{
+    /// <summary>Payload marker that makes a handler throw.</summary>
+    public const string Throw = "throw";
+
+    /// <summary>Payload marker that makes a pre-interceptor abort.</summary>
+    public const string Abort = "abort";
+
+    /// <summary>Suffix a pre-interceptor appends when it rewrites the message.</summary>
+    public const string Rewritten = "+rewritten";
+
+    /// <summary>Suffix a post-interceptor appends when it rewrites a string result.</summary>
+    public const string Posted = "+posted";
+
+    /// <summary>What a value-typed post-interceptor adds to the handler's number.</summary>
+    public const int PostAddend = 100;
+
+    /// <summary>What a value-typed exception interceptor falls back to.</summary>
+    public const int ValueFallback = -1;
+
+    /// <summary>What a string exception interceptor falls back to.</summary>
+    public const string StringFallback = "fallback";
+
+    /// <summary>The number a value query's handler produces.</summary>
+    public const int HandlerValue = 7;
+
+    /// <summary>Renders a stage's result argument for the recorder.</summary>
+    public static string Describe(object? result) => result switch
+    {
+        null => "null",
+        string text => text,
+        ValueTask => nameof(ValueTask),
+        _ => result.ToString() ?? result.GetType().Name,
+    };
+
+    /// <summary>Renders a stage's exception argument for the recorder.</summary>
+    public static string Describe(Exception? exception)
+        => exception is null ? "none" : exception.GetType().Name;
+}
+
+/// <summary>The exception a scenario's handler throws, distinguishable from framework ones.</summary>
+public sealed class PipelineFailure(string message) : Exception(message);
+
+/// <summary>A void command carrying the payload that drives its scenario.</summary>
+[ExcludeFromDiscovery]
+public interface IPayloadCommand : ICommand
+{
+    /// <summary>Drives handler/interceptor behavior and records what each stage saw.</summary>
+    string Payload { get; set; }
+}
+
+/// <summary>A string-result command carrying the payload that drives its scenario.</summary>
+[ExcludeFromDiscovery]
+public interface IPayloadResultCommand : ICommand<string>
+{
+    /// <inheritdoc cref="IPayloadCommand.Payload"/>
+    string Payload { get; set; }
+}
+
+/// <summary>A value-typed query carrying the payload that drives its scenario.</summary>
+[ExcludeFromDiscovery]
+public interface IPayloadValueQuery : IQuery<int>
+{
+    /// <inheritdoc cref="IPayloadCommand.Payload"/>
+    string Payload { get; set; }
+}
+
+// ---------------------------------------------------------------------------
+// void command pipeline
+// ---------------------------------------------------------------------------
+
+/// <summary>Marks its stage, then throws when the payload asks it to.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadHandlerBase<TCommand> : ICommandHandler<TCommand>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler", command.Payload);
+
+        if (command.Payload.Contains(PipelineVocabulary.Throw, StringComparison.Ordinal))
+        {
+            throw new PipelineFailure("void handler failed");
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Aborts when asked, otherwise hands the handler a rewritten message.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadPreBase<TCommand> : ICommandPreInterceptor<TCommand>
+    where TCommand : class, IPayloadCommand, new()
+{
+    /// <inheritdoc />
+    public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("pre", command.Payload);
+
+        if (command.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort();
+        }
+
+        return ValueTask.FromResult(new TCommand { Payload = command.Payload + PipelineVocabulary.Rewritten });
+    }
+}
+
+/// <summary>Records the message and result a void post-interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadPostBase<TCommand> : ICommandPostInterceptor<TCommand>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object result, IExecutionContext context)
+    {
+        context.Mark("post", $"{command.Payload}|{PipelineVocabulary.Describe(result)}");
+        return ValueTask.FromResult(result);
+    }
+}
+
+/// <summary>Records everything a void exception interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadExceptionBase<TCommand> : ICommandExceptionInterceptor<TCommand>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object? result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception",
+            $"{command.Payload}|{PipelineVocabulary.Describe(result)}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.FromResult<object>(ValueTask.CompletedTask);
+    }
+}
+
+/// <summary>Records everything a void final interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadFinalBase<TCommand> : ICommandFinalInterceptor<TCommand>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, object? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final",
+            $"{command.Payload}|{PipelineVocabulary.Describe(result)}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// string-result command pipeline
+// ---------------------------------------------------------------------------
+
+/// <summary>Returns its received payload as the result, or throws when asked.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadResultHandlerBase<TCommand> : ICommandHandler<TCommand, string>
+    where TCommand : class, IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler", command.Payload);
+
+        if (command.Payload.Contains(PipelineVocabulary.Throw, StringComparison.Ordinal))
+        {
+            throw new PipelineFailure("result handler failed");
+        }
+
+        return ValueTask.FromResult(command.Payload);
+    }
+}
+
+/// <summary>Aborts when asked — with a result value, to pin whether the value survives.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadResultPreBase<TCommand> : ICommandPreInterceptor<TCommand>
+    where TCommand : class, IPayloadResultCommand, new()
+{
+    /// <summary>The value handed to <see cref="IExecutionContext.Abort"/> on the abort path.</summary>
+    public const string AbortValue = "aborted-with-value";
+
+    /// <inheritdoc />
+    public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("pre", command.Payload);
+
+        if (command.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort(AbortValue);
+        }
+
+        return ValueTask.FromResult(new TCommand { Payload = command.Payload + PipelineVocabulary.Rewritten });
+    }
+}
+
+/// <summary>Rewrites the handler's result on its way to the caller.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadResultPostBase<TCommand> : ICommandPostInterceptor<TCommand, string>
+    where TCommand : class, IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, string result, IExecutionContext context)
+    {
+        context.Mark("post", $"{command.Payload}|{result}");
+        return ValueTask.FromResult(result + PipelineVocabulary.Posted);
+    }
+}
+
+/// <summary>Substitutes a fallback result for the handler's exception.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadResultExceptionBase<TCommand> : ICommandExceptionInterceptor<TCommand, string>
+    where TCommand : class, IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string?> HandleAsync(TCommand command, string? result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception",
+            $"{command.Payload}|{PipelineVocabulary.Describe(result)}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.FromResult<string?>(PipelineVocabulary.StringFallback);
+    }
+}
+
+/// <summary>Records everything a string-result final interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadResultFinalBase<TCommand> : ICommandFinalInterceptor<TCommand, string>
+    where TCommand : class, IPayloadResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, string? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final",
+            $"{command.Payload}|{PipelineVocabulary.Describe(result)}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// value-typed query pipeline
+// ---------------------------------------------------------------------------
+
+/// <summary>Produces a number, or throws when asked.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadValueHandlerBase<TQuery> : IQueryHandler<TQuery, int>
+    where TQuery : class, IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, IExecutionContext context)
+    {
+        context.Mark("handler", query.Payload);
+
+        if (query.Payload.Contains(PipelineVocabulary.Throw, StringComparison.Ordinal))
+        {
+            throw new PipelineFailure("value handler failed");
+        }
+
+        return ValueTask.FromResult(PipelineVocabulary.HandlerValue);
+    }
+}
+
+/// <summary>Aborts when asked, otherwise hands the handler a rewritten query.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadValuePreBase<TQuery> : IQueryPreInterceptor<TQuery>
+    where TQuery : class, IPayloadValueQuery, new()
+{
+    /// <summary>The value handed to <see cref="IExecutionContext.Abort"/> on the abort path.</summary>
+    public const int AbortValue = 41;
+
+    /// <inheritdoc />
+    public ValueTask<TQuery> HandleAsync(TQuery query, IExecutionContext context)
+    {
+        context.Mark("pre", query.Payload);
+
+        if (query.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort(AbortValue);
+        }
+
+        return ValueTask.FromResult(new TQuery { Payload = query.Payload + PipelineVocabulary.Rewritten });
+    }
+}
+
+/// <summary>Adds to the handler's number on its way to the caller.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadValuePostBase<TQuery> : IQueryPostInterceptor<TQuery, int>
+    where TQuery : class, IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, int result, IExecutionContext context)
+    {
+        context.Mark("post", $"{query.Payload}|{result}");
+        return ValueTask.FromResult(result + PipelineVocabulary.PostAddend);
+    }
+}
+
+/// <summary>Substitutes a fallback number for the handler's exception.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadValueExceptionBase<TQuery> : IQueryExceptionInterceptor<TQuery, int>
+    where TQuery : class, IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, int result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception",
+            $"{query.Payload}|{result}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.FromResult(PipelineVocabulary.ValueFallback);
+    }
+}
+
+/// <summary>Records everything a value-typed final interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class PayloadValueFinalBase<TQuery> : IQueryFinalInterceptor<TQuery, int>
+    where TQuery : class, IPayloadValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TQuery query, int result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final", $"{query.Payload}|{result}|{PipelineVocabulary.Describe(exception)}");
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stage ordering
+// ---------------------------------------------------------------------------
+
+/// <summary>Marks the handler of the ordering scenario.</summary>
+[ExcludeFromDiscovery]
+public abstract class OrderedHandlerBase<TCommand> : ICommandHandler<TCommand>
+    where TCommand : class, ICommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler");
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>A pre-interceptor that only announces which slot it is.</summary>
+[ExcludeFromDiscovery]
+public abstract class OrderedPreBase<TCommand>(string slot) : ICommandPreInterceptor<TCommand>
+    where TCommand : class, ICommand
+{
+    /// <inheritdoc />
+    public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark(slot);
+        return ValueTask.FromResult(command);
+    }
+}
+
+/// <summary>A post-interceptor that only announces which slot it is.</summary>
+[ExcludeFromDiscovery]
+public abstract class OrderedPostBase<TCommand>(string slot) : ICommandPostInterceptor<TCommand>
+    where TCommand : class, ICommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object result, IExecutionContext context)
+    {
+        context.Mark(slot);
+        return ValueTask.FromResult(result);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineSemanticsContract.cs
@@ -1,0 +1,363 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Contract.Test.Pipeline;
+
+/// <summary>
+/// The pipeline semantics every registration axis must reproduce: what runs, in what
+/// order, and what each stage is handed. Both the source-generated axis and the runtime
+/// fallback axis inherit these scenarios verbatim, so a divergence between the two shows
+/// up as one subclass failing.
+/// </summary>
+public abstract class PipelineSemanticsContract
+{
+    /// <summary>A container with this axis' pipeline types registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The void command whose pipeline carries every interceptor stage.</summary>
+    protected abstract IPayloadCommand NewCommand(string payload);
+
+    /// <summary>The void command whose pipeline is a bare handler.</summary>
+    protected abstract IPayloadCommand NewBareCommand(string payload);
+
+    /// <summary>The string-result command whose pipeline carries every stage.</summary>
+    protected abstract IPayloadResultCommand NewResultCommand(string payload);
+
+    /// <summary>The string-result command whose pipeline is a bare handler.</summary>
+    protected abstract IPayloadResultCommand NewBareResultCommand(string payload);
+
+    /// <summary>The value-typed query whose pipeline carries every stage.</summary>
+    protected abstract IPayloadValueQuery NewValueQuery(string payload);
+
+    /// <summary>The value-typed query whose pipeline is a bare handler.</summary>
+    protected abstract IPayloadValueQuery NewBareValueQuery(string payload);
+
+    /// <summary>The command whose pipeline exists only to expose stage ordering.</summary>
+    protected abstract ICommand NewOrderedCommand();
+
+    /// <summary>
+    /// A recorder stamped with the running axis, so a diagnostic dump of these shared
+    /// scenarios says which registration path produced each trace.
+    /// </summary>
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    // -----------------------------------------------------------------------
+    // message and result rewriting
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_pre_interceptor_rewrite_is_the_message_the_handler_receives()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("ok"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "post", "final");
+        Assert.Equal("ok", recorder.DetailOf("pre"));
+        Assert.Equal("ok+rewritten", recorder.DetailOf("handler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_post_interceptor_rewrite_is_the_result_the_caller_receives()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("ok"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "post", "final");
+        Assert.Equal("ok+rewritten+posted", result);
+        Assert.Equal("ok+rewritten|ok+rewritten", recorder.DetailOf("post"));
+    }
+
+    // -----------------------------------------------------------------------
+    // stage ordering
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Interceptors_in_a_stage_run_by_descending_weight()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewOrderedCommand(), recorder.Commands());
+
+        recorder.AssertStages(
+            "pre:heavy", "pre:tie-alpha", "pre:tie-omega", "pre:light",
+            "handler",
+            "post:high", "post:low");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Interceptors_of_equal_weight_run_in_ordinal_type_name_order()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewOrderedCommand(), recorder.Commands());
+
+        Assert.True(
+            recorder.IndexOf("pre:tie-alpha") < recorder.IndexOf("pre:tie-omega"),
+            recorder.Dump("equal weights must break the tie on the handler type name:"));
+    }
+
+    // -----------------------------------------------------------------------
+    // exception semantics
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("throw"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "exception", "final");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("throw"), recorder.Commands());
+
+        Assert.Equal($"throw+rewritten|null|{nameof(PipelineFailure)}", recorder.DetailOf("exception"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_post_interceptor_does_not_run_when_the_handler_throws()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("throw"), recorder.Commands());
+
+        Assert.DoesNotContain("post", recorder.Stages);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var thrown = await Assert.ThrowsAsync<PipelineFailure>(
+            async () => await mediator.SendAsync(NewBareCommand("throw"), recorder.Commands()));
+
+        Assert.Equal("void handler failed", thrown.Message);
+        recorder.AssertStages("handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_result_handler_exception_yields_the_exception_interceptors_fallback_result()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("throw"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "exception", "final");
+        Assert.Equal(PipelineVocabulary.StringFallback, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_result_handler_exception_propagates_unwrapped_without_an_exception_interceptor()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<PipelineFailure>(
+            async () => await mediator.SendAsync(NewBareResultCommand("throw")));
+    }
+
+    // -----------------------------------------------------------------------
+    // final semantics
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_final_interceptor_runs_on_success_with_no_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("ok"), recorder.Commands());
+
+        Assert.Equal($"ok+rewritten|{nameof(ValueTask)}|none", recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_final_interceptor_runs_after_a_handled_exception_and_receives_it()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("throw"), recorder.Commands());
+
+        Assert.Equal($"throw+rewritten|{nameof(ValueTask)}|{nameof(PipelineFailure)}", recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_final_interceptor_receives_the_post_rewritten_result()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("ok"), recorder.Commands());
+
+        Assert.Equal("ok+rewritten|ok+rewritten+posted|none", recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_final_interceptor_runs_on_abort_with_no_result_and_no_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewCommand("abort"), recorder.Commands()));
+
+        Assert.Equal("abort|null|none", recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // abort semantics
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewCommand("abort"), recorder.Commands()));
+
+        recorder.AssertStages("pre", "final");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // The pre-interceptor calls Abort(AbortValue); the caller never sees that value.
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewResultCommand("abort"), recorder.Commands()));
+
+        recorder.AssertStages("pre", "final");
+        Assert.Equal("abort|null|none", recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // value-typed results through the same pipeline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_typed_query_flows_through_pre_handler_post_and_final()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<IQueryMediator>()
+            .QueryAsync(NewValueQuery("ok"), recorder.Queries());
+
+        recorder.AssertStages("pre", "handler", "post", "final");
+        Assert.Equal(PipelineVocabulary.HandlerValue + PipelineVocabulary.PostAddend, result);
+        Assert.Equal($"ok+rewritten|{PipelineVocabulary.HandlerValue}", recorder.DetailOf("post"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_typed_query_exception_yields_the_interceptors_fallback_value()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<IQueryMediator>()
+            .QueryAsync(NewValueQuery("throw"), recorder.Queries());
+
+        recorder.AssertStages("pre", "handler", "exception", "final");
+        Assert.Equal(PipelineVocabulary.ValueFallback, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_typed_exception_interceptor_receives_the_result_types_default()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<IQueryMediator>()
+            .QueryAsync(NewValueQuery("throw"), recorder.Queries());
+
+        Assert.Equal($"throw+rewritten|0|{nameof(PipelineFailure)}", recorder.DetailOf("exception"));
+        Assert.Equal($"throw+rewritten|{PipelineVocabulary.ValueFallback}|{nameof(PipelineFailure)}",
+            recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.QueryAsync(NewValueQuery("abort"), recorder.Queries()));
+
+        recorder.AssertStages("pre", "final");
+        Assert.Equal("abort|0|none", recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_typed_handler_exception_propagates_unwrapped_without_an_exception_interceptor()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        await Assert.ThrowsAsync<PipelineFailure>(
+            async () => await mediator.QueryAsync(NewBareValueQuery("throw")));
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/RuntimeRegistrationPipelineTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/RuntimeRegistrationPipelineTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Pipeline.Fallback;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Pipeline;
+
+/// <summary>
+/// The same pipeline contract under explicit runtime registration — the fallback the
+/// generated axis degrades to. These types are excluded from discovery, so no generated
+/// descriptor, dispatch root or compile-time plan exists for them and every stage is
+/// resolved reflectively.
+/// </summary>
+/// <remarks>
+/// The tie-break scenario registers <c>OrderedTieOmegaPre</c> before
+/// <c>OrderedTieAlphaPre</c> on purpose: if registration order decided equal weights, the
+/// inherited expectation would fail here and pass on the generated axis.
+/// </remarks>
+public sealed class RuntimeRegistrationPipelineTests : PipelineSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<PipelineCommandHandler>()
+                    .Register<PipelineCommandPre>()
+                    .Register<PipelineCommandPost>()
+                    .Register<PipelineCommandException>()
+                    .Register<PipelineCommandFinal>()
+                    .Register<BarePipelineCommandHandler>()
+                    .Register<PipelineResultCommandHandler>()
+                    .Register<PipelineResultCommandPre>()
+                    .Register<PipelineResultCommandPost>()
+                    .Register<PipelineResultCommandException>()
+                    .Register<PipelineResultCommandFinal>()
+                    .Register<BarePipelineResultCommandHandler>()
+                    .Register<OrderedCommandHandler>()
+                    .Register<OrderedTieOmegaPre>()
+                    .Register<OrderedTieAlphaPre>()
+                    .Register<OrderedLightPre>()
+                    .Register<OrderedHeavyPre>()
+                    .Register<OrderedLowPost>()
+                    .Register<OrderedHighPost>())
+                .AddQueryModule(queries => queries
+                    .Register<PipelineValueQueryHandler>()
+                    .Register<PipelineValueQueryPre>()
+                    .Register<PipelineValueQueryPost>()
+                    .Register<PipelineValueQueryException>()
+                    .Register<PipelineValueQueryFinal>()
+                    .Register<BarePipelineValueQueryHandler>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IPayloadCommand NewCommand(string payload) => new PipelineCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadCommand NewBareCommand(string payload) => new BarePipelineCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadResultCommand NewResultCommand(string payload)
+        => new PipelineResultCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadResultCommand NewBareResultCommand(string payload)
+        => new BarePipelineResultCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadValueQuery NewValueQuery(string payload)
+        => new PipelineValueQuery { Payload = payload };
+
+    /// <inheritdoc />
+    protected override IPayloadValueQuery NewBareValueQuery(string payload)
+        => new BarePipelineValueQuery { Payload = payload };
+
+    /// <inheritdoc />
+    protected override ICommand NewOrderedCommand() => new OrderedCommand();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Polymorphism;
+
+/// <summary>
+/// How the registry matches participants that were written against a supertype of the
+/// dispatched message.
+/// </summary>
+/// <remarks>
+/// Every supertype here is declared by this class. Registering an interceptor against a
+/// module marker (<c>ICommand</c>, <c>IEvent</c>) would attach it to every pipeline in the
+/// process — the registry is process-wide — and quietly break unrelated test classes.
+/// </remarks>
+public sealed class PolymorphicDispatchTests
+{
+    private const string Key = "contract.polymorphism";
+
+    // --- interceptor matched through an implemented interface -----------------
+
+    /// <summary>A supertype owned by this class, never a module marker.</summary>
+    [ExcludeFromDiscovery]
+    public interface IAudited : ICommand;
+
+    [DiscoveryKey(Key)]
+    public sealed class Withdraw : IAudited;
+
+    [DiscoveryKey(Key)]
+    public sealed class WithdrawHandler : ICommandHandler<Withdraw>
+    {
+        public ValueTask HandleAsync(Withdraw command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Registered against the interface, not the concrete command.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class AuditedPre : ICommandPreInterceptor<IAudited>
+    {
+        public ValueTask<IAudited> HandleAsync(IAudited command, IExecutionContext context)
+        {
+            context.Mark("pre:audited");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    // --- handler matched through a base class ---------------------------------
+
+    /// <summary>The base the handler is written against.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class LedgerEntry : ICommand
+    {
+        /// <summary>The runtime type the base-typed handler observed.</summary>
+        public string? SeenType;
+    }
+
+    /// <summary>Registered as a message in its own right.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class DepositEntry : LedgerEntry;
+
+    /// <summary>Never registered: only the base-typed handler knows about this shape.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class TransferEntry : LedgerEntry;
+
+    [DiscoveryKey(Key)]
+    public sealed class LedgerEntryHandler : ICommandHandler<LedgerEntry>
+    {
+        public ValueTask HandleAsync(LedgerEntry command, IExecutionContext context)
+        {
+            command.SeenType = command.GetType().Name;
+            context.Mark("handler:base");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // --- event handlers matched directly and through an interface -------------
+
+    /// <inheritdoc cref="IAudited"/>
+    [ExcludeFromDiscovery]
+    public interface IShipmentEvent : IEvent;
+
+    [DiscoveryKey(Key)]
+    public sealed class ShipmentDispatched : IShipmentEvent;
+
+    /// <summary>Direct handler; its type name sorts before the other direct one.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class ShipmentAuditHandler : IEventHandler<ShipmentDispatched>
+    {
+        public ValueTask HandleAsync(ShipmentDispatched @event, IExecutionContext context)
+        {
+            context.Mark("direct:audit");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Direct handler; its type name sorts after the other direct one.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class ShipmentNotifyHandler : IEventHandler<ShipmentDispatched>
+    {
+        public ValueTask HandleAsync(ShipmentDispatched @event, IExecutionContext context)
+        {
+            context.Mark("direct:notify");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Matched only through the interface the event implements.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class ShipmentInterfaceHandler : IEventHandler<IShipmentEvent>
+    {
+        public ValueTask HandleAsync(IShipmentEvent @event, IExecutionContext context)
+        {
+            context.Mark("indirect:interface");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated(Key))
+                .AddEventModule(events => events.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_interceptor_registered_against_an_implemented_interface_joins_the_pipeline()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(new Withdraw(), recorder.Commands());
+
+        recorder.AssertStages("pre:audited", "handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_base_typed_handler_serves_a_derived_message_that_is_not_registered_itself()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+        var command = new TransferEntry();
+
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command, recorder.Commands());
+
+        recorder.AssertStages("handler:base");
+        Assert.Equal(nameof(TransferEntry), command.SeenType);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Covariant command dispatch is resolution-time only: once the derived type has a
+        // descriptor of its own, the base-typed handler is an indirect handler there and
+        // single-handler mediation never considers it. See the README.
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.SendAsync(new DepositEntry()));
+
+        Assert.Contains(nameof(DepositEntry), thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publish_runs_direct_handlers_before_interface_matched_ones()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        await provider.GetRequiredService<IEventMediator>()
+            .PublishAsync(new ShipmentDispatched(), recorder.Events());
+
+        recorder.AssertStages("direct:audit", "direct:notify", "indirect:interface");
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -1,0 +1,241 @@
+# Stella.Ergosfare.Contract.Test
+
+An executable specification of Ergosfare's **currently observable** public behavior.
+
+This suite exists for one reason: the core is about to be redesigned. Internals may change
+freely; this suite — and only this suite — defines what "unchanged behavior" means. It is
+written as characterization tests, so **the current behavior is correct by definition**.
+Where a behavior looked wrong, it was still pinned as-is and written down under
+[Suspicious behaviors observed](#suspicious-behaviors-observed). Nothing in this project
+fixes or works around anything.
+
+```bash
+dotnet test test/Stella.Ergosfare.Contract.Test
+```
+
+## What it may touch
+
+Public types from the `Stella.Ergosfare.*` packages only: `AddErgosfare`, the module
+builders, `ICommandMediator` / `IQueryMediator` / `IEventMediator`, the mediation settings
+and `GroupSet`, `IExecutionContext`, `IMessageRegistry`, and the handler/interceptor
+contract interfaces. No `InternalsVisibleTo`, no `*.Internal` namespaces, no reflection
+into non-public members. A behavior that cannot be observed through the public surface is
+out of scope by design — if the suite could see internals, the modernization could not keep
+it green and the whole point would collapse.
+
+## Registration axes
+
+Source-generated registration is the primary axis: the generator is referenced as an
+analyzer, and containers are built with `RegisterGenerated(<discovery key>)`. Explicit
+`Register<T>()` is the fallback axis — the path the generated one degrades to.
+
+The pipeline scenarios in [`Pipeline/`](Pipeline) run under **both**, sharing their code
+through `PipelineSemanticsContract`:
+
+| Axis | Types | Registration | Executors actually reached |
+| --- | --- | --- | --- |
+| `GeneratedRegistrationPipelineTests` | `Pipeline/GeneratedPipelineTypes.cs` — top-level, unkeyed, ungrouped | `RegisterGenerated()` | `StagedVoidPipelineExecutor`, `StagedResultPipelineExecutor`, `GeneratedVoidPipelineExecutor` + the emitted `StagedPlanN` classes |
+| `RuntimeRegistrationPipelineTests` | `Pipeline/FallbackPipelineTypes.cs` — `[ExcludeFromDiscovery]` | `Register<T>()` | `VoidPipelineExecutor`, `ResultPipelineExecutor` + `SingleAsyncHandlerMediationStrategy` |
+
+Both halves of that table are load-bearing, and both are easy to break by accident:
+
+- **The generated axis must stay top-level, unkeyed and ungrouped.** The generator
+  disqualifies keyed, grouped and nested types from its compile-time plans
+  (`TryGetSolePlannableHandler` requires `DiscoveryKeys.IsEmpty`; staged-plan participants
+  additionally must not be nested). Adding a `[DiscoveryKey]` here still registers through
+  generated descriptors — and silently dispatches on the reflective executors, testing
+  nothing the fallback axis does not already cover. The pattern-less `RegisterGenerated()`
+  is therefore **reserved for this axis**.
+- **The fallback axis must stay `[ExcludeFromDiscovery]`.** The generator's descriptor
+  catalog is populated by a module initializer for *every* type it models, so a type the
+  generator has seen gets pre-computed descriptors even when registered with
+  `Register<T>()`. Excluding them is the only way to make the reflective path run.
+
+Every other area registers by its own discovery key (`contract.dispatch`,
+`contract.lifetime`, `contract.scope`, `contract.groups`, `contract.polymorphism`,
+`contract.events`, `contract.mutation`, `contract.context`, `contract.stream`), which is
+also what keeps the pattern-less call above selecting only the pipeline axis. Types that
+must never be auto-registered — never-registered messages, late-registered interceptors —
+carry `[ExcludeFromDiscovery]`.
+
+## Rules for anyone adding tests here
+
+**The `MessageRegistry` is process-wide.** It is a singleton shared by every container in
+the test process, and it never forgets. Everything below follows from that.
+
+1. **Give every test class its own message, handler and interceptor types.** Never share a
+   message type across classes. Cross-class isolation is type isolation; there is nothing
+   else.
+2. **Give your area its own discovery key, and never call the pattern-less
+   `RegisterGenerated()`.** That overload registers every default-discovery construct in
+   the assembly, and it belongs to `GeneratedRegistrationPipelineTests` alone (see
+   [Registration axes](#registration-axes)). An unkeyed message anywhere else joins that
+   axis' containers and breaks its plan expectations.
+3. **Never assert on registry contents or counts, and never assume an empty registry.** By
+   the time your test runs, other classes have registered their types into the same
+   registry.
+4. **Do not register interceptors against a module marker** (`ICommand`, `IQuery`,
+   `IEvent`). Such an interceptor attaches to every pipeline in the process, permanently,
+   and breaks unrelated classes — including ones whose containers were built before it
+   appeared and therefore cannot resolve it. Declare your own supertype instead, as
+   `PolymorphicDispatchTests` does. If a scenario ever genuinely needs a marker-wide
+   registration, it belongs in its own collection with `DisableParallelization = true`.
+5. **Mutating the registry after a container is live goes in
+   `RegistryMutationCollection`** (`DisableParallelization = true`). The version bump
+   invalidates every container's cached pipeline.
+6. **Do not pin internals.** Instance identity is contract only where lifetime says so
+   (transient = new per dispatch, memoized = reused). No assertions on pooling, caching,
+   plan or strategy selection, or timing.
+7. **No sleeps.** Use `TaskCompletionSource` if async coordination is ever needed. Every
+   scenario here completes synchronously today.
+8. **Hand-written stubs, no Moq.** The repository is phasing mocks out.
+
+## How a scenario observes a dispatch
+
+`PipelineRecorder` travels into a dispatch on the mediation settings' `Items` dictionary —
+the public way to hand data to a pipeline — and every participant marks its own stage
+through it. An expectation is therefore one ordered list of stage names, and a failure
+prints the whole trace.
+
+## Diagnostic stack dump
+
+Ordering alone does not say *which* internal lane ran. With capture switched on, every
+mark also records the managed frames between the mediator entry point and the stage, and
+the traces are written to one file at process exit:
+
+```bash
+ERGOSFARE_CONTRACT_STACKDUMP=1 ERGOSFARE_CONTRACT_DUMP_PATH=./contract-stackdump.txt dotnet test test/Stella.Ergosfare.Contract.Test -f net9.0
+```
+
+Each section is labelled with the scenario and the axis, so a redesigned core can be
+diffed against the current one frame by frame. The same scenario under the two axes is
+what the [Registration axes](#registration-axes) table asserts in prose — the compiled
+plan on one side, the strategy-and-invoker stack on the other (both excerpts are the
+`pre` stage of `A_post_interceptor_rewrite_is_the_result_the_caller_receives`, trimmed of
+their test-side frames):
+
+```
+GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | ...
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | ...
+                   | ...IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | ...
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | ...
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | ...SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | ...
+                   | ...PreInterceptorInvocationStrategy`1.Invoke
+                     | ...
+                       | ...IAsyncPreInterceptor<TCommand>.HandleAsync
+```
+
+Capture is **off by default and never asserted on**. It changes nothing the tests observe;
+the pinned contract remains the stage ordering alone.
+
+Hardware counters (cache misses, branch mispredictions, cycles) are deliberately *not*
+here: measurement is neither deterministic nor a behavioral contract, and rules 6 and 7
+above rule it out. That work lives in `test/Stella.Ergosfare.Benchmarking` as
+`CachePressureBenchmark`, whose baseline was captured alongside this one.
+
+## Lane-map baseline
+
+[`baselines/lane-map.txt`](baselines/lane-map.txt) is that dump, captured and committed
+before the core modernization started. Sections are written in a stable order, so two
+dumps of an unchanged core are byte-identical — as are the two TFMs.
+
+**Every modernization phase re-captures it and diffs against the stored file:**
+
+```bash
+ERGOSFARE_CONTRACT_STACKDUMP=1 ERGOSFARE_CONTRACT_DUMP_PATH=./lane-map.txt dotnet test test/Stella.Ergosfare.Contract.Test -f net9.0
+diff test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt ./lane-map.txt
+```
+
+Green tests say the *behavior* survived. They cannot say which lane produced it: a
+compiled plan that quietly stops qualifying falls back to the reflective executors and
+every assertion in this suite still passes. **A changed lane map under green tests is the
+only early warning that the plan lanes silently degraded.** So a diff is not a failure —
+it is a question that must be answered in the PR:
+
+- Expected (the phase moved a lane on purpose): re-capture and commit the new baseline in
+  the same PR, and say in the body which frames moved and why.
+- Unexpected: the lanes diverged. Stop and report; do not update the baseline to make the
+  diff go away.
+
+Frames are captured from a `Debug` build; a `Release` capture inlines differently and is
+not comparable to this file.
+
+## Suspicious behaviors observed
+
+Pinned as-is. Each is a candidate for the modernization to decide on deliberately rather
+than change by accident.
+
+1. **`IExecutionContext.Abort(object? messageResult)` ignores its argument.** The
+   implementation throws `ExecutionAbortedException` unconditionally; the documented
+   "result to abort with" never reaches the caller, and the final interceptor is handed
+   `null` (or the result type's default). Pinned by
+   `Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value`.
+
+2. **Two different exceptions mean "nothing will handle this."** A message type that is not
+   in the registry produces `NoHandlerFoundException`; a registered message whose handlers
+   are all filtered out by a group filter produces a plain
+   `InvalidOperationException("No handler is registered for X.")`. Callers cannot catch
+   both with one type.
+
+3. **Events invert the default for "no handler."** Publishing a *registered* event nobody
+   handles is a silent no-op unless `ThrowIfNoHandlerFound` is set; publishing an
+   *unregistered* event type throws `NoHandlerFoundException` regardless of that flag. The
+   setting only controls the first case.
+
+4. **Covariance applies to interceptors but not to main handlers.** An interceptor
+   registered against a supertype joins a derived message's pipeline. A *handler*
+   registered against a supertype only serves a derived message that has no descriptor of
+   its own — register the derived type (which `RegisterGenerated` does for every discovered
+   message) and the base handler becomes an indirect handler that single-handler mediation
+   never considers, so the dispatch fails. Pinned by the two
+   `A_base_typed_handler_*` scenarios.
+
+5. **Runtime registry mutation is half-supported.** Registering an interceptor type after
+   the container is built does change the next dispatch — but only if that type was already
+   in DI. Otherwise the next dispatch throws `InvalidOperationException: No service for
+   type ...`, and because the registry has no removal, that message type stays broken for
+   the rest of the process. Pinned by
+   `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`.
+
+6. **A void pipeline's "result" is a `ValueTask` sentinel, except on abort.** Post, final
+   and exception interceptors of a void command are handed a non-null `ValueTask` as the
+   result argument even though the handler produced nothing — but on an aborted dispatch
+   the final interceptor gets `null`. Three different values (`ValueTask`, `null` from the
+   exception stage, `null` on abort) for "there is no result."
+
+7. **The generated staged-plan code emits nullable warnings into the consumer's build.**
+   Building this project surfaces `CS8604` twice in
+   `ErgosfareRegistrations.g.cs` — the emitted staged result plan passes a
+   possibly-null `string` into `IAsyncPostInterceptor<TMessage, TResult>.HandleAsync`,
+   whose `messageResult` parameter is non-nullable. It appears for any reference-typed
+   result whose pipeline qualifies for a staged plan. Left unsuppressed on purpose: it is
+   the only warning in this project and it is evidence the staged-plan lane is being
+   exercised.
+
+## Where it runs
+
+The project is listed in `Stella.Ergosfare.slnx`, so a solution-wide `dotnet test` picks
+it up on both TFMs. CI runs it in the `UnitTests` workflow, whose filter names this
+suite's category explicitly (`Category=Unit|Category=Contract`) — a contract test without
+`[Trait("Category", "Contract")]` builds and passes locally but never runs there. The
+`Coverage` workflow has no filter and runs it too.
+
+Triggers are unchanged: pull requests into `preview` and `main` run CI; the `preview-dev`
+integration branch keeps its no-CI-on-dev-PRs policy, so the local run before a dev PR is
+still mandatory.

--- a/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
@@ -1,0 +1,183 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Runtime;
+
+/// <summary>
+/// Registering into a warm container: after the pipeline for a message has already run
+/// once, adding an interceptor through the public registry must change the next dispatch —
+/// under generated registration exactly as under runtime registration.
+/// </summary>
+/// <remarks>
+/// Serialized against the rest of the suite: these are the only scenarios that mutate the
+/// process-wide registry after a container is live, and the version bump they cause
+/// invalidates every container's cached pipeline.
+/// </remarks>
+[Collection(RegistryMutationCollection.Name)]
+public sealed class RuntimeRegistrationMutationTests
+{
+    private const string Key = "contract.mutation";
+
+    // --- generated axis --------------------------------------------------------
+
+    [DiscoveryKey(Key)]
+    public sealed class GeneratedTarget : ICommand;
+
+    [DiscoveryKey(Key)]
+    public sealed class GeneratedTargetHandler : ICommandHandler<GeneratedTarget>
+    {
+        public ValueTask HandleAsync(GeneratedTarget command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Excluded from discovery so no registration path can install it early: the scenario
+    /// must observe a pipeline that genuinely lacked it before the mutation.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    public sealed class GeneratedLatePre : ICommandPreInterceptor<GeneratedTarget>
+    {
+        public ValueTask<GeneratedTarget> HandleAsync(GeneratedTarget command, IExecutionContext context)
+        {
+            context.Mark("late");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    // --- runtime axis ----------------------------------------------------------
+
+    [ExcludeFromDiscovery]
+    public sealed class RuntimeTarget : ICommand;
+
+    [ExcludeFromDiscovery]
+    public sealed class RuntimeTargetHandler : ICommandHandler<RuntimeTarget>
+    {
+        public ValueTask HandleAsync(RuntimeTarget command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="GeneratedLatePre"/>
+    [ExcludeFromDiscovery]
+    public sealed class RuntimeLatePre : ICommandPreInterceptor<RuntimeTarget>
+    {
+        public ValueTask<RuntimeTarget> HandleAsync(RuntimeTarget command, IExecutionContext context)
+        {
+            context.Mark("late");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    // --- unresolvable late registration ----------------------------------------
+
+    /// <summary>
+    /// Its own message type: the registry never forgets, so the scenario below leaves this
+    /// pipeline permanently broken for the rest of the process.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    public sealed class PoisonTarget : ICommand;
+
+    [ExcludeFromDiscovery]
+    public sealed class PoisonTargetHandler : ICommandHandler<PoisonTarget>
+    {
+        public ValueTask HandleAsync(PoisonTarget command, IExecutionContext context) => ValueTask.CompletedTask;
+    }
+
+    /// <summary>Registered nowhere in DI, to pin what an unresolvable late type does.</summary>
+    [ExcludeFromDiscovery]
+    public sealed class UnresolvableLatePre : ICommandPreInterceptor<PoisonTarget>
+    {
+        public ValueTask<PoisonTarget> HandleAsync(PoisonTarget command, IExecutionContext context)
+            => ValueTask.FromResult(command);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran()
+    {
+        await using var provider = new ServiceCollection()
+            .AddTransient<GeneratedLatePre>()
+            .AddErgosfare(options => options.AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var before = new PipelineRecorder();
+        await mediator.SendAsync(new GeneratedTarget(), before.Commands());
+        before.AssertStages("handler");
+
+        provider.GetRequiredService<IMessageRegistry>().Register(typeof(GeneratedLatePre));
+
+        var after = new PipelineRecorder();
+        await mediator.SendAsync(new GeneratedTarget(), after.Commands());
+        after.AssertStages("late", "handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran()
+    {
+        await using var provider = new ServiceCollection()
+            .AddTransient<RuntimeLatePre>()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.Register<RuntimeTargetHandler>()))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var before = new PipelineRecorder();
+        await mediator.SendAsync(new RuntimeTarget(), before.Commands());
+        before.AssertStages("handler");
+
+        provider.GetRequiredService<IMessageRegistry>().Register(typeof(RuntimeLatePre));
+
+        var after = new PipelineRecorder();
+        await mediator.SendAsync(new RuntimeTarget(), after.Commands());
+        after.AssertStages("late", "handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch()
+    {
+        await using var provider = new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.Register<PoisonTargetHandler>()))
+            .BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+        await mediator.SendAsync(new PoisonTarget());
+
+        // The registry accepts the type, but the container was built without it: the
+        // pipeline that now includes it cannot be constructed. See the README.
+        provider.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableLatePre));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await mediator.SendAsync(new PoisonTarget()));
+
+        Assert.Contains(nameof(UnresolvableLatePre), thrown.Message, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Serializes the registry-mutating scenarios against each other. The registry is
+/// process-wide; letting these run beside anything else invites unrelated flakes.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RegistryMutationCollection
+{
+    /// <summary>The collection name.</summary>
+    public const string Name = "registry-mutation";
+}

--- a/test/Stella.Ergosfare.Contract.Test/Stella.Ergosfare.Contract.Test.csproj
+++ b/test/Stella.Ergosfare.Contract.Test/Stella.Ergosfare.Contract.Test.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- The whole public facade (commands, queries, events + their DI extensions):
+           the suite is written against this surface and nothing below it. -->
+      <ProjectReference Include="..\..\src\Stella.Ergosfare\Stella.Ergosfare.csproj" />
+      <!-- The source generator as an analyzer, so the generated-registration axis has a
+           RegisterGenerated() to call over this assembly's own types. -->
+      <ProjectReference Include="..\..\src\Stella.Ergosfare.SourceGenerator\Stella.Ergosfare.SourceGenerator.csproj"
+                        OutputItemType="Analyzer"
+                        ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+</Project>

--- a/test/Stella.Ergosfare.Contract.Test/Streaming/StreamQueryTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Streaming/StreamQueryTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Abstractions;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Streaming;
+
+/// <summary>
+/// The streaming surface as it stands today, pinned shallowly on purpose: it is marked
+/// experimental, so only the two observations a caller can rely on are recorded here —
+/// items arrive in order, and a mid-stream failure surfaces after the items that preceded
+/// it.
+/// </summary>
+public sealed class StreamQueryTests
+{
+    private const string Key = "contract.stream";
+
+    /// <summary>Thrown from the middle of a stream.</summary>
+    public sealed class StreamFailure() : Exception("stream failed");
+
+    [DiscoveryKey(Key)]
+    public sealed class Ticks : IStreamQuery<int>
+    {
+        /// <summary>Whether the handler stops mid-stream by throwing.</summary>
+        public bool FailMidway;
+    }
+
+    [DiscoveryKey(Key)]
+    public sealed class TicksHandler : IStreamQueryHandler<Ticks, int>
+    {
+        public async IAsyncEnumerable<int> StreamAsync(Ticks query, IExecutionContext context)
+        {
+            yield return 1;
+
+            // A real await between items, so the scenario is not a synchronous shortcut.
+            await Task.Yield();
+            yield return 2;
+
+            if (query.FailMidway)
+            {
+                throw new StreamFailure();
+            }
+
+            yield return 3;
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options.AddQueryModule(queries => queries.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_stream_query_yields_its_items_in_order_and_completes()
+    {
+        await using var provider = CreateProvider();
+        var received = new List<int>();
+
+        await foreach (var tick in provider.GetRequiredService<IQueryMediator>().StreamAsync(new Ticks()))
+        {
+            received.Add(tick);
+        }
+
+        Assert.Equal([1, 2, 3], received);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_mid_stream_exception_surfaces_unwrapped_after_the_items_that_preceded_it()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+        var received = new List<int>();
+
+        await Assert.ThrowsAsync<StreamFailure>(async () =>
+        {
+            await foreach (var tick in mediator.StreamAsync(new Ticks { FailMidway = true }))
+            {
+                received.Add(tick);
+            }
+        });
+
+        Assert.Equal([1, 2], received);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/baselines/.gitattributes
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/.gitattributes
@@ -1,0 +1,4 @@
+# The lane map is re-captured on every modernization phase and diffed against the
+# committed copy. Normalizing it on commit and checking it out with native endings keeps
+# that diff about frames, never about CRLF.
+lane-map.txt text

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -1,0 +1,1177 @@
+GeneratedRegistrationPipelineTests — stages: [handler]
+  1. handler  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>d__16.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass16_0.<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass16_0+<<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.GeneratedVoidPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|0|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+rewritten|null|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultExceptionBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+rewritten|fallback|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                     | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+rewritten|0|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TQuery,TResult>.HandleAsync
+                     | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueExceptionBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+rewritten|-1|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+rewritten|null|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadExceptionBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+rewritten|ValueTask|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+rewritten|ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+rewritten|ok+rewritten+posted|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+rewritten|ValueTask
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPostBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+rewritten|ValueTask|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                     | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+rewritten|7
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
+                     | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+rewritten|107|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:tie-omega, pre:light, handler, post:high, post:low]
+  1. pre:heavy
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. pre:tie-alpha
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. pre:tie-omega
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. pre:light
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  5. handler
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.OrderedHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  6. post:high
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  7. post:low
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [handler]
+  1. handler  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>d__16.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass16_0.<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass16_0+<<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                             | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|0|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                             | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
+                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                             | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
+         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
+           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+rewritten|null|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultExceptionBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+rewritten|fallback|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_exception_yields_the_exception_interceptors_fallback_result
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_exception_yields_the_exception_interceptors_fallback_result>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+rewritten|0|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TQuery,TResult>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueExceptionBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+rewritten|-1|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_exception_yields_the_interceptors_fallback_value
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_exception_yields_the_interceptors_fallback_value>d__26.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+rewritten|null|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadExceptionBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+rewritten|ValueTask|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_handler_exception_is_swallowed_when_an_exception_interceptor_is_registered>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+rewritten|ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPostBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+rewritten|ok+rewritten+posted|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+rewritten|ValueTask
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+rewritten|ValueTask|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+rewritten
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+rewritten|7
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePostBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+rewritten|107|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_flows_through_pre_handler_post_and_final
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_flows_through_pre_handler_post_and_final>d__25.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:tie-omega, pre:light, handler, post:high, post:low]
+  1. pre:heavy
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. pre:tie-alpha
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. pre:tie-omega
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. pre:light
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  5. handler
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.OrderedHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  6. post:high
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  7. post:low
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Interceptors_in_a_stage_run_by_descending_weight
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Interceptors_in_a_stage_run_by_descending_weight>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: []
+
+stages: [default]
+  1. default
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.A_default_publish_skips_grouped_handlers
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<A_default_publish_skips_grouped_handlers>d__15.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+StockChangedDefaultHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [direct:audit, direct:notify, indirect:interface]
+  1. direct:audit
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.Publish_runs_direct_handlers_before_interface_matched_ones
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<Publish_runs_direct_handlers_before_interface_matched_ones>d__18.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+ShipmentAuditHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. direct:notify
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.Publish_runs_direct_handlers_before_interface_matched_ones
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<Publish_runs_direct_handlers_before_interface_matched_ones>d__18.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+ShipmentNotifyHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. indirect:interface
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.Publish_runs_direct_handlers_before_interface_matched_ones
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<Publish_runs_direct_handlers_before_interface_matched_ones>d__18.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+ShipmentInterfaceHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler:base]
+  1. handler:base
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.A_base_typed_handler_serves_a_derived_message_that_is_not_registered_itself
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<A_base_typed_handler_serves_a_derived_message_that_is_not_registered_itself>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+LedgerEntryHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler:reporting]
+  1. handler:reporting
+     | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests.A_grouped_dispatch_reaches_the_grouped_handler
+       | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests+<A_grouped_dispatch_reaches_the_grouped_handler>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests+ReportingOnlyHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler:reporting]
+  1. handler:reporting
+     | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests.A_plain_group_sequence_and_a_canonical_GroupSet_select_the_same_participants
+       | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests+<A_plain_group_sequence_and_a_canonical_GroupSet_select_the_same_participants>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests+ReportingOnlyHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests.A_default_dispatch_skips_grouped_participants
+       | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests+<A_default_dispatch_skips_grouped_participants>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Groups.GroupFilteringTests+MixedHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+GeneratedTargetHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RuntimeTargetHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [invoice, warehouse]
+  1. invoice
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.Publish_reaches_every_registered_handler
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<Publish_reaches_every_registered_handler>d__11.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+OrderPlacedInvoiceHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. warehouse
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.Publish_reaches_every_registered_handler
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<Publish_reaches_every_registered_handler>d__11.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+OrderPlacedWarehouseHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [late, handler]
+  1. late
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+GeneratedLatePre.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+GeneratedTargetHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [late, handler]
+  1. late
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RuntimeLatePre.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RuntimeTargetHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [pre:audited, handler]
+  1. pre:audited
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.An_interceptor_registered_against_an_implemented_interface_joins_the_pipeline
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<An_interceptor_registered_against_an_implemented_interface_joins_the_pipeline>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+AuditedPre.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.An_interceptor_registered_against_an_implemented_interface_joins_the_pipeline
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<An_interceptor_registered_against_an_implemented_interface_joins_the_pipeline>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+WithdrawHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [reporting]
+  1. reporting
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.A_grouped_publish_reaches_only_the_grouped_handlers
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<A_grouped_publish_reaches_only_the_grouped_handlers>d__16.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+StockChangedReportingHandler.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+


### PR DESCRIPTION
Closes #127

Phase 0 of the core modernization: the safety net goes in, and the two "before" pictures
the later phases will be measured against are captured. **No production code changes.**

Board: [[v2] Modernizasyon Faz 0](https://github.com/orgs/stellayazilim/projects/10?pane=issue&itemId=PVTI_lADOBoQSvM4Bftylzg10zeY)

## 1. The suite lands and gets connected

`test/Stella.Ergosfare.Contract.Test` — 83 characterization tests over the public surface
only — was built under a brief that forbade touching anything outside its own directory,
so it was never added to the solution. It is now:

- listed in `Stella.Ergosfare.slnx`, so a solution-wide `dotnet test` picks it up on both
  TFMs;
- named explicitly in the `UnitTests` workflow filter (`Category=Unit|Category=Contract`).
  This is not cosmetic: the suite's tests carry `Category=Contract` and the old
  `Category=Unit` filter excluded them, so adding the project alone would have wired it
  into the solution and *not* into CI. The `Coverage` workflow has no filter and picks it
  up as-is.

Triggers are untouched — PRs into `preview`/`main` run CI, `preview-dev` keeps its
no-CI-on-dev-PRs policy, so the local run before a dev PR stays mandatory.

## 2. Lane-map baseline — `baselines/lane-map.txt`

Green tests say the *behavior* survived; they cannot say which lane produced it. A
compiled plan that quietly stops qualifying falls back to the reflective executors with
every assertion in the suite still passing. The stack dump is the only early warning, so
it is now a committed artifact that every phase re-captures and diffs.

For that diff to mean anything the dump had to become deterministic. It was written in
`ConcurrentQueue` completion order: two captures of the same code produced the same 1177
lines with **500 diff lines** between them. `ContractDiagnostics.Flush` now emits sections
in ordinal order, and two captures are byte-identical — across runs *and* across both
TFMs. This is diagnostic-only code: off by default, never asserted on, no test semantics
touched.

The baseline confirms the README's registration-axes table frame by frame — `StagedPlan0..3`
plus the `StagedVoid`/`StagedResult`/`GeneratedVoid` executors on the generated axis,
`Void`/`ResultPipelineExecutor` plus `SingleAsyncHandlerMediationStrategy` on the fallback
axis.

**README fix:** the documented stack-dump example was wrong — it showed *reflective* frames
under the `GeneratedRegistrationPipelineTests` label. Replaced with real captured traces,
both axes of the same scenario side by side. (This was the single defect the independent
verification found.)

## 3. Cache-pressure measurement gate — `CachePressureBenchmark`

The measurement gate folded into Phase 0 from the old cache-pressure draft. A **new**
class; **no existing `MediationBenchmark` row was touched**.

- Two shapes (void command, result query) × five lanes: Ergosfare default / generated /
  memoized against MediatR and martinothamar/Mediator on their own defaults, Ergosfare's
  default lane as the per-shape baseline.
- Every case pinned to logical core 0 — the single-core-server reality, and what makes
  cache-miss counts comparable between rows at all.
- Hardware counters (cache misses, branch mispredictions, retired instructions) attach
  only when the process can open the ETW session, i.e. an elevated console on Windows.
  Unelevated, the run still yields timings and allocations instead of failing validation
  with nothing to show.
- Generated and memoized install process-wide state, so each has a targeted setup and
  therefore its own benchmark process. Every setup asserts its provider actually answers
  before measuring — a lane that silently stops dispatching still benchmarks beautifully.
- `Program.Main`: a bare run still means "the whole `MediationBenchmark` table"; with
  arguments the switcher selects across both classes.

Baseline stored at
`test/Stella.Ergosfare.Benchmarking/BenchmarkDotNet.Artifacts/baselines/2026-08-09-cache-pressure-baseline.md`.
The ignore rule now excludes that directory's *contents* rather than the directory, because
git never descends into an excluded directory and the re-inclusion needs the parent
traversable.

| | Ergosfare | generated | memoized | MediatR | Mediator |
| --- | ---: | ---: | ---: | ---: | ---: |
| void command | 36.3 ns / 24 B | 22.7 / 24 | 23.8 / 0 | 65.5 / 192 | 8.4 / 0 |
| result query | 40.1 ns / 24 B | 26.5 / 24 | 34.8 / 0 | 56.4 / 192 | 8.8 / 0 |

Single core, 7800X3D. Note `Query_Result_Memoized` (34.8) sitting well behind the generated
lane (26.5): the memoized gate closing over the faster lane, the same inversion the
five-participant rows show, now visible on a plain participant-free dispatch too.

## Verification

- Solution-level `dotnet test --filter "Category=Unit|Category=Contract"` **twice**:
  Contract 83/83 on net9.0 and net10.0, every other project green.
- Unfiltered solution run (what `Coverage` does) green.
- Lane map re-captured after rebasing onto `preview-dev`: **0 diff lines** against the
  committed baseline.
- Benchmark project builds Release with 0 warnings.
- No `InternalsVisibleTo` added anywhere; no contract-test semantics changed.

## Two things still open

1. **The counter columns in the stored baseline are empty** — that capture ran unelevated.
   Re-run from an administrator console before the surgery starts:
   `dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking -- --filter '*CachePressure*'`
2. **Wiring the suite in surfaces its two `CS8604` warnings** (2 per TFM) in solution
   builds. They come from the emitted staged result plan and are documented as
   "Suspicious behaviors observed #7", deliberately left unsuppressed as evidence the
   staged lane is exercised. F7 fixes the emitter in Phase 2. Left as-is here; say the
   word and they get a justified `NoWarn` instead.
