### PR TITLE
test: phase 1 — contract suite coverage reinforcements

### DIFF
--- a/test/Stella.Ergosfare.Contract.Test/Abort/FallbackPostAbortTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/FallbackPostAbortTypes.cs
@@ -1,0 +1,94 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+// The post-abort scenarios' types for the runtime-registration axis. Every type here is
+// excluded from discovery, so the generator models none of them: no pre-computed
+// descriptors and no staged plan, and the scenarios abort inside the reflective mediation
+// strategy instead of the emitted plan body. Excluding them is mandatory, not tidiness —
+// the generator's descriptor catalog is filled by a module initializer for every type it
+// models, so a discoverable type would keep its pre-computed descriptors even when
+// registered with Register<T>().
+namespace Stella.Ergosfare.Contract.Test.Abort.Fallback;
+
+// --- void command -----------------------------------------------------------
+
+/// <inheritdoc cref="Generated.AbortVoidCommand"/>
+[ExcludeFromDiscovery]
+public sealed class AbortVoidCommand : IAbortCommand;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortVoidCommandHandler : AbortVoidHandlerBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class AbortVoidCommandPost : AbortingVoidPostBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(1)]
+public sealed class AbortVoidCommandLatePost : LateVoidPostBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortVoidCommandException : AbortVoidExceptionBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortVoidCommandFinal : AbortVoidFinalBase<AbortVoidCommand>;
+
+// --- string-result command --------------------------------------------------
+
+/// <inheritdoc cref="Generated.AbortResultCommand"/>
+[ExcludeFromDiscovery]
+public sealed class AbortResultCommand : IAbortResultCommand;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortResultCommandHandler : AbortResultHandlerBase<AbortResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class AbortResultCommandPost : AbortingResultPostBase<AbortResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(1)]
+public sealed class AbortResultCommandLatePost : LateResultPostBase<AbortResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortResultCommandException : AbortResultExceptionBase<AbortResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortResultCommandFinal : AbortResultFinalBase<AbortResultCommand>;
+
+// --- value-typed query ------------------------------------------------------
+
+/// <inheritdoc cref="Generated.AbortValueQuery"/>
+[ExcludeFromDiscovery]
+public sealed class AbortValueQuery : IAbortValueQuery;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortValueQueryHandler : AbortQueryHandlerBase<AbortValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class AbortValueQueryPost : AbortingQueryPostBase<AbortValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(1)]
+public sealed class AbortValueQueryLatePost : LateQueryPostBase<AbortValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortValueQueryException : AbortQueryExceptionBase<AbortValueQuery>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AbortValueQueryFinal : AbortQueryFinalBase<AbortValueQuery>;

--- a/test/Stella.Ergosfare.Contract.Test/Abort/GeneratedPostAbortTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/GeneratedPostAbortTypes.cs
@@ -1,0 +1,79 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Contract.Test.Abort.Generated;
+
+// The post-abort scenarios' types for the source-generated registration axis. Top-level,
+// unkeyed and ungrouped on purpose: the abort semantics the modernization is about to
+// change live in the emitted staged-plan body (its catch-when/finally shell), and only
+// default-discovery participants reach it. A [DiscoveryKey] here would register, pass, and
+// silently test nothing the fallback axis does not already cover.
+//
+// Every message type is local to this area and no interceptor is registered against a
+// module marker, so joining the assembly's unkeyed pool cannot reach another area's
+// pipelines.
+
+// --- void command -----------------------------------------------------------
+
+/// <summary>Void command whose post stage aborts after the handler has run.</summary>
+public sealed class AbortVoidCommand : IAbortCommand;
+
+/// <inheritdoc />
+public sealed class AbortVoidCommandHandler : AbortVoidHandlerBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class AbortVoidCommandPost : AbortingVoidPostBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+[Weight(1)]
+public sealed class AbortVoidCommandLatePost : LateVoidPostBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+public sealed class AbortVoidCommandException : AbortVoidExceptionBase<AbortVoidCommand>;
+
+/// <inheritdoc />
+public sealed class AbortVoidCommandFinal : AbortVoidFinalBase<AbortVoidCommand>;
+
+// --- string-result command --------------------------------------------------
+
+/// <summary>String-result command whose post stage aborts after the handler has run.</summary>
+public sealed class AbortResultCommand : IAbortResultCommand;
+
+/// <inheritdoc />
+public sealed class AbortResultCommandHandler : AbortResultHandlerBase<AbortResultCommand>;
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class AbortResultCommandPost : AbortingResultPostBase<AbortResultCommand>;
+
+/// <inheritdoc />
+[Weight(1)]
+public sealed class AbortResultCommandLatePost : LateResultPostBase<AbortResultCommand>;
+
+/// <inheritdoc />
+public sealed class AbortResultCommandException : AbortResultExceptionBase<AbortResultCommand>;
+
+/// <inheritdoc />
+public sealed class AbortResultCommandFinal : AbortResultFinalBase<AbortResultCommand>;
+
+// --- value-typed query ------------------------------------------------------
+
+/// <summary>Value-typed query whose post stage aborts after the handler has run.</summary>
+public sealed class AbortValueQuery : IAbortValueQuery;
+
+/// <inheritdoc />
+public sealed class AbortValueQueryHandler : AbortQueryHandlerBase<AbortValueQuery>;
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class AbortValueQueryPost : AbortingQueryPostBase<AbortValueQuery>;
+
+/// <inheritdoc />
+[Weight(1)]
+public sealed class AbortValueQueryLatePost : LateQueryPostBase<AbortValueQuery>;
+
+/// <inheritdoc />
+public sealed class AbortValueQueryException : AbortQueryExceptionBase<AbortValueQuery>;
+
+/// <inheritdoc />
+public sealed class AbortValueQueryFinal : AbortQueryFinalBase<AbortValueQuery>;

--- a/test/Stella.Ergosfare.Contract.Test/Abort/GeneratedRegistrationPostAbortTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/GeneratedRegistrationPostAbortTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Abort.Generated;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Abort;
+
+/// <summary>
+/// The post-abort contract under source-generated registration: the abort unwinds out of
+/// the emitted staged-plan body, through its <c>catch</c>-when-not-aborted guard and into
+/// its <c>finally</c>.
+/// </summary>
+/// <remarks>
+/// The pattern-less overload is deliberate: plan eligibility requires default-discovery,
+/// top-level, ungrouped participants, so a keyed selection would abort inside the
+/// reflective strategy the other axis already covers.
+/// </remarks>
+public sealed class GeneratedRegistrationPostAbortTests : PostAbortSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated())
+                .AddQueryModule(queries => queries.RegisterGenerated()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IAbortCommand NewCommand() => new AbortVoidCommand();
+
+    /// <inheritdoc />
+    protected override IAbortResultCommand NewResultCommand() => new AbortResultCommand();
+
+    /// <inheritdoc />
+    protected override IAbortValueQuery NewValueQuery() => new AbortValueQuery();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Abort/PostAbortContracts.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/PostAbortContracts.cs
@@ -1,0 +1,262 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Contract.Test.Abort;
+
+/// <summary>
+/// The shared vocabulary and behavior of the post-interceptor abort scenarios: a pipeline
+/// that has already produced a result, aborted from the stage that runs after the handler.
+/// </summary>
+/// <remarks>
+/// Everything here is excluded from discovery: these are shapes, not registrable
+/// constructs. Exclusion is not inherited, so the closing types stay discoverable.
+/// </remarks>
+public static class AbortVocabulary
+{
+    /// <summary>The value the string-result handler produces before the abort.</summary>
+    public const string HandlerResult = "produced";
+
+    /// <summary>The value the query handler produces before the abort.</summary>
+    public const int HandlerValue = 7;
+
+    /// <summary>What the aborting post-interceptor would have returned had it returned.</summary>
+    public const string NeverPosted = "+never";
+
+    /// <summary>Renders a stage's result argument for the recorder.</summary>
+    public static string Describe(object? result) => result switch
+    {
+        null => "null",
+        string text => text,
+        ValueTask => nameof(ValueTask),
+        _ => result.ToString() ?? result.GetType().Name,
+    };
+
+    /// <summary>Renders a stage's exception argument for the recorder.</summary>
+    public static string Describe(Exception? exception)
+        => exception is null ? "none" : exception.GetType().Name;
+}
+
+/// <summary>The void command whose post stage aborts.</summary>
+[ExcludeFromDiscovery]
+public interface IAbortCommand : ICommand;
+
+/// <summary>The string-result command whose post stage aborts.</summary>
+[ExcludeFromDiscovery]
+public interface IAbortResultCommand : ICommand<string>;
+
+/// <summary>The value-typed query whose post stage aborts.</summary>
+[ExcludeFromDiscovery]
+public interface IAbortValueQuery : IQuery<int>;
+
+// ---------------------------------------------------------------------------
+// void pipeline
+// ---------------------------------------------------------------------------
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public abstract class AbortVoidHandlerBase<TCommand> : ICommandHandler<TCommand>
+    where TCommand : class, IAbortCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler");
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Aborts after the handler has run — the heaviest post slot, so it runs first.</summary>
+[ExcludeFromDiscovery]
+public abstract class AbortingVoidPostBase<TCommand> : ICommandPostInterceptor<TCommand>
+    where TCommand : class, IAbortCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object result, IExecutionContext context)
+    {
+        context.Mark("post:abort", AbortVocabulary.Describe(result));
+        context.Abort();
+        return ValueTask.FromResult(result);
+    }
+}
+
+/// <summary>The lighter post slot: it marks only if the abort did not stop the stage.</summary>
+[ExcludeFromDiscovery]
+public abstract class LateVoidPostBase<TCommand> : ICommandPostInterceptor<TCommand>
+    where TCommand : class, IAbortCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object result, IExecutionContext context)
+    {
+        context.Mark("post:after");
+        return ValueTask.FromResult(result);
+    }
+}
+
+/// <summary>Marks only if an abort is routed through the exception stage.</summary>
+[ExcludeFromDiscovery]
+public abstract class AbortVoidExceptionBase<TCommand> : ICommandExceptionInterceptor<TCommand>
+    where TCommand : class, IAbortCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object? result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception", AbortVocabulary.Describe(exception));
+        return ValueTask.FromResult<object>(ValueTask.CompletedTask);
+    }
+}
+
+/// <summary>Records the result and exception the final stage is handed after the abort.</summary>
+[ExcludeFromDiscovery]
+public abstract class AbortVoidFinalBase<TCommand> : ICommandFinalInterceptor<TCommand>
+    where TCommand : class, IAbortCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, object? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final", $"{AbortVocabulary.Describe(result)}|{AbortVocabulary.Describe(exception)}");
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// string-result pipeline
+// ---------------------------------------------------------------------------
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public abstract class AbortResultHandlerBase<TCommand> : ICommandHandler<TCommand, string>
+    where TCommand : class, IAbortResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler");
+        return ValueTask.FromResult(AbortVocabulary.HandlerResult);
+    }
+}
+
+/// <inheritdoc cref="AbortingVoidPostBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AbortingResultPostBase<TCommand> : ICommandPostInterceptor<TCommand, string>
+    where TCommand : class, IAbortResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, string commandResult, IExecutionContext context)
+    {
+        context.Mark("post:abort", commandResult);
+        context.Abort();
+        return ValueTask.FromResult(commandResult + AbortVocabulary.NeverPosted);
+    }
+}
+
+/// <inheritdoc cref="LateVoidPostBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class LateResultPostBase<TCommand> : ICommandPostInterceptor<TCommand, string>
+    where TCommand : class, IAbortResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, string commandResult, IExecutionContext context)
+    {
+        context.Mark("post:after");
+        return ValueTask.FromResult(commandResult);
+    }
+}
+
+/// <inheritdoc cref="AbortVoidExceptionBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AbortResultExceptionBase<TCommand> : ICommandExceptionInterceptor<TCommand, string>
+    where TCommand : class, IAbortResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string?> HandleAsync(TCommand command, string? result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception", AbortVocabulary.Describe(exception));
+        return ValueTask.FromResult<string?>(result);
+    }
+}
+
+/// <inheritdoc cref="AbortVoidFinalBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AbortResultFinalBase<TCommand> : ICommandFinalInterceptor<TCommand, string>
+    where TCommand : class, IAbortResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, string? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final", $"{AbortVocabulary.Describe(result)}|{AbortVocabulary.Describe(exception)}");
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// value-typed query pipeline
+// ---------------------------------------------------------------------------
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public abstract class AbortQueryHandlerBase<TQuery> : IQueryHandler<TQuery, int>
+    where TQuery : class, IAbortValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, IExecutionContext context)
+    {
+        context.Mark("handler");
+        return ValueTask.FromResult(AbortVocabulary.HandlerValue);
+    }
+}
+
+/// <inheritdoc cref="AbortingVoidPostBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AbortingQueryPostBase<TQuery> : IQueryPostInterceptor<TQuery, int>
+    where TQuery : class, IAbortValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, int queryResult, IExecutionContext context)
+    {
+        context.Mark("post:abort", queryResult.ToString());
+        context.Abort();
+        return ValueTask.FromResult(queryResult + 1);
+    }
+}
+
+/// <inheritdoc cref="LateVoidPostBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class LateQueryPostBase<TQuery> : IQueryPostInterceptor<TQuery, int>
+    where TQuery : class, IAbortValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, int queryResult, IExecutionContext context)
+    {
+        context.Mark("post:after");
+        return ValueTask.FromResult(queryResult);
+    }
+}
+
+/// <inheritdoc cref="AbortVoidExceptionBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AbortQueryExceptionBase<TQuery> : IQueryExceptionInterceptor<TQuery, int>
+    where TQuery : class, IAbortValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask<int> HandleAsync(TQuery query, int result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception", AbortVocabulary.Describe(exception));
+        return ValueTask.FromResult(result);
+    }
+}
+
+/// <inheritdoc cref="AbortVoidFinalBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AbortQueryFinalBase<TQuery> : IQueryFinalInterceptor<TQuery, int>
+    where TQuery : class, IAbortValueQuery
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TQuery query, int result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final", $"{result}|{AbortVocabulary.Describe(exception)}");
+        return ValueTask.CompletedTask;
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Abort/PostAbortSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/PostAbortSemanticsContract.cs
@@ -1,0 +1,163 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Contract.Test.Abort;
+
+/// <summary>
+/// What aborting from a <em>post</em> interceptor does — the arm where the pipeline has
+/// already produced a result. The pre-interceptor abort pinned in
+/// <c>PipelineSemanticsContract</c> covers the other arm, where nothing was produced yet;
+/// the two disagree about what the final stage is handed, which is the whole point of
+/// pinning this one before the abort semantics change.
+/// </summary>
+/// <remarks>
+/// Both registration axes inherit these scenarios verbatim: the generated axis aborts
+/// inside the emitted staged-plan body, the runtime axis inside the reflective mediation
+/// strategy. Those are two separate implementations of the same catch-when/finally shell,
+/// and a divergence shows up as one subclass failing.
+/// </remarks>
+public abstract class PostAbortSemanticsContract
+{
+    /// <summary>A container with this axis' post-abort types registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The void command whose post stage aborts.</summary>
+    protected abstract IAbortCommand NewCommand();
+
+    /// <summary>The string-result command whose post stage aborts.</summary>
+    protected abstract IAbortResultCommand NewResultCommand();
+
+    /// <summary>The value-typed query whose post stage aborts.</summary>
+    protected abstract IAbortValueQuery NewValueQuery();
+
+    /// <summary>
+    /// A recorder stamped with the running axis, so a diagnostic dump of these shared
+    /// scenarios says which registration path produced each trace.
+    /// </summary>
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    // -----------------------------------------------------------------------
+    // void pipeline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewCommand(), recorder.Commands()));
+
+        recorder.AssertStages("handler", "post:abort", "final");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_pipelines_final_interceptor_is_handed_the_completed_task_after_a_post_abort()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewCommand(), recorder.Commands()));
+
+        // A pre-interceptor abort leaves this null; by the post stage the handler has run,
+        // so the completed-task sentinel is already in the result slot and survives.
+        Assert.Equal($"{nameof(ValueTask)}|none", recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // string-result pipeline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewResultCommand(), recorder.Commands()));
+
+        recorder.AssertStages("handler", "post:abort", "final");
+        Assert.Equal(AbortVocabulary.HandlerResult, recorder.DetailOf("post:abort"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_result_pipelines_final_interceptor_is_handed_the_handlers_result_after_a_post_abort()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewResultCommand(), recorder.Commands()));
+
+        // The handler's result, not the value the aborting interceptor was about to return:
+        // the abort unwinds before the post stage writes its result back.
+        Assert.Equal($"{AbortVocabulary.HandlerResult}|none", recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // value-typed pipeline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.QueryAsync(NewValueQuery(), recorder.Queries()));
+
+        recorder.AssertStages("handler", "post:abort", "final");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_value_typed_querys_final_interceptor_is_handed_the_handlers_value_after_a_post_abort()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<IQueryMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.QueryAsync(NewValueQuery(), recorder.Queries()));
+
+        Assert.Equal($"{AbortVocabulary.HandlerValue}|none", recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // what the abort stops
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_post_abort_skips_the_remaining_post_interceptors_and_the_exception_stage()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewResultCommand(), recorder.Commands()));
+
+        // An abort is not a failure: the exception stage never sees it, and the lighter
+        // post slot never runs.
+        Assert.DoesNotContain("post:after", recorder.Stages);
+        Assert.DoesNotContain("exception", recorder.Stages);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Abort/RuntimeRegistrationPostAbortTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/RuntimeRegistrationPostAbortTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Abort.Fallback;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Abort;
+
+/// <summary>
+/// The same post-abort contract under explicit runtime registration: the abort unwinds out
+/// of the reflective mediation strategy instead of an emitted plan.
+/// </summary>
+/// <remarks>
+/// Each stage's slots are registered out of weight order on purpose: if registration order
+/// decided which post interceptor aborts first, the inherited expectations would fail here
+/// and pass on the generated axis.
+/// </remarks>
+public sealed class RuntimeRegistrationPostAbortTests : PostAbortSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<AbortVoidCommandHandler>()
+                    .Register<AbortVoidCommandLatePost>()
+                    .Register<AbortVoidCommandPost>()
+                    .Register<AbortVoidCommandException>()
+                    .Register<AbortVoidCommandFinal>()
+                    .Register<AbortResultCommandHandler>()
+                    .Register<AbortResultCommandLatePost>()
+                    .Register<AbortResultCommandPost>()
+                    .Register<AbortResultCommandException>()
+                    .Register<AbortResultCommandFinal>())
+                .AddQueryModule(queries => queries
+                    .Register<AbortValueQueryHandler>()
+                    .Register<AbortValueQueryLatePost>()
+                    .Register<AbortValueQueryPost>()
+                    .Register<AbortValueQueryException>()
+                    .Register<AbortValueQueryFinal>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IAbortCommand NewCommand() => new AbortVoidCommand();
+
+    /// <inheritdoc />
+    protected override IAbortResultCommand NewResultCommand() => new AbortResultCommand();
+
+    /// <inheritdoc />
+    protected override IAbortValueQuery NewValueQuery() => new AbortValueQuery();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Exclusion/PipelineExclusionTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Exclusion/PipelineExclusionTests.cs
@@ -1,0 +1,226 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Exclusion;
+
+/// <summary>
+/// What <c>[ExcludeFromPipeline]</c> on a message does to an interceptor that reaches it
+/// covariantly — registered against a supertype the message implements — and what it
+/// deliberately does not do to an interceptor written for the message itself.
+/// </summary>
+/// <remarks>
+/// Each axis declares its own supertype. The registry is process-wide, so a shared
+/// supertype would attach both axes' covariant interceptors to both axes' messages, and
+/// each container could only resolve its own half.
+/// <para>
+/// These types stay keyed: the generator skips messages carrying the attribute rather than
+/// modeling the exclusion, so no staged plan can serve them and both axes reach the
+/// reflective pipeline shape.
+/// </para>
+/// </remarks>
+public abstract class PipelineExclusionContract
+{
+    /// <summary>The discovery key this area registers under.</summary>
+    protected const string Key = "contract.exclude";
+
+    /// <summary>Marks the handler of whichever message was dispatched.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class AuditedHandlerBase<TCommand> : ICommandHandler<TCommand>
+        where TCommand : class, ICommand
+    {
+        /// <inheritdoc />
+        public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Registered against a supertype: it reaches its messages covariantly.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class CovariantPreBase<TSupertype> : ICommandPreInterceptor<TSupertype>
+        where TSupertype : class, ICommand
+    {
+        /// <inheritdoc />
+        public ValueTask<TSupertype> HandleAsync(TSupertype command, IExecutionContext context)
+        {
+            context.Mark("pre:covariant");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    /// <summary>Registered against the excluded message itself, deliberately.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class DirectPreBase<TCommand> : ICommandPreInterceptor<TCommand>
+        where TCommand : class, ICommand
+    {
+        /// <inheritdoc />
+        public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
+        {
+            context.Mark("pre:direct");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    /// <summary>A container with this axis' exclusion types registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The message carrying <c>[ExcludeFromPipeline]</c>.</summary>
+    protected abstract ICommand NewExcludedCommand();
+
+    /// <summary>Its sibling, implementing the same supertype without the attribute.</summary>
+    protected abstract ICommand NewIncludedCommand();
+
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_covariantly_matched_interceptor_stays_out_of_a_message_marked_ExcludeFromPipeline()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewExcludedCommand(), recorder.Commands());
+
+        Assert.DoesNotContain("pre:covariant", recorder.Stages);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_interceptor_registered_against_the_message_itself_still_runs_on_it()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewExcludedCommand(), recorder.Commands());
+
+        // The attribute suppresses covariant matching only; an interceptor written for this
+        // message was written for it deliberately.
+        recorder.AssertStages("pre:direct", "handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewIncludedCommand(), recorder.Commands());
+
+        recorder.AssertStages("pre:covariant", "handler");
+    }
+}
+
+/// <summary>The exclusion types registered through generated descriptors.</summary>
+public static class KeyedExclusionTypes
+{
+    /// <summary>The axis-local supertype the covariant interceptor is registered against.</summary>
+    [ExcludeFromDiscovery]
+    public interface IAudited : ICommand;
+
+    /// <summary>The message carrying [ExcludeFromPipeline].</summary>
+    [DiscoveryKey("contract.exclude")]
+    [ExcludeFromPipeline]
+    public sealed class ExcludedCommand : IAudited;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.exclude")]
+    public sealed class ExcludedCommandHandler : PipelineExclusionContract.AuditedHandlerBase<ExcludedCommand>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.exclude")]
+    public sealed class ExcludedCommandDirectPre : PipelineExclusionContract.DirectPreBase<ExcludedCommand>;
+
+    /// <summary>Its sibling, same supertype, without the attribute.</summary>
+    [DiscoveryKey("contract.exclude")]
+    public sealed class IncludedCommand : IAudited;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.exclude")]
+    public sealed class IncludedCommandHandler : PipelineExclusionContract.AuditedHandlerBase<IncludedCommand>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.exclude")]
+    public sealed class AuditedPre : PipelineExclusionContract.CovariantPreBase<IAudited>;
+}
+
+/// <summary>The same shapes, hidden from the generator so <c>Register&lt;T&gt;()</c> is reflective.</summary>
+public static class FallbackExclusionTypes
+{
+    /// <inheritdoc cref="KeyedExclusionTypes.IAudited"/>
+    [ExcludeFromDiscovery]
+    public interface IAudited : ICommand;
+
+    /// <inheritdoc cref="KeyedExclusionTypes.ExcludedCommand"/>
+    [ExcludeFromDiscovery]
+    [ExcludeFromPipeline]
+    public sealed class ExcludedCommand : IAudited;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ExcludedCommandHandler : PipelineExclusionContract.AuditedHandlerBase<ExcludedCommand>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ExcludedCommandDirectPre : PipelineExclusionContract.DirectPreBase<ExcludedCommand>;
+
+    /// <inheritdoc cref="KeyedExclusionTypes.IncludedCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class IncludedCommand : IAudited;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class IncludedCommandHandler : PipelineExclusionContract.AuditedHandlerBase<IncludedCommand>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class AuditedPre : PipelineExclusionContract.CovariantPreBase<IAudited>;
+}
+
+/// <summary>The exclusion contract under generated (keyed) registration.</summary>
+public sealed class GeneratedRegistrationPipelineExclusionTests : PipelineExclusionContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ICommand NewExcludedCommand() => new KeyedExclusionTypes.ExcludedCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewIncludedCommand() => new KeyedExclusionTypes.IncludedCommand();
+}
+
+/// <summary>The same contract under explicit runtime registration.</summary>
+public sealed class RuntimeRegistrationPipelineExclusionTests : PipelineExclusionContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<FallbackExclusionTypes.ExcludedCommandHandler>()
+                    .Register<FallbackExclusionTypes.ExcludedCommandDirectPre>()
+                    .Register<FallbackExclusionTypes.IncludedCommandHandler>()
+                    .Register<FallbackExclusionTypes.AuditedPre>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ICommand NewExcludedCommand() => new FallbackExclusionTypes.ExcludedCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewIncludedCommand() => new FallbackExclusionTypes.IncludedCommand();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Handlers/MultipleMainHandlerTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Handlers/MultipleMainHandlerTests.cs
@@ -1,0 +1,230 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Handlers;
+
+/// <summary>
+/// What a dispatch does when two main handlers claim the same message. Single-handler
+/// mediation is the only mediation a command has, so this is a dispatch-time failure
+/// rather than a registration-time one — the registry accepts both handlers and the
+/// message stays broken for every container in the process.
+/// </summary>
+/// <remarks>
+/// These types stay keyed: a message with two handlers is disqualified from every
+/// compile-time plan by the sole-handler gate, so both axes reach the reflective mediation
+/// strategies. What the two axes do differ in is where the second descriptor comes from —
+/// the generator's pre-computed catalog on one side, reflective descriptor construction on
+/// the other.
+/// </remarks>
+public abstract class MultipleMainHandlerContract
+{
+    /// <summary>The discovery key this area registers under.</summary>
+    protected const string Key = "contract.multi";
+
+    /// <summary>Marks itself so a run that reached a handler can be told from one that did not.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class ContestedVoidHandlerBase<TCommand>(string slot) : ICommandHandler<TCommand>
+        where TCommand : class, ICommand
+    {
+        /// <inheritdoc />
+        public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+        {
+            context.Mark(slot);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="ContestedVoidHandlerBase{TCommand}"/>
+    [ExcludeFromDiscovery]
+    public abstract class ContestedResultHandlerBase<TCommand>(string slot) : ICommandHandler<TCommand, string>
+        where TCommand : class, ICommand<string>
+    {
+        /// <inheritdoc />
+        public ValueTask<string> HandleAsync(TCommand command, IExecutionContext context)
+        {
+            context.Mark(slot);
+            return ValueTask.FromResult(slot);
+        }
+    }
+
+    /// <summary>A container with this axis' contested messages registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The void command two handlers claim.</summary>
+    protected abstract ICommand NewContestedCommand();
+
+    /// <summary>The string-result command two handlers claim.</summary>
+    protected abstract ICommand<string> NewContestedResultCommand();
+
+    /// <summary>The simple name of the contested void command's type.</summary>
+    protected abstract string ContestedCommandName { get; }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Two_main_handlers_for_one_void_command_fail_the_dispatch_with_MultipleHandlerFoundException()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<MultipleHandlerFoundException>(
+            async () => await mediator.SendAsync(NewContestedCommand()));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Two_main_handlers_for_one_result_command_fail_the_dispatch_with_MultipleHandlerFoundException()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<MultipleHandlerFoundException>(
+            async () => await mediator.SendAsync(NewContestedResultCommand()));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_failure_names_the_message_type_and_how_many_handlers_claimed_it()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var thrown = await Assert.ThrowsAsync<MultipleHandlerFoundException>(
+            async () => await mediator.SendAsync(NewContestedCommand()));
+
+        Assert.Contains(ContestedCommandName, thrown.Message, StringComparison.Ordinal);
+        Assert.Contains("2", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Neither_handler_runs_when_two_claim_the_same_message()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder { Label = GetType().Name };
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<MultipleHandlerFoundException>(
+            async () => await mediator.SendAsync(NewContestedCommand(), recorder.Commands()));
+
+        // The count is checked before anything is resolved: the dispatch does not pick one
+        // handler, and it does not run both either.
+        Assert.Empty(recorder.Stages);
+    }
+}
+
+/// <summary>The contested messages registered through generated descriptors.</summary>
+public static class KeyedContestedTypes
+{
+    /// <summary>Void command two main handlers claim.</summary>
+    [DiscoveryKey("contract.multi")]
+    public sealed class ContestedCommand : ICommand;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.multi")]
+    public sealed class ContestedCommandFirstHandler()
+        : MultipleMainHandlerContract.ContestedVoidHandlerBase<ContestedCommand>("handler:first");
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.multi")]
+    public sealed class ContestedCommandSecondHandler()
+        : MultipleMainHandlerContract.ContestedVoidHandlerBase<ContestedCommand>("handler:second");
+
+    /// <summary>String-result command two main handlers claim.</summary>
+    [DiscoveryKey("contract.multi")]
+    public sealed class ContestedResultCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.multi")]
+    public sealed class ContestedResultCommandFirstHandler()
+        : MultipleMainHandlerContract.ContestedResultHandlerBase<ContestedResultCommand>("handler:first");
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.multi")]
+    public sealed class ContestedResultCommandSecondHandler()
+        : MultipleMainHandlerContract.ContestedResultHandlerBase<ContestedResultCommand>("handler:second");
+}
+
+/// <summary>The same shapes, hidden from the generator so <c>Register&lt;T&gt;()</c> is reflective.</summary>
+public static class FallbackContestedTypes
+{
+    /// <inheritdoc cref="KeyedContestedTypes.ContestedCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class ContestedCommand : ICommand;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ContestedCommandFirstHandler()
+        : MultipleMainHandlerContract.ContestedVoidHandlerBase<ContestedCommand>("handler:first");
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ContestedCommandSecondHandler()
+        : MultipleMainHandlerContract.ContestedVoidHandlerBase<ContestedCommand>("handler:second");
+
+    /// <inheritdoc cref="KeyedContestedTypes.ContestedResultCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class ContestedResultCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ContestedResultCommandFirstHandler()
+        : MultipleMainHandlerContract.ContestedResultHandlerBase<ContestedResultCommand>("handler:first");
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ContestedResultCommandSecondHandler()
+        : MultipleMainHandlerContract.ContestedResultHandlerBase<ContestedResultCommand>("handler:second");
+}
+
+/// <summary>The contested-message contract under generated (keyed) registration.</summary>
+public sealed class GeneratedRegistrationMultipleMainHandlerTests : MultipleMainHandlerContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ICommand NewContestedCommand() => new KeyedContestedTypes.ContestedCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewContestedResultCommand()
+        => new KeyedContestedTypes.ContestedResultCommand();
+
+    /// <inheritdoc />
+    protected override string ContestedCommandName => nameof(KeyedContestedTypes.ContestedCommand);
+}
+
+/// <summary>The same contract under explicit runtime registration.</summary>
+public sealed class RuntimeRegistrationMultipleMainHandlerTests : MultipleMainHandlerContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<FallbackContestedTypes.ContestedCommandFirstHandler>()
+                    .Register<FallbackContestedTypes.ContestedCommandSecondHandler>()
+                    .Register<FallbackContestedTypes.ContestedResultCommandFirstHandler>()
+                    .Register<FallbackContestedTypes.ContestedResultCommandSecondHandler>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ICommand NewContestedCommand() => new FallbackContestedTypes.ContestedCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewContestedResultCommand()
+        => new FallbackContestedTypes.ContestedResultCommand();
+
+    /// <inheritdoc />
+    protected override string ContestedCommandName => nameof(FallbackContestedTypes.ContestedCommand);
+}

--- a/test/Stella.Ergosfare.Contract.Test/Lifetime/HandlerLifetimeTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Lifetime/HandlerLifetimeTests.cs
@@ -3,6 +3,7 @@ using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Contract.Test.Runtime;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Generated;
 
@@ -13,6 +14,14 @@ namespace Stella.Ergosfare.Contract.Test.Lifetime;
 /// are contract because lifetime says so — the scenarios below never assert on pooling or
 /// caching, only on what a user's own DI registration promises.
 /// </summary>
+/// <remarks>
+/// Serialized with the registry-mutating scenarios, for the mirror-image reason: memoized
+/// instances are pinned to a registry version, so a registration landing anywhere in the
+/// process between two of these dispatches drops the memoized instance and the count moves.
+/// The scenarios do not mutate the registry — they are sensitive to anything that does.
+/// See the suite README, <em>Suspicious behaviors observed</em> 11.
+/// </remarks>
+[Collection(RegistryMutationCollection.Name)]
 public sealed class HandlerLifetimeTests
 {
     private const string Key = "contract.lifetime";

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -29,13 +29,19 @@ Source-generated registration is the primary axis: the generator is referenced a
 analyzer, and containers are built with `RegisterGenerated(<discovery key>)`. Explicit
 `Register<T>()` is the fallback axis — the path the generated one degrades to.
 
-The pipeline scenarios in [`Pipeline/`](Pipeline) run under **both**, sharing their code
-through `PipelineSemanticsContract`:
+Three areas run under **both** axes, each sharing its scenarios through an abstract
+contract class and closing it over a per-axis type set:
+
+| Area | Contract | Generated types | Fallback types |
+| --- | --- | --- | --- |
+| Pipeline semantics | `Pipeline/PipelineSemanticsContract.cs` | `Pipeline/GeneratedPipelineTypes.cs` | `Pipeline/FallbackPipelineTypes.cs` |
+| Synchronous interceptors | `Sync/SyncSemanticsContract.cs` | `Sync/GeneratedSyncTypes.cs` | `Sync/FallbackSyncTypes.cs` |
+| Post-interceptor abort | `Abort/PostAbortSemanticsContract.cs` | `Abort/GeneratedPostAbortTypes.cs` | `Abort/FallbackPostAbortTypes.cs` |
 
 | Axis | Types | Registration | Executors actually reached |
 | --- | --- | --- | --- |
-| `GeneratedRegistrationPipelineTests` | `Pipeline/GeneratedPipelineTypes.cs` — top-level, unkeyed, ungrouped | `RegisterGenerated()` | `StagedVoidPipelineExecutor`, `StagedResultPipelineExecutor`, `GeneratedVoidPipelineExecutor` + the emitted `StagedPlanN` classes |
-| `RuntimeRegistrationPipelineTests` | `Pipeline/FallbackPipelineTypes.cs` — `[ExcludeFromDiscovery]` | `Register<T>()` | `VoidPipelineExecutor`, `ResultPipelineExecutor` + `SingleAsyncHandlerMediationStrategy` |
+| `GeneratedRegistration*Tests` | top-level, unkeyed, ungrouped | `RegisterGenerated()` | `StagedVoidPipelineExecutor`, `StagedResultPipelineExecutor`, `GeneratedVoidPipelineExecutor` + the emitted `StagedPlanN` classes |
+| `RuntimeRegistration*Tests` | `[ExcludeFromDiscovery]` | `Register<T>()` | `VoidPipelineExecutor`, `ResultPipelineExecutor` + `SingleAsyncHandlerMediationStrategy` |
 
 Both halves of that table are load-bearing, and both are easy to break by accident:
 
@@ -45,7 +51,9 @@ Both halves of that table are load-bearing, and both are easy to break by accide
   additionally must not be nested). Adding a `[DiscoveryKey]` here still registers through
   generated descriptors — and silently dispatches on the reflective executors, testing
   nothing the fallback axis does not already cover. The pattern-less `RegisterGenerated()`
-  is therefore **reserved for this axis**.
+  is therefore **reserved for the three areas above**, and every type they declare is local
+  to its own area: a message type shared with another area, or an interceptor registered
+  against something outside the area, would cross-contaminate the shared unkeyed pool.
 - **The fallback axis must stay `[ExcludeFromDiscovery]`.** The generator's descriptor
   catalog is populated by a module initializer for *every* type it models, so a type the
   generator has seen gets pre-computed descriptors even when registered with
@@ -53,10 +61,27 @@ Both halves of that table are load-bearing, and both are easy to break by accide
 
 Every other area registers by its own discovery key (`contract.dispatch`,
 `contract.lifetime`, `contract.scope`, `contract.groups`, `contract.polymorphism`,
-`contract.events`, `contract.mutation`, `contract.context`, `contract.stream`), which is
-also what keeps the pattern-less call above selecting only the pipeline axis. Types that
-must never be auto-registered — never-registered messages, late-registered interceptors —
-carry `[ExcludeFromDiscovery]`.
+`contract.events`, `contract.mutation`, `contract.context`, `contract.stream`,
+`contract.sync`, `contract.multi`, `contract.exclude`), which is also what keeps the
+pattern-less call above selecting only the three axes. Types that must never be
+auto-registered — never-registered messages, late-registered interceptors — carry
+`[ExcludeFromDiscovery]`.
+
+Three of the keyed areas are keyed *because* no plan can serve them, so both of their axes
+reach the reflective path by construction and the key costs nothing:
+
+- **`contract.sync`** (`Sync/SyncMainHandlerTests.cs`) — the bare-result contracts
+  (`IHandler<T, object>`, `IHandler<T, string>`) put the bare result type in their
+  descriptor rather than the `ValueTask` carrier every plan computation matches against
+  (`ErgosfareRegistrationGenerator.cs:1668`), so they are disqualified before discovery
+  keys are even considered. The `ValueTask`-shaped ones must stay keyed for a different and
+  worse reason — see [suspicious behavior 10](#suspicious-behaviors-observed). Synchronous
+  *interceptors* are neither: they do reach the emitted plans, which is why they live on
+  the unkeyed axis above.
+- **`contract.multi`** (`Handlers/MultipleMainHandlerTests.cs`) — the sole-handler gate
+  drops any message with more than one main handler.
+- **`contract.exclude`** (`Exclusion/PipelineExclusionTests.cs`) — the generator skips
+  messages carrying `[ExcludeFromPipeline]` rather than modeling the exclusion.
 
 ## Rules for anyone adding tests here
 
@@ -68,9 +93,11 @@ the test process, and it never forgets. Everything below follows from that.
    else.
 2. **Give your area its own discovery key, and never call the pattern-less
    `RegisterGenerated()`.** That overload registers every default-discovery construct in
-   the assembly, and it belongs to `GeneratedRegistrationPipelineTests` alone (see
-   [Registration axes](#registration-axes)). An unkeyed message anywhere else joins that
-   axis' containers and breaks its plan expectations.
+   the assembly, and it belongs to the three both-axis areas alone (see
+   [Registration axes](#registration-axes)). An unkeyed message anywhere else joins those
+   containers and can break their plan expectations. Reach for it only when the scenario
+   genuinely needs to run inside an emitted plan — and then keep every type the scenario
+   declares local to the new area.
 3. **Never assert on registry contents or counts, and never assume an empty registry.** By
    the time your test runs, other classes have registered their types into the same
    registry.
@@ -173,6 +200,12 @@ it is a question that must be answered in the PR:
 - Unexpected: the lanes diverged. Stop and report; do not update the baseline to make the
   diff go away.
 
+One diff shape is mechanical rather than behavioral: the emitted plan classes are numbered
+positionally (`StagedPlan0`, `StagedPlan1`, …), so adding an unkeyed message that qualifies
+for a plan renumbers the existing ones. That shows up as changed frames inside untouched
+sections. It is only benign when every removed line is a `StagedPlanN` frame and the shift
+is uniform — check that before waving it through.
+
 Frames are captured from a `Debug` build; a `Release` capture inlines differently and is
 not comparable to this file.
 
@@ -220,13 +253,67 @@ than change by accident.
    exception stage, `null` on abort) for "there is no result."
 
 7. **The generated staged-plan code emits nullable warnings into the consumer's build.**
-   Building this project surfaces `CS8604` twice in
+   Building this project surfaces `CS8604` eight times per TFM in
    `ErgosfareRegistrations.g.cs` — the emitted staged result plan passes a
-   possibly-null `string` into `IAsyncPostInterceptor<TMessage, TResult>.HandleAsync`,
-   whose `messageResult` parameter is non-nullable. It appears for any reference-typed
-   result whose pipeline qualifies for a staged plan. Left unsuppressed on purpose: it is
-   the only warning in this project and it is evidence the staged-plan lane is being
-   exercised.
+   possibly-null `string` into the post-interceptor's non-nullable `messageResult`
+   parameter. It appears once per reference-typed post interceptor per emitted plan body
+   (the direct and the provider-resolved one), so the count tracks how many staged result
+   plans carry post interceptors: two for `PipelineResultCommand`, two for the synchronous
+   `SyncResultCommand`, four for `AbortResultCommand`'s two post slots. The synchronous
+   ones prove the arm is not async-only: `IPostInterceptor<TMessage, TResult>.Handle` has
+   the same non-nullable parameter. Left unsuppressed on purpose: these are the only
+   warnings in this project and they are evidence the staged-plan lane is being exercised.
+
+8. **A synchronous exception or final interceptor throws `NullReferenceException` on a
+   void pipeline.** The void pipeline carries a `ValueTask` in its result slot, but the
+   slot is still empty before the handler completes — and the synchronous contracts have no
+   result-agnostic flavor, so `FinalInterceptorInvocationStrategy.cs:59` (and its
+   exception-stage twin) unboxes that `null` into a `ValueTask` parameter. The emitted plan
+   does the same, through `ResultCast`'s `(ValueTask)result!`. Every failure path of such a
+   pipeline therefore ends in a `NullReferenceException`, which — thrown from a `finally` —
+   replaces both the handler's own exception and `ExecutionAbortedException`. Pinned by the
+   two `A_void_pipelines_synchronous_*` scenarios on both axes. Result-typed pipelines are
+   unaffected: `null` casts to `string?` and `default` boxes for value types.
+
+9. **A synchronous participant cannot be registered without a module marker.** The module
+   builders reject any type that is not assignable to `ICommand` / `IQuery` / `IEvent`
+   (`CommandModuleBuilder.Register`), and the module-flavored interceptor facades inherit
+   that marker themselves — `ICommandPreInterceptor<T> : ICommand`. The synchronous
+   contracts in `Core.Abstractions.Handlers` have no such facade, so a bare
+   `IPreInterceptor<T>` is silently skipped by `RegisterGenerated`, and the dispatch fails
+   later with `InvalidOperationException: No handler is registered for X`. Every
+   synchronous participant in this suite therefore declares `: ICommand, IPreInterceptor<T>`
+   — see `Sync/SyncContracts.cs`.
+
+10. **A `ValueTask`-shaped synchronous main handler breaks the consumer's build.** The plan
+    computations gate on the descriptor's result type, and `IHandler<T, ValueTask>` /
+    `IHandler<T, ValueTask<TResult>>` record exactly the carrier they look for — so an
+    unkeyed one qualifies and the generator emits `AddVoidPlan<TMessage, THandler>` /
+    `AddResultPlan<…>` for it. Those methods constrain `THandler` to `IAsyncHandler<…>`,
+    which a synchronous handler does not implement, and the emitted file fails to compile
+    with `CS0311`. Both shapes were verified by temporarily un-keying them; both fail. This
+    is why `Sync/SyncMainHandlerTests.cs` keeps its types keyed — a compile error cannot be
+    pinned by a test, so this entry is the record. The runtime is not at fault:
+    `VoidPipelineExecutor` and the mediation strategies both have a working arm for these
+    handlers, and the keyed axis exercises it.
+
+11. **A memoized handler instance survives only until the next registration anywhere in the
+    process.** `ForceMemoizedHandlers` caches the instance inside the handler reference held
+    by a `MessageDependencies` object, and that object is cached against the registry
+    version (`MessageDependenciesFactory.Create` →
+    `MessageDescriptorCache.InvalidateIfRegistryChanged`). Registering a *new* type — in any
+    container, for any unrelated message — bumps `MessageRegistry.Version`, drops the cache
+    and rebuilds the references, so the next dispatch constructs a fresh "memoized"
+    instance. Duplicate registrations are free; only genuinely new types bump.
+    <br />This one was found the hard way. `ForceMemoizedHandlers_reuses_one_instance_across_dispatches`
+    had been passing since the suite was written, but the phase-1 areas added six more
+    classes whose first container build registers new types, widening the window enough to
+    fail roughly one run in ten. It is not a test defect and not a race in the registry: a
+    registration between two dispatches genuinely resets memoization. The scenario is now in
+    `RegistryMutationCollection` so nothing registers beside it — the only change this phase
+    made to an existing test file, and the reason is this entry. Whether memoized instances
+    should survive a refresh is a live question for the plan lifecycle
+    (freeze → refresh → re-freeze), not something to paper over here.
 
 ## Where it runs
 

--- a/test/Stella.Ergosfare.Contract.Test/Sync/FallbackSyncTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/FallbackSyncTypes.cs
@@ -1,0 +1,109 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+// The synchronous-interceptor scenarios' types for the runtime-registration axis. Every
+// type here is excluded from discovery, so the generator models none of them: no
+// pre-computed descriptors and no compile-time plan, and the scenarios reach the
+// synchronous arms of the reflective invocation strategies instead of the emitted calls.
+// Excluding them is mandatory, not tidiness — the generator's descriptor catalog is filled
+// by a module initializer for every type it models, so a discoverable type would keep its
+// pre-computed descriptors even when registered with Register<T>().
+namespace Stella.Ergosfare.Contract.Test.Sync.Fallback;
+
+// --- void command, synchronous interceptors --------------------------------
+
+/// <inheritdoc cref="Generated.SyncCommand"/>
+[ExcludeFromDiscovery]
+public sealed class SyncCommand : ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncCommandHandler : SyncVoidHandlerBase<SyncCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncCommandPre : SyncVoidPreBase<SyncCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncCommandPost : SyncVoidPostBase<SyncCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncCommandException : SyncVoidExceptionBase<SyncCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncCommandFinal : SyncVoidFinalBase<SyncCommand>;
+
+// --- string-result command, synchronous interceptors -----------------------
+
+/// <inheritdoc cref="Generated.SyncResultCommand"/>
+[ExcludeFromDiscovery]
+public sealed class SyncResultCommand : ISyncPayloadResultCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncResultCommandHandler : SyncResultHandlerBase<SyncResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncResultCommandPre : SyncResultPreBase<SyncResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncResultCommandPost : SyncResultPostBase<SyncResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncResultCommandException : SyncResultExceptionBase<SyncResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncResultCommandFinal : SyncResultFinalBase<SyncResultCommand>;
+
+// --- stage ordering across the two flavors ---------------------------------
+
+/// <inheritdoc cref="Generated.SyncOrderedCommand"/>
+[ExcludeFromDiscovery]
+public sealed class SyncOrderedCommand : ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class SyncOrderedCommandHandler : SyncVoidHandlerBase<SyncOrderedCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(8)]
+public sealed class OrderedAsyncHighPre() : AsyncOrderedPreBase<SyncOrderedCommand>("pre:async-high");
+
+/// <inheritdoc cref="Generated.OrderedSyncMidPre"/>
+[ExcludeFromDiscovery]
+[Weight(6)]
+public sealed class OrderedSyncMidPre() : SyncOrderedPreBase<SyncOrderedCommand>("pre:sync-mid");
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(4)]
+public sealed class OrderedAsyncLowPre() : AsyncOrderedPreBase<SyncOrderedCommand>("pre:async-low");
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class OrderedSyncHighPost() : SyncOrderedPostBase<SyncOrderedCommand>("post:sync-high");
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(3)]
+public sealed class OrderedAsyncLowPost() : AsyncOrderedPostBase<SyncOrderedCommand>("post:async-low");

--- a/test/Stella.Ergosfare.Contract.Test/Sync/GeneratedRegistrationSyncTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/GeneratedRegistrationSyncTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Sync.Generated;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Sync;
+
+/// <summary>
+/// The synchronous interceptor contract under source-generated registration. The generator
+/// emits the staged plans for these messages, so the scenarios run the emitted
+/// <c>((IPreInterceptor&lt;T&gt;)x).Handle(...)</c> calls rather than the reflective
+/// invocation strategies.
+/// </summary>
+/// <remarks>
+/// The pattern-less overload is deliberate: plan eligibility requires default-discovery,
+/// top-level, ungrouped participants, so a keyed selection would quietly fall back to the
+/// reflective arms the other axis already covers.
+/// </remarks>
+public sealed class GeneratedRegistrationSyncTests : SyncSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ISyncPayloadCommand NewCommand(string payload) => new SyncCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override ISyncPayloadResultCommand NewResultCommand(string payload)
+        => new SyncResultCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override ISyncPayloadCommand NewOrderedCommand() => new SyncOrderedCommand();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Sync/GeneratedSyncTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/GeneratedSyncTypes.cs
@@ -1,0 +1,94 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Contract.Test.Sync.Generated;
+
+// The synchronous-interceptor scenarios' types for the source-generated registration axis.
+// They are top-level, unkeyed and ungrouped on purpose — the generator disqualifies keyed,
+// grouped and nested participants from its compile-time plans, and these scenarios exist to
+// run the emitted synchronous interceptor calls (`((IPreInterceptor<T>)x).Handle(...)` and
+// friends). A [DiscoveryKey] here would still register, still pass, and silently test only
+// what the fallback axis already covers.
+//
+// Every message type is local to this area and no interceptor is registered against a
+// module marker, so joining the assembly's unkeyed pool cannot reach another area's
+// pipelines.
+
+// --- void command, synchronous interceptors --------------------------------
+
+/// <summary>Void command whose interceptor stages are all synchronous.</summary>
+public sealed class SyncCommand : ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class SyncCommandHandler : SyncVoidHandlerBase<SyncCommand>;
+
+/// <inheritdoc />
+public sealed class SyncCommandPre : SyncVoidPreBase<SyncCommand>;
+
+/// <inheritdoc />
+public sealed class SyncCommandPost : SyncVoidPostBase<SyncCommand>;
+
+/// <inheritdoc />
+public sealed class SyncCommandException : SyncVoidExceptionBase<SyncCommand>;
+
+/// <inheritdoc />
+public sealed class SyncCommandFinal : SyncVoidFinalBase<SyncCommand>;
+
+// --- string-result command, synchronous interceptors -----------------------
+
+/// <summary>String-result command whose interceptor stages are all synchronous.</summary>
+public sealed class SyncResultCommand : ISyncPayloadResultCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class SyncResultCommandHandler : SyncResultHandlerBase<SyncResultCommand>;
+
+/// <inheritdoc />
+public sealed class SyncResultCommandPre : SyncResultPreBase<SyncResultCommand>;
+
+/// <inheritdoc />
+public sealed class SyncResultCommandPost : SyncResultPostBase<SyncResultCommand>;
+
+/// <inheritdoc />
+public sealed class SyncResultCommandException : SyncResultExceptionBase<SyncResultCommand>;
+
+/// <inheritdoc />
+public sealed class SyncResultCommandFinal : SyncResultFinalBase<SyncResultCommand>;
+
+// --- stage ordering across the two flavors ---------------------------------
+
+/// <summary>Void command whose stages interleave synchronous and asynchronous slots.</summary>
+public sealed class SyncOrderedCommand : ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class SyncOrderedCommandHandler : SyncVoidHandlerBase<SyncOrderedCommand>;
+
+/// <inheritdoc />
+[Weight(8)]
+public sealed class OrderedAsyncHighPre() : AsyncOrderedPreBase<SyncOrderedCommand>("pre:async-high");
+
+/// <summary>Sits between the two asynchronous slots, so flavor cannot be what orders them.</summary>
+[Weight(6)]
+public sealed class OrderedSyncMidPre() : SyncOrderedPreBase<SyncOrderedCommand>("pre:sync-mid");
+
+/// <inheritdoc />
+[Weight(4)]
+public sealed class OrderedAsyncLowPre() : AsyncOrderedPreBase<SyncOrderedCommand>("pre:async-low");
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class OrderedSyncHighPost() : SyncOrderedPostBase<SyncOrderedCommand>("post:sync-high");
+
+/// <inheritdoc />
+[Weight(3)]
+public sealed class OrderedAsyncLowPost() : AsyncOrderedPostBase<SyncOrderedCommand>("post:async-low");

--- a/test/Stella.Ergosfare.Contract.Test/Sync/RuntimeRegistrationSyncTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/RuntimeRegistrationSyncTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Sync.Fallback;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.Sync;
+
+/// <summary>
+/// The same synchronous interceptor contract under explicit runtime registration. No
+/// generated descriptor or plan exists for these types, so every stage resolves through
+/// the reflective invocation strategies and their synchronous pattern-match arms.
+/// </summary>
+/// <remarks>
+/// The ordering scenario registers each stage's slots out of weight order on purpose: if
+/// registration order decided the sequence, the inherited expectation would fail here and
+/// pass on the generated axis.
+/// </remarks>
+public sealed class RuntimeRegistrationSyncTests : SyncSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<SyncCommandHandler>()
+                    .Register<SyncCommandPre>()
+                    .Register<SyncCommandPost>()
+                    .Register<SyncCommandException>()
+                    .Register<SyncCommandFinal>()
+                    .Register<SyncResultCommandHandler>()
+                    .Register<SyncResultCommandPre>()
+                    .Register<SyncResultCommandPost>()
+                    .Register<SyncResultCommandException>()
+                    .Register<SyncResultCommandFinal>()
+                    .Register<SyncOrderedCommandHandler>()
+                    .Register<OrderedAsyncLowPre>()
+                    .Register<OrderedSyncMidPre>()
+                    .Register<OrderedAsyncHighPre>()
+                    .Register<OrderedAsyncLowPost>()
+                    .Register<OrderedSyncHighPost>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ISyncPayloadCommand NewCommand(string payload) => new SyncCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override ISyncPayloadResultCommand NewResultCommand(string payload)
+        => new SyncResultCommand { Payload = payload };
+
+    /// <inheritdoc />
+    protected override ISyncPayloadCommand NewOrderedCommand() => new SyncOrderedCommand();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Sync/SyncContracts.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/SyncContracts.cs
@@ -1,0 +1,302 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Contract.Test.Sync;
+
+/// <summary>
+/// The synchronous participants' shared vocabulary and behavior. Each registration axis
+/// closes these bases over its own concrete message types, so the axes run byte-identical
+/// participant code and any difference the scenarios see is a difference in registration.
+/// </summary>
+/// <remarks>
+/// Everything here is excluded from discovery: these are shapes, not registrable
+/// constructs. Exclusion is not inherited, so the closing types stay discoverable.
+/// <para>
+/// Every interceptor base also implements the module marker (<see cref="ICommand"/>). That
+/// is not decoration: <c>CommandModuleBuilder</c> rejects any type that is not assignable
+/// to <see cref="ICommand"/>, and the synchronous contracts in
+/// <c>Stella.Ergosfare.Core.Abstractions.Handlers</c> have no module-flavored facade to
+/// inherit it from — unlike <c>ICommandPreInterceptor&lt;T&gt;</c> and friends, which
+/// extend <see cref="ICommand"/> themselves. A bare <c>IPreInterceptor&lt;T&gt;</c> cannot
+/// be registered at all; see the suite README.
+/// </para>
+/// </remarks>
+public static class SyncVocabulary
+{
+    /// <summary>Payload marker that makes a handler throw.</summary>
+    public const string Throw = "throw";
+
+    /// <summary>Payload marker that makes a pre-interceptor abort.</summary>
+    public const string Abort = "abort";
+
+    /// <summary>Suffix a synchronous pre-interceptor appends when it rewrites the message.</summary>
+    public const string Rewritten = "+sync-pre";
+
+    /// <summary>Suffix a synchronous post-interceptor appends to a string result.</summary>
+    public const string Posted = "+sync-post";
+
+    /// <summary>What a synchronous string exception interceptor falls back to.</summary>
+    public const string StringFallback = "sync-fallback";
+
+    /// <summary>Renders a stage's result argument for the recorder.</summary>
+    public static string Describe(object? result) => result switch
+    {
+        null => "null",
+        string text => text,
+        ValueTask => nameof(ValueTask),
+        _ => result.ToString() ?? result.GetType().Name,
+    };
+
+    /// <summary>Renders a stage's exception argument for the recorder.</summary>
+    public static string Describe(Exception? exception)
+        => exception is null ? "none" : exception.GetType().Name;
+}
+
+/// <summary>The exception a scenario's handler throws, distinguishable from framework ones.</summary>
+public sealed class SyncFailure(string message) : Exception(message);
+
+/// <summary>A void command carrying the payload that drives its scenario.</summary>
+[ExcludeFromDiscovery]
+public interface ISyncPayloadCommand : ICommand
+{
+    /// <summary>Drives handler/interceptor behavior and records what each stage saw.</summary>
+    string Payload { get; set; }
+}
+
+/// <summary>A string-result command carrying the payload that drives its scenario.</summary>
+[ExcludeFromDiscovery]
+public interface ISyncPayloadResultCommand : ICommand<string>
+{
+    /// <inheritdoc cref="ISyncPayloadCommand.Payload"/>
+    string Payload { get; set; }
+}
+
+// ---------------------------------------------------------------------------
+// void pipeline — asynchronous handler, synchronous interceptors
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// The main handler stays asynchronous on purpose: a synchronous main handler disqualifies
+/// its message from every compile-time plan, and these scenarios exist to run the emitted
+/// synchronous interceptor calls. <see cref="SyncMainHandlerContract"/> covers the
+/// synchronous main-handler contracts themselves.
+/// </summary>
+[ExcludeFromDiscovery]
+public abstract class SyncVoidHandlerBase<TCommand> : ICommandHandler<TCommand>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler", command.Payload);
+
+        if (command.Payload.Contains(SyncVocabulary.Throw, StringComparison.Ordinal))
+        {
+            throw new SyncFailure("sync-area void handler failed");
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Aborts when asked, otherwise hands the handler a rewritten message.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncVoidPreBase<TCommand> : ICommand, IPreInterceptor<TCommand>
+    where TCommand : class, ISyncPayloadCommand, new()
+{
+    /// <inheritdoc />
+    public object Handle(TCommand message, IExecutionContext context)
+    {
+        context.Mark("pre", message.Payload);
+
+        if (message.Payload.Contains(SyncVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort();
+        }
+
+        return new TCommand { Payload = message.Payload + SyncVocabulary.Rewritten };
+    }
+}
+
+/// <summary>Records the message and result a synchronous void post-interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncVoidPostBase<TCommand> : ICommand, IPostInterceptor<TCommand, ValueTask>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public object Handle(TCommand message, ValueTask messageResult, IExecutionContext context)
+    {
+        context.Mark("post", $"{message.Payload}|{SyncVocabulary.Describe(messageResult)}");
+        return messageResult;
+    }
+}
+
+/// <summary>
+/// Records everything a synchronous void exception interceptor is handed — when it is
+/// reached at all. There is no result-agnostic synchronous flavor, so the void pipeline's
+/// empty result slot meets a <see cref="ValueTask"/>-typed parameter here.
+/// </summary>
+[ExcludeFromDiscovery]
+public abstract class SyncVoidExceptionBase<TCommand> : ICommand, IExceptionInterceptor<TCommand, ValueTask>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public object? Handle(TCommand message, ValueTask messageResult, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception",
+            $"{message.Payload}|{SyncVocabulary.Describe(messageResult)}|{SyncVocabulary.Describe(exception)}");
+
+        return messageResult;
+    }
+}
+
+/// <inheritdoc cref="SyncVoidExceptionBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class SyncVoidFinalBase<TCommand> : ICommand, IFinalInterceptor<TCommand, ValueTask>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public void Handle(TCommand message, ValueTask result, Exception? exception, IExecutionContext executionContext)
+        => executionContext.Mark("final",
+            $"{message.Payload}|{SyncVocabulary.Describe(result)}|{SyncVocabulary.Describe(exception)}");
+}
+
+// ---------------------------------------------------------------------------
+// string-result pipeline — asynchronous handler, synchronous interceptors
+// ---------------------------------------------------------------------------
+
+/// <inheritdoc cref="SyncVoidHandlerBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class SyncResultHandlerBase<TCommand> : ICommandHandler<TCommand, string>
+    where TCommand : class, ISyncPayloadResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler", command.Payload);
+
+        if (command.Payload.Contains(SyncVocabulary.Throw, StringComparison.Ordinal))
+        {
+            throw new SyncFailure("sync-area result handler failed");
+        }
+
+        return ValueTask.FromResult(command.Payload);
+    }
+}
+
+/// <inheritdoc cref="SyncVoidPreBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class SyncResultPreBase<TCommand> : ICommand, IPreInterceptor<TCommand>
+    where TCommand : class, ISyncPayloadResultCommand, new()
+{
+    /// <inheritdoc />
+    public object Handle(TCommand message, IExecutionContext context)
+    {
+        context.Mark("pre", message.Payload);
+
+        if (message.Payload.Contains(SyncVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort();
+        }
+
+        return new TCommand { Payload = message.Payload + SyncVocabulary.Rewritten };
+    }
+}
+
+/// <summary>Rewrites the handler's result on its way to the caller.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncResultPostBase<TCommand> : ICommand, IPostInterceptor<TCommand, string>
+    where TCommand : class, ISyncPayloadResultCommand
+{
+    /// <inheritdoc />
+    public object Handle(TCommand message, string messageResult, IExecutionContext context)
+    {
+        context.Mark("post", $"{message.Payload}|{messageResult}");
+        return messageResult + SyncVocabulary.Posted;
+    }
+}
+
+/// <summary>Substitutes a fallback result for the handler's exception.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncResultExceptionBase<TCommand> : ICommand, IExceptionInterceptor<TCommand, string>
+    where TCommand : class, ISyncPayloadResultCommand
+{
+    /// <inheritdoc />
+    public object? Handle(TCommand message, string? messageResult, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception",
+            $"{message.Payload}|{SyncVocabulary.Describe(messageResult)}|{SyncVocabulary.Describe(exception)}");
+
+        return SyncVocabulary.StringFallback;
+    }
+}
+
+/// <summary>Records everything a synchronous string-result final interceptor is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncResultFinalBase<TCommand> : ICommand, IFinalInterceptor<TCommand, string>
+    where TCommand : class, ISyncPayloadResultCommand
+{
+    /// <inheritdoc />
+    public void Handle(TCommand message, string? result, Exception? exception, IExecutionContext executionContext)
+        => executionContext.Mark("final",
+            $"{message.Payload}|{SyncVocabulary.Describe(result)}|{SyncVocabulary.Describe(exception)}");
+}
+
+// ---------------------------------------------------------------------------
+// stage ordering across the two flavors
+// ---------------------------------------------------------------------------
+
+/// <summary>A synchronous pre-interceptor that only announces which slot it is.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncOrderedPreBase<TCommand>(string slot) : ICommand, IPreInterceptor<TCommand>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public object Handle(TCommand message, IExecutionContext context)
+    {
+        context.Mark(slot);
+        return message;
+    }
+}
+
+/// <summary>An asynchronous pre-interceptor that only announces which slot it is.</summary>
+[ExcludeFromDiscovery]
+public abstract class AsyncOrderedPreBase<TCommand>(string slot) : ICommandPreInterceptor<TCommand>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark(slot);
+        return ValueTask.FromResult(command);
+    }
+}
+
+/// <summary>A synchronous post-interceptor that only announces which slot it is.</summary>
+[ExcludeFromDiscovery]
+public abstract class SyncOrderedPostBase<TCommand>(string slot) : ICommand, IPostInterceptor<TCommand, ValueTask>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public object Handle(TCommand message, ValueTask messageResult, IExecutionContext context)
+    {
+        context.Mark(slot);
+        return messageResult;
+    }
+}
+
+/// <summary>An asynchronous post-interceptor that only announces which slot it is.</summary>
+[ExcludeFromDiscovery]
+public abstract class AsyncOrderedPostBase<TCommand>(string slot) : ICommandPostInterceptor<TCommand>
+    where TCommand : class, ISyncPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand command, object result, IExecutionContext context)
+    {
+        context.Mark(slot);
+        return ValueTask.FromResult(result);
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/Sync/SyncMainHandlerTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/SyncMainHandlerTests.cs
@@ -1,0 +1,392 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Sync;
+
+/// <summary>
+/// The four synchronous main-handler contracts a dispatch can resolve — the bare-result and
+/// the <see cref="ValueTask"/>-shaped form of both the void and the result pipeline. Each is
+/// one arm of the handler pattern match the modernization removes, and each is exercised
+/// twice: once without interceptors, where the executor invokes the handler itself, and once
+/// with an interceptor, where the mediation strategy does.
+/// </summary>
+/// <remarks>
+/// These types stay keyed on purpose. A synchronous main handler carries the bare result type
+/// in its descriptor rather than the <c>ValueTask</c> carrier the plan computations require,
+/// so no compile-time plan can ever serve it — both axes here reach the reflective path, and
+/// the fallback axis is what pins the reflective loop the target architecture keeps. The
+/// synchronous <em>interceptor</em> contracts, which do reach the emitted plans, live in
+/// <see cref="SyncSemanticsContract"/>.
+/// </remarks>
+public abstract class SyncMainHandlerContract
+{
+    /// <summary>The discovery key this area registers under.</summary>
+    protected const string Key = "contract.sync";
+
+    /// <summary>Marks the handler and reports which contract served the dispatch.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class VoidObjectHandlerBase<TCommand> : ICommand, IHandler<TCommand, object>
+        where TCommand : class, ICommand
+    {
+        /// <inheritdoc />
+        public object Handle(TCommand message, IExecutionContext context)
+        {
+            context.Mark("handler", "IHandler<T,object>");
+            return "ignored";
+        }
+    }
+
+    /// <inheritdoc cref="VoidObjectHandlerBase{TCommand}"/>
+    [ExcludeFromDiscovery]
+    public abstract class VoidTaskHandlerBase<TCommand> : ICommand, IHandler<TCommand, ValueTask>
+        where TCommand : class, ICommand
+    {
+        /// <inheritdoc />
+        public ValueTask Handle(TCommand message, IExecutionContext context)
+        {
+            context.Mark("handler", "IHandler<T,ValueTask>");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="VoidObjectHandlerBase{TCommand}"/>
+    [ExcludeFromDiscovery]
+    public abstract class ResultStringHandlerBase<TCommand> : ICommand, IHandler<TCommand, string>
+        where TCommand : class, ICommand<string>
+    {
+        /// <inheritdoc />
+        public string Handle(TCommand message, IExecutionContext context)
+        {
+            context.Mark("handler", "IHandler<T,string>");
+            return "sync-value";
+        }
+    }
+
+    /// <inheritdoc cref="VoidObjectHandlerBase{TCommand}"/>
+    [ExcludeFromDiscovery]
+    public abstract class ResultTaskHandlerBase<TCommand> : ICommand, IHandler<TCommand, ValueTask<string>>
+        where TCommand : class, ICommand<string>
+    {
+        /// <inheritdoc />
+        public ValueTask<string> Handle(TCommand message, IExecutionContext context)
+        {
+            context.Mark("handler", "IHandler<T,ValueTask<string>>");
+            return ValueTask.FromResult("sync-task-value");
+        }
+    }
+
+    /// <summary>Forces the interceptor-carrying path, where the strategy resolves the handler.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class GatePreBase<TCommand> : ICommandPreInterceptor<TCommand>
+        where TCommand : class, ICommand
+    {
+        /// <inheritdoc />
+        public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
+        {
+            context.Mark("pre");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    /// <summary>A container with this axis' synchronous main handlers registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>Void command served by an <c>IHandler&lt;T, object&gt;</c>, no interceptors.</summary>
+    protected abstract ICommand NewVoidObjectCommand();
+
+    /// <summary>Void command served by an <c>IHandler&lt;T, ValueTask&gt;</c>, no interceptors.</summary>
+    protected abstract ICommand NewVoidTaskCommand();
+
+    /// <summary>String command served by an <c>IHandler&lt;T, string&gt;</c>, no interceptors.</summary>
+    protected abstract ICommand<string> NewResultStringCommand();
+
+    /// <summary>String command served by an <c>IHandler&lt;T, ValueTask&lt;string&gt;&gt;</c>, no interceptors.</summary>
+    protected abstract ICommand<string> NewResultTaskCommand();
+
+    /// <summary>Void command served by an <c>IHandler&lt;T, object&gt;</c> behind an interceptor.</summary>
+    protected abstract ICommand NewInterceptedVoidCommand();
+
+    /// <summary>String command served by an <c>IHandler&lt;T, string&gt;</c> behind an interceptor.</summary>
+    protected abstract ICommand<string> NewInterceptedResultCommand();
+
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_void_handler_serves_a_dispatch()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewVoidObjectCommand(), recorder.Commands());
+
+        recorder.AssertStages("handler");
+        Assert.Equal("IHandler<T,object>", recorder.DetailOf("handler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewVoidTaskCommand(), recorder.Commands());
+
+        recorder.AssertStages("handler");
+        Assert.Equal("IHandler<T,ValueTask>", recorder.DetailOf("handler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_handler_returns_its_value_to_the_caller()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultStringCommand(), recorder.Commands());
+
+        recorder.AssertStages("handler");
+        Assert.Equal("sync-value", result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultTaskCommand(), recorder.Commands());
+
+        recorder.AssertStages("handler");
+        Assert.Equal("sync-task-value", result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewInterceptedVoidCommand(), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler");
+        Assert.Equal("IHandler<T,object>", recorder.DetailOf("handler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_handler_behind_an_interceptor_still_returns_its_value()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewInterceptedResultCommand(), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler");
+        Assert.Equal("sync-value", result);
+    }
+}
+
+/// <summary>The synchronous main-handler types registered through generated descriptors.</summary>
+public static class KeyedSyncMainTypes
+{
+    /// <summary>Void command served by a bare-result synchronous handler, no interceptors.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class VoidObjectCommand : ICommand;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class VoidObjectHandler : SyncMainHandlerContract.VoidObjectHandlerBase<VoidObjectCommand>;
+
+    /// <summary>Void command served by a ValueTask-shaped synchronous handler.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class VoidTaskCommand : ICommand;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class VoidTaskHandler : SyncMainHandlerContract.VoidTaskHandlerBase<VoidTaskCommand>;
+
+    /// <summary>String command served by a bare-result synchronous handler.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class ResultStringCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class ResultStringHandler : SyncMainHandlerContract.ResultStringHandlerBase<ResultStringCommand>;
+
+    /// <summary>String command served by a ValueTask-shaped synchronous handler.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class ResultTaskCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class ResultTaskHandler : SyncMainHandlerContract.ResultTaskHandlerBase<ResultTaskCommand>;
+
+    /// <summary>Void command whose synchronous handler sits behind an interceptor.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedVoidCommand : ICommand;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedVoidHandler : SyncMainHandlerContract.VoidObjectHandlerBase<InterceptedVoidCommand>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedVoidPre : SyncMainHandlerContract.GatePreBase<InterceptedVoidCommand>;
+
+    /// <summary>String command whose synchronous handler sits behind an interceptor.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedResultCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedResultHandler : SyncMainHandlerContract.ResultStringHandlerBase<InterceptedResultCommand>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedResultPre : SyncMainHandlerContract.GatePreBase<InterceptedResultCommand>;
+}
+
+/// <summary>The same shapes, hidden from the generator so <c>Register&lt;T&gt;()</c> is reflective.</summary>
+public static class FallbackSyncMainTypes
+{
+    /// <inheritdoc cref="KeyedSyncMainTypes.VoidObjectCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class VoidObjectCommand : ICommand;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class VoidObjectHandler : SyncMainHandlerContract.VoidObjectHandlerBase<VoidObjectCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.VoidTaskCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class VoidTaskCommand : ICommand;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class VoidTaskHandler : SyncMainHandlerContract.VoidTaskHandlerBase<VoidTaskCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.ResultStringCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class ResultStringCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ResultStringHandler : SyncMainHandlerContract.ResultStringHandlerBase<ResultStringCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.ResultTaskCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class ResultTaskCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class ResultTaskHandler : SyncMainHandlerContract.ResultTaskHandlerBase<ResultTaskCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.InterceptedVoidCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedVoidCommand : ICommand;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedVoidHandler : SyncMainHandlerContract.VoidObjectHandlerBase<InterceptedVoidCommand>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedVoidPre : SyncMainHandlerContract.GatePreBase<InterceptedVoidCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.InterceptedResultCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedResultCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedResultHandler : SyncMainHandlerContract.ResultStringHandlerBase<InterceptedResultCommand>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedResultPre : SyncMainHandlerContract.GatePreBase<InterceptedResultCommand>;
+}
+
+/// <summary>The synchronous main-handler contract under generated (keyed) registration.</summary>
+public sealed class GeneratedRegistrationSyncMainHandlerTests : SyncMainHandlerContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ICommand NewVoidObjectCommand() => new KeyedSyncMainTypes.VoidObjectCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewVoidTaskCommand() => new KeyedSyncMainTypes.VoidTaskCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewResultStringCommand() => new KeyedSyncMainTypes.ResultStringCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewResultTaskCommand() => new KeyedSyncMainTypes.ResultTaskCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewInterceptedVoidCommand() => new KeyedSyncMainTypes.InterceptedVoidCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewInterceptedResultCommand()
+        => new KeyedSyncMainTypes.InterceptedResultCommand();
+}
+
+/// <summary>The same contract under explicit runtime registration.</summary>
+public sealed class RuntimeRegistrationSyncMainHandlerTests : SyncMainHandlerContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<FallbackSyncMainTypes.VoidObjectHandler>()
+                    .Register<FallbackSyncMainTypes.VoidTaskHandler>()
+                    .Register<FallbackSyncMainTypes.ResultStringHandler>()
+                    .Register<FallbackSyncMainTypes.ResultTaskHandler>()
+                    .Register<FallbackSyncMainTypes.InterceptedVoidHandler>()
+                    .Register<FallbackSyncMainTypes.InterceptedVoidPre>()
+                    .Register<FallbackSyncMainTypes.InterceptedResultHandler>()
+                    .Register<FallbackSyncMainTypes.InterceptedResultPre>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override ICommand NewVoidObjectCommand() => new FallbackSyncMainTypes.VoidObjectCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewVoidTaskCommand() => new FallbackSyncMainTypes.VoidTaskCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewResultStringCommand() => new FallbackSyncMainTypes.ResultStringCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewResultTaskCommand() => new FallbackSyncMainTypes.ResultTaskCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewInterceptedVoidCommand() => new FallbackSyncMainTypes.InterceptedVoidCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewInterceptedResultCommand()
+        => new FallbackSyncMainTypes.InterceptedResultCommand();
+}

--- a/test/Stella.Ergosfare.Contract.Test/Sync/SyncSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/SyncSemanticsContract.cs
@@ -1,0 +1,217 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+
+namespace Stella.Ergosfare.Contract.Test.Sync;
+
+/// <summary>
+/// What the synchronous interceptor contracts do inside a pipeline: which stage each
+/// flavor serves, what it is handed, and how it orders against its asynchronous twins.
+/// Both registration axes inherit these scenarios verbatim, so a divergence between the
+/// emitted synchronous calls and the reflective synchronous arms shows up as one subclass
+/// failing.
+/// </summary>
+/// <remarks>
+/// The main handlers here are asynchronous: a synchronous main handler disqualifies its
+/// message from every compile-time plan, so it could never exercise the emitted calls.
+/// <see cref="SyncMainHandlerContract"/> covers the synchronous main-handler contracts.
+/// </remarks>
+public abstract class SyncSemanticsContract
+{
+    /// <summary>A container with this axis' synchronous types registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The void command whose interceptor stages are all synchronous.</summary>
+    protected abstract ISyncPayloadCommand NewCommand(string payload);
+
+    /// <summary>The string-result command whose interceptor stages are all synchronous.</summary>
+    protected abstract ISyncPayloadResultCommand NewResultCommand(string payload);
+
+    /// <summary>The command whose stages interleave the two flavors.</summary>
+    protected abstract ISyncPayloadCommand NewOrderedCommand();
+
+    /// <summary>
+    /// A recorder stamped with the running axis, so a diagnostic dump of these shared
+    /// scenarios says which registration path produced each trace.
+    /// </summary>
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    // -----------------------------------------------------------------------
+    // void pipeline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("ok"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "post", "final");
+        Assert.Equal("ok", recorder.DetailOf("pre"));
+        Assert.Equal("ok" + SyncVocabulary.Rewritten, recorder.DetailOf("handler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_void_post_interceptor_is_handed_the_pipelines_completed_task()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("ok"), recorder.Commands());
+
+        Assert.Equal($"ok{SyncVocabulary.Rewritten}|{nameof(ValueTask)}", recorder.DetailOf("post"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_void_final_interceptor_sees_the_completed_task_and_no_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewCommand("ok"), recorder.Commands());
+
+        Assert.Equal($"ok{SyncVocabulary.Rewritten}|{nameof(ValueTask)}|none", recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Suspicious behavior, pinned as observed: the empty result slot of a void pipeline
+        // is unboxed into the ValueTask-typed parameter of the synchronous exception and
+        // final contracts. Both throw, the second one from a finally block, so the caller
+        // never sees the handler's own exception. See the suite README.
+        await Assert.ThrowsAsync<NullReferenceException>(
+            async () => await mediator.SendAsync(NewCommand("throw"), recorder.Commands()));
+
+        recorder.AssertStages("pre", "handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Same unboxing, reached through the abort path: ExecutionAbortedException never
+        // reaches the caller either.
+        await Assert.ThrowsAsync<NullReferenceException>(
+            async () => await mediator.SendAsync(NewCommand("abort"), recorder.Commands()));
+
+        recorder.AssertStages("pre");
+    }
+
+    // -----------------------------------------------------------------------
+    // string-result pipeline
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("ok"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "post", "final");
+        Assert.Equal($"ok{SyncVocabulary.Rewritten}{SyncVocabulary.Posted}", result);
+        Assert.Equal($"ok{SyncVocabulary.Rewritten}|ok{SyncVocabulary.Rewritten}", recorder.DetailOf("post"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_final_interceptor_receives_the_post_rewritten_result()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("ok"), recorder.Commands());
+
+        Assert.Equal(
+            $"ok{SyncVocabulary.Rewritten}|ok{SyncVocabulary.Rewritten}{SyncVocabulary.Posted}|none",
+            recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("throw"), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler", "exception", "final");
+        Assert.Equal($"throw{SyncVocabulary.Rewritten}|null|{nameof(SyncFailure)}", recorder.DetailOf("exception"));
+        Assert.Equal(SyncVocabulary.StringFallback, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_synchronous_final_interceptor_runs_after_a_handled_exception_and_receives_it()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewResultCommand("throw"), recorder.Commands());
+
+        Assert.Equal(
+            $"throw{SyncVocabulary.Rewritten}|{SyncVocabulary.StringFallback}|{nameof(SyncFailure)}",
+            recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<ExecutionAbortedException>(
+            async () => await mediator.SendAsync(NewResultCommand("abort"), recorder.Commands()));
+
+        recorder.AssertStages("pre", "final");
+        Assert.Equal("abort|null|none", recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // stage ordering across the two flavors
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Synchronous_and_asynchronous_interceptors_share_one_weight_order()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewOrderedCommand(), recorder.Commands());
+
+        recorder.AssertStages(
+            "pre:async-high", "pre:sync-mid", "pre:async-low",
+            "handler",
+            "post:sync-high", "post:async-low");
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -1,3 +1,57 @@
+GeneratedRegistrationPipelineExclusionTests — stages: [pre:covariant, handler]
+  1. pre:covariant
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+CovariantPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+AuditedHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineExclusionTests — stages: [pre:direct, handler]
+  1. pre:direct
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.An_interceptor_registered_against_the_message_itself_still_runs_on_it
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<An_interceptor_registered_against_the_message_itself_still_runs_on_it>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+DirectPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.An_interceptor_registered_against_the_message_itself_still_runs_on_it
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<An_interceptor_registered_against_the_message_itself_still_runs_on_it>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+AuditedHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
 GeneratedRegistrationPipelineTests — stages: [handler]
   1. handler  <- throw
      | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered
@@ -19,8 +73,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
              | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
                | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
                  | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                        | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                          | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                            | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -33,8 +87,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
              | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
                | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
                  | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -47,8 +101,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
              | Stella.Ergosfare.Commands.CommandMediator.SendAsync
                | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
                  | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                        | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                          | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                            | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -61,8 +115,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
              | Stella.Ergosfare.Commands.CommandMediator.SendAsync
                | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
                  | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -75,8 +129,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
              | Stella.Ergosfare.Commands.CommandMediator.SendAsync
                | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
                  | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                        | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                          | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                            | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -89,8 +143,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
              | Stella.Ergosfare.Commands.CommandMediator.SendAsync
                | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
                  | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -101,8 +155,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -113,8 +167,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|null|PipelineFailure
@@ -123,8 +177,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultExceptionBase`1.HandleAsync
@@ -135,8 +189,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -147,8 +201,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -159,8 +213,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|0|PipelineFailure
@@ -169,8 +223,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TQuery,TResult>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueExceptionBase`1.HandleAsync
@@ -181,8 +235,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -193,8 +247,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -205,8 +259,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|null|PipelineFailure
@@ -215,8 +269,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadExceptionBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+rewritten|ValueTask|PipelineFailure
@@ -225,8 +279,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -237,8 +291,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -249,8 +303,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|ok+rewritten
@@ -259,8 +313,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPostBase`1.HandleAsync
@@ -271,8 +325,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -283,8 +337,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -295,8 +349,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|ValueTask
@@ -305,8 +359,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+rewritten|ValueTask|none
@@ -315,8 +369,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -327,8 +381,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -339,8 +393,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|7
@@ -349,8 +403,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePostBase`1.HandleAsync
@@ -361,8 +415,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -373,8 +427,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -385,8 +439,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -397,8 +451,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -409,8 +463,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -421,8 +475,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   6. post:high
@@ -431,8 +485,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   7. post:low
@@ -441,10 +495,534 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__7.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__7.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortVoidHandlerBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort  <- ValueTask
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortingVoidPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- ValueTask|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortVoidFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortResultHandlerBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort  <- produced
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortingResultPostBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- produced|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortQueryHandlerBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort  <- 7
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortingQueryPostBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- 7|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,ValueTask<string>>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultTaskHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,ValueTask>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidTaskHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,object>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_void_handler_serves_a_dispatch
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_void_handler_serves_a_dispatch>d__14.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidObjectHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,string>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_handler_returns_its_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_handler_returns_its_value_to_the_caller>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultStringHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__19.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,string>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__19.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultStringHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__18.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,object>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__18.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidObjectHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+sync-pre|null|SyncFailure
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultExceptionBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+sync-pre|sync-fallback|SyncFailure
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+sync-pre|ok+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultPostBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+sync-pre|ok+sync-pre+sync-post|none
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+sync-pre|ValueTask
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPostBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+sync-pre|ValueTask|none
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre, handler]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0.<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0+<<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0.<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0+<<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:async-low, handler, post:sync-high, post:async-low]
+  1. pre:async-high
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. pre:sync-mid
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPreBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. pre:async-low
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. handler  <- 
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  5. post:sync-high
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPostBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  6. post:async-low
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__7.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPostBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncTests — stages: [pre]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0.<A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0+<<A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__7.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineExclusionTests — stages: [pre:covariant, handler]
+  1. pre:covariant
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+CovariantPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+AuditedHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineExclusionTests — stages: [pre:direct, handler]
+  1. pre:direct
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.An_interceptor_registered_against_the_message_itself_still_runs_on_it
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<An_interceptor_registered_against_the_message_itself_still_runs_on_it>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+DirectPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.An_interceptor_registered_against_the_message_itself_still_runs_on_it
+       | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+<An_interceptor_registered_against_the_message_itself_still_runs_on_it>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+AuditedHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineTests — stages: [handler]
   1. handler  <- throw
@@ -960,6 +1538,532 @@ RuntimeRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:tie-
                      | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                         | Stella.Ergosfare.Contract.Test.Abort.AbortVoidHandlerBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort  <- ValueTask
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortingVoidPostBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- ValueTask|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortVoidFinalBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                         | Stella.Ergosfare.Contract.Test.Abort.AbortResultHandlerBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort  <- produced
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
+                             | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                               | Stella.Ergosfare.Contract.Test.Abort.AbortingResultPostBase`1.HandleAsync
+                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- produced|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortResultFinalBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                         | Stella.Ergosfare.Contract.Test.Abort.AbortQueryHandlerBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort  <- 7
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
+                             | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                               | Stella.Ergosfare.Contract.Test.Abort.AbortingQueryPostBase`1.HandleAsync
+                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- 7|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
+           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
+             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,ValueTask<string>>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultTaskHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,ValueTask>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidTaskHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,object>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_void_handler_serves_a_dispatch
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_void_handler_serves_a_dispatch>d__14.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidObjectHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [handler]
+  1. handler  <- IHandler<T,string>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_handler_returns_its_value_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_handler_returns_its_value_to_the_caller>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultStringHandlerBase`1.Handle
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__19.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,string>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__19.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultStringHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__18.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,object>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__18.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidObjectHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre, final]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre, handler, exception, final]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception  <- throw+sync-pre|null|SyncFailure
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultExceptionBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- throw+sync-pre|sync-fallback|SyncFailure
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_exception_interceptor_receives_the_rewritten_message_a_null_result_and_the_thrown_exception>d__12.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+sync-pre|ok+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultPostBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+sync-pre|ok+sync-pre+sync-post|none
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_post_interceptor_rewrite_is_the_result_the_caller_receives>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre, handler, post, final]
+  1. pre  <- ok
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- ok+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. post  <- ok+sync-pre|ValueTask
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPostBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- ok+sync-pre|ValueTask|none
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_synchronous_pre_interceptor_rewrite_is_the_message_the_handler_receives>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre, handler]
+  1. pre  <- throw
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0.<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0+<<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- throw+sync-pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0.<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass8_0+<<A_void_pipelines_synchronous_stages_throw_NullReferenceException_when_the_handler_throws>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                         | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:async-low, handler, post:sync-high, post:async-low]
+  1. pre:async-high
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. pre:sync-mid
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. pre:async-low
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. handler  <- 
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  5. post:sync-high
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPostBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  6. post:async-low
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.Synchronous_and_asynchronous_interceptors_share_one_weight_order
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<Synchronous_and_asynchronous_interceptors_share_one_weight_order>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncTests — stages: [pre]
+  1. pre  <- abort
+     | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort
+       | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort>d__9.MoveNext
+         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0.<A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort>b__0
+           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0+<<A_void_pipelines_synchronous_final_interceptor_throws_NullReferenceException_on_abort>b__0>d.MoveNext
+             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 stages: []
 


### PR DESCRIPTION
Closes #128

Phase 1 of the modernization: the four areas the surgery is about to touch, characterized
before it starts. Current behavior is correct by definition here — what looked wrong was
pinned as observed and written up, not fixed.

83 tests become 145. Both TFMs, both axes.

## Where the two axes actually land

The brief suggested a discovery key per area. Two of them do not take one, deliberately:
keyed participants are disqualified from the compile-time plans, so a keyed area would run
the reflective strategies on *both* axes and pin the emitted code not at all. The generated
axis now reaches:

| Area | Generated axis | Fallback axis |
| --- | --- | --- |
| Synchronous interceptors | `StagedPlan7/8/9` — the emitted `((IPreInterceptor<T>)x).Handle(...)` calls | `VoidPipelineExecutor` / `ResultPipelineExecutor` |
| Post-interceptor abort | `StagedPlan0/1/2` — the emitted `catch`-when-not-aborted / `finally` shell | `VoidPipelineExecutor` / `ResultPipelineExecutor` |
| Synchronous main handlers | reflective (see finding 10) | reflective |
| Contested handlers, `[ExcludeFromPipeline]` | reflective (plan-disqualified by construction) | reflective |

That is the point of the change: F1 rewrites `RegistrationEmitter`'s abort shell *and* the
strategy's, and each is now gated by its own axis. Every message type stays local to its
area and no interceptor is registered against a module marker, so joining the shared
unkeyed pool cannot reach another area's pipelines.

Synchronous main handlers cover all four invoker arms — `IHandler<T,object>`,
`<T,ValueTask>`, `<T,string>`, `<T,ValueTask<string>>` — each once without interceptors,
where the executor invokes the handler, and once behind one, where the mediation strategy
does.

## Findings (README, pinned not fixed)

**8 — A synchronous exception or final interceptor on a void pipeline throws
`NullReferenceException`.** The empty result slot is unboxed into a `ValueTask` parameter
(`FinalInterceptorInvocationStrategy.cs:59`, and `ResultCast`'s `(ValueTask)result!` in the
emitted plan). Because the final stage runs from a `finally`, the NRE replaces both the
handler's own exception and `ExecutionAbortedException`. Both axes agree.

**9 — A synchronous participant cannot be registered without a module marker.** The module
builders reject anything not assignable to `ICommand`/`IQuery`/`IEvent`, and the
synchronous contracts have no flavored facade to inherit it from. A bare
`IPreInterceptor<T>` is skipped in silence; the dispatch fails later with "No handler is
registered".

**10 — A `ValueTask`-shaped synchronous main handler breaks the consumer's build.** It
passes the plan gate, the generator emits `AddVoidPlan`/`AddResultPlan`, and those
constrain `THandler` to `IAsyncHandler` — `CS0311` in generated code. Verified by
temporarily un-keying both shapes; both fail. A compile error cannot be pinned by a test,
so the README entry is the record.

**11 — A memoized handler instance survives only until the next registration anywhere in
the process.** The instance lives in a `MessageDependencies` object cached against the
registry version; any new type registered in any container drops it. See below.

Finding 7 updated: the generated staged plans' `CS8604` count goes from two to eight per
TFM. Two of the new ones come through `IPostInterceptor.Handle`, which is evidence the
emitted synchronous arm genuinely runs. Left unsuppressed and deferred: F7 fixes the emitter itself in phase 2, so the count is a
symptom to watch rather than something to decide on here.

## The one change to an existing test file

`HandlerLifetimeTests.ForceMemoizedHandlers_reuses_one_instance_across_dispatches` started
failing about one run in ten once six more classes began registering beside it. Not a test
defect and not a registry race: a registration between two dispatches genuinely resets
memoization (finding 11).

| | failures |
| --- | --- |
| new areas moved out of the project | 0 / 10 |
| new areas in | 2 / 20 and 2 / 7 |
| after the fix | 0 / 25 (net10.0) + 0 / 15 (net9.0) |

The fix is one attribute: the scenario joins the suite's own `RegistryMutationCollection`
(`DisableParallelization = true`), so nothing registers while it runs — the mirror image of
why that collection exists. Revert it and the ~10% flake comes back; whether memoization
should survive a plan refresh is a question for the freeze → refresh → re-freeze design,
not something to paper over here.

## Lane map

Re-captured in its own commit so the behavior diff stays readable: 1177 lines / 36 sections
become 2281 / 58, almost all of it new sections.

One part of the diff is mechanical. Emitted plan classes are numbered positionally, so the
new unkeyed messages push the existing ones along: `StagedPlan0..3` become `3..6`, a
uniform shift. **Every removed line in the diff is a `StagedPlanN` frame** — no other frame
moved and no section changed shape. The README now says to check exactly that before waving
such a diff through.

## Verification

- Contract suite 145/145 on `net9.0` and `net10.0`, both axes.
- Flake hunt: 25 repeat runs on net10.0 + 15 on net9.0, all clean.
- Full solution: 14 projects green, 0 errors.
- Lane map byte-identical across two runs and both TFMs, and equal to the committed
  baseline.
- All 93 `[Fact]` declarations carry `[Trait("Category", "Contract")]`, so the CI filter
  picks up all 145 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
