### PR TITLE
test: phase 1.5 — strategy arms of the sync main handler and the broadcast side

### DIFF
--- a/test/Stella.Ergosfare.Contract.Test/Events/SyncEventHandlerTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Events/SyncEventHandlerTests.cs
@@ -1,0 +1,250 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Events.Abstractions;
+using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.Events;
+
+/// <summary>
+/// The synchronous main-handler contracts inside an event broadcast — the fan-out twin of
+/// <c>Sync/SyncMainHandlerTests.cs</c>. A publish resolves every handler of the event, and
+/// each fan-out slot dispatches through its own contract: the two synchronous shapes pinned
+/// here run beside an asynchronous sibling in one broadcast. Each shape is exercised twice —
+/// once on a bare publish, and once behind an interceptor, which is a different fan-out
+/// implementation the same way it is for commands.
+/// </summary>
+/// <remarks>
+/// These types stay keyed: a publish never enters a compile-time plan — the generator emits
+/// plans for sole-handler command and query dispatches only — so both axes fan out
+/// reflectively, and the fallback axis pins the reflective descriptor construction the same
+/// way the command-side area does.
+/// <para>
+/// The synchronous bases implement <see cref="IEvent"/> themselves for the same reason the
+/// command-side ones implement <c>ICommand</c>: the module builders reject any type without
+/// their marker, and the bare synchronous contracts have no event-flavored facade to
+/// inherit it from — see the suite README, suspicious behavior 9.
+/// </para>
+/// </remarks>
+public abstract class SyncEventHandlerContract
+{
+    /// <summary>The discovery key this area registers under.</summary>
+    protected const string Key = "contract.broadcast";
+
+    /// <summary>Marks itself and reports which contract served its slot of the broadcast.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class TaskShapedHandlerBase<TEvent> : IEvent, IHandler<TEvent, ValueTask>
+        where TEvent : class, IEvent
+    {
+        /// <inheritdoc />
+        public ValueTask Handle(TEvent message, IExecutionContext context)
+        {
+            context.Mark("sync:valuetask");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="TaskShapedHandlerBase{TEvent}"/>
+    [ExcludeFromDiscovery]
+    public abstract class BareShapedHandlerBase<TEvent> : IEvent, IHandler<TEvent, object>
+        where TEvent : class, IEvent
+    {
+        /// <inheritdoc />
+        public object Handle(TEvent message, IExecutionContext context)
+        {
+            context.Mark("sync:object");
+            return "ignored";
+        }
+    }
+
+    /// <summary>The asynchronous sibling the synchronous shapes fan out beside.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class AsyncSiblingHandlerBase<TEvent> : IEventHandler<TEvent>
+        where TEvent : class, IEvent
+    {
+        /// <inheritdoc />
+        public ValueTask HandleAsync(TEvent @event, IExecutionContext context)
+        {
+            context.Mark("async");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Forces the interceptor-carrying fan-out, the way the command-side gate does.</summary>
+    [ExcludeFromDiscovery]
+    public abstract class GatePreBase<TEvent> : IEventPreInterceptor<TEvent>
+        where TEvent : class, IEvent
+    {
+        /// <inheritdoc />
+        public ValueTask<TEvent> HandleAsync(TEvent @event, IExecutionContext context)
+        {
+            context.Mark("pre");
+            return ValueTask.FromResult(@event);
+        }
+    }
+
+    /// <summary>A container with this axis' broadcast handlers registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The event all three handler shapes claim, no interceptors.</summary>
+    protected abstract IEvent NewEvent();
+
+    /// <summary>Its sibling whose fan-out sits behind an interceptor.</summary>
+    protected abstract IEvent NewInterceptedEvent();
+
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<IEventMediator>()
+            .PublishAsync(NewEvent(), recorder.Events());
+
+        // Observed fan-out order, identical on both axes: it follows neither the keyed
+        // declaration order nor the runtime registration order (both say async, task,
+        // bare) — pinned as observed.
+        recorder.AssertStages("async", "sync:object", "sync:valuetask");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<IEventMediator>()
+            .PublishAsync(NewInterceptedEvent(), recorder.Events());
+
+        recorder.AssertStages("pre", "async", "sync:object", "sync:valuetask");
+    }
+}
+
+/// <summary>The broadcast handler types registered through generated descriptors.</summary>
+public static class KeyedBroadcastTypes
+{
+    /// <summary>The event all three handler shapes claim, no interceptors.</summary>
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class MixedShapesEvent : IEvent;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class MixedShapesAsyncHandler : SyncEventHandlerContract.AsyncSiblingHandlerBase<MixedShapesEvent>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class MixedShapesTaskHandler : SyncEventHandlerContract.TaskShapedHandlerBase<MixedShapesEvent>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class MixedShapesBareHandler : SyncEventHandlerContract.BareShapedHandlerBase<MixedShapesEvent>;
+
+    /// <summary>The event whose fan-out sits behind an interceptor.</summary>
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class InterceptedMixedEvent : IEvent;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class InterceptedMixedAsyncHandler : SyncEventHandlerContract.AsyncSiblingHandlerBase<InterceptedMixedEvent>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class InterceptedMixedTaskHandler : SyncEventHandlerContract.TaskShapedHandlerBase<InterceptedMixedEvent>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class InterceptedMixedBareHandler : SyncEventHandlerContract.BareShapedHandlerBase<InterceptedMixedEvent>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.broadcast")]
+    public sealed class InterceptedMixedPre : SyncEventHandlerContract.GatePreBase<InterceptedMixedEvent>;
+}
+
+/// <summary>The same shapes, hidden from the generator so <c>Register&lt;T&gt;()</c> is reflective.</summary>
+public static class FallbackBroadcastTypes
+{
+    /// <inheritdoc cref="KeyedBroadcastTypes.MixedShapesEvent"/>
+    [ExcludeFromDiscovery]
+    public sealed class MixedShapesEvent : IEvent;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class MixedShapesAsyncHandler : SyncEventHandlerContract.AsyncSiblingHandlerBase<MixedShapesEvent>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class MixedShapesTaskHandler : SyncEventHandlerContract.TaskShapedHandlerBase<MixedShapesEvent>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class MixedShapesBareHandler : SyncEventHandlerContract.BareShapedHandlerBase<MixedShapesEvent>;
+
+    /// <inheritdoc cref="KeyedBroadcastTypes.InterceptedMixedEvent"/>
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedMixedEvent : IEvent;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedMixedAsyncHandler : SyncEventHandlerContract.AsyncSiblingHandlerBase<InterceptedMixedEvent>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedMixedTaskHandler : SyncEventHandlerContract.TaskShapedHandlerBase<InterceptedMixedEvent>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedMixedBareHandler : SyncEventHandlerContract.BareShapedHandlerBase<InterceptedMixedEvent>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedMixedPre : SyncEventHandlerContract.GatePreBase<InterceptedMixedEvent>;
+}
+
+/// <summary>The broadcast contract under generated (keyed) registration.</summary>
+public sealed class GeneratedRegistrationSyncEventHandlerTests : SyncEventHandlerContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddEventModule(events => events.RegisterGenerated(Key)))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IEvent NewEvent() => new KeyedBroadcastTypes.MixedShapesEvent();
+
+    /// <inheritdoc />
+    protected override IEvent NewInterceptedEvent() => new KeyedBroadcastTypes.InterceptedMixedEvent();
+}
+
+/// <summary>The same contract under explicit runtime registration.</summary>
+public sealed class RuntimeRegistrationSyncEventHandlerTests : SyncEventHandlerContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddEventModule(events => events
+                    .Register<FallbackBroadcastTypes.MixedShapesAsyncHandler>()
+                    .Register<FallbackBroadcastTypes.MixedShapesTaskHandler>()
+                    .Register<FallbackBroadcastTypes.MixedShapesBareHandler>()
+                    .Register<FallbackBroadcastTypes.InterceptedMixedAsyncHandler>()
+                    .Register<FallbackBroadcastTypes.InterceptedMixedTaskHandler>()
+                    .Register<FallbackBroadcastTypes.InterceptedMixedBareHandler>()
+                    .Register<FallbackBroadcastTypes.InterceptedMixedPre>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IEvent NewEvent() => new FallbackBroadcastTypes.MixedShapesEvent();
+
+    /// <inheritdoc />
+    protected override IEvent NewInterceptedEvent() => new FallbackBroadcastTypes.InterceptedMixedEvent();
+}

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -61,13 +61,13 @@ Both halves of that table are load-bearing, and both are easy to break by accide
 
 Every other area registers by its own discovery key (`contract.dispatch`,
 `contract.lifetime`, `contract.scope`, `contract.groups`, `contract.polymorphism`,
-`contract.events`, `contract.mutation`, `contract.context`, `contract.stream`,
-`contract.sync`, `contract.multi`, `contract.exclude`), which is also what keeps the
-pattern-less call above selecting only the three axes. Types that must never be
+`contract.events`, `contract.broadcast`, `contract.mutation`, `contract.context`,
+`contract.stream`, `contract.sync`, `contract.multi`, `contract.exclude`), which is also
+what keeps the pattern-less call above selecting only the three axes. Types that must never be
 auto-registered — never-registered messages, late-registered interceptors — carry
 `[ExcludeFromDiscovery]`.
 
-Three of the keyed areas are keyed *because* no plan can serve them, so both of their axes
+Four of the keyed areas are keyed *because* no plan can serve them, so both of their axes
 reach the reflective path by construction and the key costs nothing:
 
 - **`contract.sync`** (`Sync/SyncMainHandlerTests.cs`) — the bare-result contracts
@@ -78,6 +78,10 @@ reach the reflective path by construction and the key costs nothing:
   worse reason — see [suspicious behavior 10](#suspicious-behaviors-observed). Synchronous
   *interceptors* are neither: they do reach the emitted plans, which is why they live on
   the unkeyed axis above.
+- **`contract.broadcast`** (`Events/SyncEventHandlerTests.cs`) — a publish never enters a
+  compile-time plan: the generator emits plans for sole-handler command and query
+  dispatches only, so every event fans out through the reflective broadcast strategy and
+  its own synchronous pattern-match arms. The fan-out twin of `contract.sync`.
 - **`contract.multi`** (`Handlers/MultipleMainHandlerTests.cs`) — the sole-handler gate
   drops any message with more than one main handler.
 - **`contract.exclude`** (`Exclusion/PipelineExclusionTests.cs`) — the generator skips
@@ -281,9 +285,11 @@ than change by accident.
    that marker themselves — `ICommandPreInterceptor<T> : ICommand`. The synchronous
    contracts in `Core.Abstractions.Handlers` have no such facade, so a bare
    `IPreInterceptor<T>` is silently skipped by `RegisterGenerated`, and the dispatch fails
-   later with `InvalidOperationException: No handler is registered for X`. Every
-   synchronous participant in this suite therefore declares `: ICommand, IPreInterceptor<T>`
-   — see `Sync/SyncContracts.cs`.
+   later with `InvalidOperationException: No handler is registered for X`. The silence is
+   the scan path's alone: handing the same bare type to the explicit `Register<T>()` throws
+   `NotSupportedException` at registration instead. Every synchronous participant in this
+   suite therefore declares `: ICommand, IPreInterceptor<T>` — see `Sync/SyncContracts.cs`
+   (and `: IEvent, IHandler<T, ·>` on the broadcast side, `Events/SyncEventHandlerTests.cs`).
 
 10. **A `ValueTask`-shaped synchronous main handler breaks the consumer's build.** The plan
     computations gate on the descriptor's result type, and `IHandler<T, ValueTask>` /

--- a/test/Stella.Ergosfare.Contract.Test/Sync/SyncMainHandlerTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/SyncMainHandlerTests.cs
@@ -201,6 +201,45 @@ public abstract class SyncMainHandlerContract
         recorder.AssertStages("pre", "handler");
         Assert.Equal("sync-value", result);
     }
+
+    /// <summary>Void command served by an <c>IHandler&lt;T, ValueTask&gt;</c> behind an interceptor.</summary>
+    /// <remarks>
+    /// The two ValueTask-shaped intercepted members sit below the original scenarios on
+    /// purpose: a member inserted above them would renumber their compiler-generated state
+    /// machines and churn the lane-map baseline for a purely mechanical reason.
+    /// </remarks>
+    protected abstract ICommand NewInterceptedVoidTaskCommand();
+
+    /// <summary>String command served by an <c>IHandler&lt;T, ValueTask&lt;string&gt;&gt;</c> behind an interceptor.</summary>
+    protected abstract ICommand<string> NewInterceptedResultTaskCommand();
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewInterceptedVoidTaskCommand(), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler");
+        Assert.Equal("IHandler<T,ValueTask>", recorder.DetailOf("handler"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewInterceptedResultTaskCommand(), recorder.Commands());
+
+        recorder.AssertStages("pre", "handler");
+        Assert.Equal("sync-task-value", result);
+    }
 }
 
 /// <summary>The synchronous main-handler types registered through generated descriptors.</summary>
@@ -261,6 +300,30 @@ public static class KeyedSyncMainTypes
     /// <inheritdoc />
     [DiscoveryKey("contract.sync")]
     public sealed class InterceptedResultPre : SyncMainHandlerContract.GatePreBase<InterceptedResultCommand>;
+
+    /// <summary>Void command whose ValueTask-shaped synchronous handler sits behind an interceptor.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedVoidTaskCommand : ICommand;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedVoidTaskHandler : SyncMainHandlerContract.VoidTaskHandlerBase<InterceptedVoidTaskCommand>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedVoidTaskPre : SyncMainHandlerContract.GatePreBase<InterceptedVoidTaskCommand>;
+
+    /// <summary>String command whose ValueTask-shaped synchronous handler sits behind an interceptor.</summary>
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedResultTaskCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedResultTaskHandler : SyncMainHandlerContract.ResultTaskHandlerBase<InterceptedResultTaskCommand>;
+
+    /// <inheritdoc />
+    [DiscoveryKey("contract.sync")]
+    public sealed class InterceptedResultTaskPre : SyncMainHandlerContract.GatePreBase<InterceptedResultTaskCommand>;
 }
 
 /// <summary>The same shapes, hidden from the generator so <c>Register&lt;T&gt;()</c> is reflective.</summary>
@@ -321,6 +384,30 @@ public static class FallbackSyncMainTypes
     /// <inheritdoc />
     [ExcludeFromDiscovery]
     public sealed class InterceptedResultPre : SyncMainHandlerContract.GatePreBase<InterceptedResultCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.InterceptedVoidTaskCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedVoidTaskCommand : ICommand;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedVoidTaskHandler : SyncMainHandlerContract.VoidTaskHandlerBase<InterceptedVoidTaskCommand>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedVoidTaskPre : SyncMainHandlerContract.GatePreBase<InterceptedVoidTaskCommand>;
+
+    /// <inheritdoc cref="KeyedSyncMainTypes.InterceptedResultTaskCommand"/>
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedResultTaskCommand : ICommand<string>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedResultTaskHandler : SyncMainHandlerContract.ResultTaskHandlerBase<InterceptedResultTaskCommand>;
+
+    /// <inheritdoc />
+    [ExcludeFromDiscovery]
+    public sealed class InterceptedResultTaskPre : SyncMainHandlerContract.GatePreBase<InterceptedResultTaskCommand>;
 }
 
 /// <summary>The synchronous main-handler contract under generated (keyed) registration.</summary>
@@ -351,6 +438,14 @@ public sealed class GeneratedRegistrationSyncMainHandlerTests : SyncMainHandlerC
     /// <inheritdoc />
     protected override ICommand<string> NewInterceptedResultCommand()
         => new KeyedSyncMainTypes.InterceptedResultCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewInterceptedVoidTaskCommand()
+        => new KeyedSyncMainTypes.InterceptedVoidTaskCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewInterceptedResultTaskCommand()
+        => new KeyedSyncMainTypes.InterceptedResultTaskCommand();
 }
 
 /// <summary>The same contract under explicit runtime registration.</summary>
@@ -368,7 +463,11 @@ public sealed class RuntimeRegistrationSyncMainHandlerTests : SyncMainHandlerCon
                     .Register<FallbackSyncMainTypes.InterceptedVoidHandler>()
                     .Register<FallbackSyncMainTypes.InterceptedVoidPre>()
                     .Register<FallbackSyncMainTypes.InterceptedResultHandler>()
-                    .Register<FallbackSyncMainTypes.InterceptedResultPre>()))
+                    .Register<FallbackSyncMainTypes.InterceptedResultPre>()
+                    .Register<FallbackSyncMainTypes.InterceptedVoidTaskHandler>()
+                    .Register<FallbackSyncMainTypes.InterceptedVoidTaskPre>()
+                    .Register<FallbackSyncMainTypes.InterceptedResultTaskHandler>()
+                    .Register<FallbackSyncMainTypes.InterceptedResultTaskPre>()))
             .BuildServiceProvider();
 
     /// <inheritdoc />
@@ -389,4 +488,12 @@ public sealed class RuntimeRegistrationSyncMainHandlerTests : SyncMainHandlerCon
     /// <inheritdoc />
     protected override ICommand<string> NewInterceptedResultCommand()
         => new FallbackSyncMainTypes.InterceptedResultCommand();
+
+    /// <inheritdoc />
+    protected override ICommand NewInterceptedVoidTaskCommand()
+        => new FallbackSyncMainTypes.InterceptedVoidTaskCommand();
+
+    /// <inheritdoc />
+    protected override ICommand<string> NewInterceptedResultTaskCommand()
+        => new FallbackSyncMainTypes.InterceptedResultTaskCommand();
 }

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -618,6 +618,83 @@ GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
                        | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
+GeneratedRegistrationSyncEventHandlerTests — stages: [async, sync:object, sync:valuetask]
+  1. async
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling>d__9.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+AsyncSiblingHandlerBase`1.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. sync:object
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling>d__9.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+BareShapedHandlerBase`1.Handle
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. sync:valuetask
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling>d__9.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+TaskShapedHandlerBase`1.Handle
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncEventHandlerTests — stages: [pre, async, sync:object, sync:valuetask]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                     | Stella.Ergosfare.Events.Abstractions.IEventPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TEvent>.HandleAsync
+                       | Stella.Ergosfare.Events.Abstractions.IEventPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TEvent>-HandleAsync>d__0.MoveNext
+                         | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+GatePreBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. async
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+AsyncSiblingHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. sync:object
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+BareShapedHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. sync:valuetask
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+TaskShapedHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
 GeneratedRegistrationSyncMainHandlerTests — stages: [handler]
   1. handler  <- IHandler<T,ValueTask<string>>
      | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller
@@ -657,6 +734,60 @@ GeneratedRegistrationSyncMainHandlerTests — stages: [handler]
              | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
                | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultStringHandlerBase`1.Handle
                  | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,ValueTask<string>>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultTaskHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__22.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,ValueTask>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__22.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidTaskHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationSyncMainHandlerTests — stages: [pre, handler]
   1. pre
@@ -1672,6 +1803,83 @@ RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
                            | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
                              | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
+RuntimeRegistrationSyncEventHandlerTests — stages: [async, sync:object, sync:valuetask]
+  1. async
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling>d__9.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+AsyncSiblingHandlerBase`1.HandleAsync
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. sync:object
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling>d__9.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+BareShapedHandlerBase`1.Handle
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. sync:valuetask
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_fans_out_to_the_synchronous_shapes_beside_their_asynchronous_sibling>d__9.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.EventBroadcastInvoker`1.PublishStraightThrough
+               | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
+                 | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+TaskShapedHandlerBase`1.Handle
+                   | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncEventHandlerTests — stages: [pre, async, sync:object, sync:valuetask]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                     | Stella.Ergosfare.Events.Abstractions.IEventPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TEvent>.HandleAsync
+                       | Stella.Ergosfare.Events.Abstractions.IEventPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TEvent>-HandleAsync>d__0.MoveNext
+                         | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+GatePreBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. async
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+AsyncSiblingHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. sync:object
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+BareShapedHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. sync:valuetask
+     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract.A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes
+       | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+<A_publish_that_carries_an_interceptor_still_reaches_the_synchronous_shapes>d__10.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.SyncEventHandlerContract+TaskShapedHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
 RuntimeRegistrationSyncMainHandlerTests — stages: [handler]
   1. handler  <- IHandler<T,ValueTask<string>>
      | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_returns_its_value_to_the_caller
@@ -1711,6 +1919,60 @@ RuntimeRegistrationSyncMainHandlerTests — stages: [handler]
              | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
                | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultStringHandlerBase`1.Handle
                  | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,ValueTask<string>>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_handler_behind_an_interceptor_still_returns_its_value>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+ResultTaskHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationSyncMainHandlerTests — stages: [pre, handler]
+  1. pre
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__22.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+GatePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler  <- IHandler<T,ValueTask>
+     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract.A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor
+       | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+<A_ValueTask_shaped_synchronous_void_handler_serves_a_dispatch_that_carries_an_interceptor>d__22.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Sync.SyncMainHandlerContract+VoidTaskHandlerBase`1.Handle
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationSyncMainHandlerTests — stages: [pre, handler]
   1. pre


### PR DESCRIPTION
Closes #128

Not a planned phase. This is the fix for a coverage gap the phase-1 review turned up, and
it closes out #128's scope before phase 2 starts touching these lines.

145 tests become 153. Both TFMs, both axes.

## The gap

Phase 1's commit message said all four synchronous invoker arms were pinned twice each.
Only two of them were. The reason is an architectural fact worth carrying into phase 2:

**An interceptor-free dispatch never descends into a mediation strategy.** It
short-circuits in the executor's `FastSingleHandler`. So the synchronous pattern-match
lives in two separate places per side, and each has to be pinned on its own:

| Side | Fast path (no interceptors) | Strategy (with interceptors) |
| --- | --- | --- |
| Command, void | `VoidPipelineExecutor.Execute` — `FastSingleHandler` short circuit, own switch (`VoidPipelineExecutor[TMessage].cs:40-49`, ValueTask arm `:44`) | `SingleAsyncHandlerMediationStrategy[TMessage].InvokeHandler` (`:151-165`, ValueTask arm `:155`) |
| Command, result | `ResultPipelineExecutor`, same shape (`ResultPipelineExecutor[TMessage,TResult].cs:51-59`, ValueTask arm `:55`) | `SingleAsyncHandlerMediationStrategy[TMessage,TResult].InvokeHandler` — a switch *expression* (`:157-165`, ValueTask arm `:160`) |
| Event | `EventBroadcastInvoker.PublishStraightThrough` (`:338`) + `Invoke`, own switch (`EventBroadcastInvoker[TEvent].cs:408-430`, switch `:416`) | `AsyncBroadcastMediationStrategy.PublishSequentially` (`:179-204`, switch `:187`, ValueTask arm `:192`) |

Phase 1 pinned the fast-path switches on the command side only. The strategies' ValueTask
arms and the entire event side were unpinned. When the surgery pulls the handler
pattern-match apart, every implementation is now behind a test of its own.

## What this adds

**`Sync/SyncMainHandlerTests.cs` — intercepted ValueTask scenarios (+4).**
`InterceptedVoidTaskCommand` / `InterceptedResultTaskCommand` behind `GatePre`, with their
keyed and fallback twins. Confirmed from the lane map: both reach
`SingleAsyncHandlerMediationStrategy`. The four-arms by (executor, strategy) matrix is now
complete on the command side.

**`Events/SyncEventHandlerTests.cs` — new area `contract.broadcast` (+4).** The fan-out
twin of `contract.sync`. Two events, one bare and one behind an interceptor, each served by
three handler shapes: `IEventHandler<T>`, `IEvent + IHandler<T,ValueTask>`, `IEvent +
IHandler<T,object>`. The bare publish pins the straight-through switch, the intercepted one
pins the strategy switch. Keyed, because a publish never enters a compile-time plan — the
generator emits plans for sole-handler command and query dispatches only — so both axes are
reflective by construction and the key costs nothing.

## New characterization finding: fan-out order

Broadcast fan-out order is **neither declaration nor registration order**. Both axes agree
deterministically on `[async, sync:object, sync:valuetask]`, which looks like type-name
ordering and is consistent with the invoice-then-warehouse expectation already in
`EventPublishTests`. Pinned as observed.

**Whether that ordering is policy is a semantic the modernization has to decide
deliberately** — if it changes, it changes together with the baseline, not by accident.

## New trap for anyone touching the suite: `d__N` drift

Inserting a member into the *middle* of a contract class renumbers the compiler-generated
state machines of every test method below it and churns the lane map for a purely
mechanical reason. New members go at the **end** of the class; `SyncMainHandlerContract`
carries a remark saying so.

That is why this baseline diff is a **pure addition**: 262 lines added, none removed,
2281/58 becomes 2543/66, no `StagedPlanN` renumbering to read past. Nothing new qualifies
for a compile-time plan either, since both new scenario sets are keyed.

## README

- `contract.broadcast` joins the discovery-key list.
- The "keyed *because* no plan can serve them" list goes from three areas to four.
- Finding 9 gains a clarification: the silent skip belongs to the scan path alone. Handing
  the same bare synchronous type to an explicit `Register<T>()` throws
  `NotSupportedException` at registration instead.

## Verification

| Gate | Result |
| --- | --- |
| Contract suite, net9.0 | 153/153 |
| Contract suite, net10.0 | 153/153 |
| Full solution, both TFMs | green |
| Build warnings | 8 per TFM, all `CS8604`, unchanged — keyed types emit no plan (finding 7, fixed by F7 in phase 2) |
| Lane map | re-captured on net9.0 Debug; byte-identical across two runs and both TFMs |
| Baseline diff | `262 0` — pure addition |

## Open items carried into phase 2

Unchanged from the phase-1 write-up: findings 8 (void-pipeline `NullReferenceException`),
10 (`CS0311` on `ValueTask`-shaped synchronous main handlers), 11 (memoized instance vs
registry version), the `CS8604` count, and now the fan-out ordering policy above.

Phase 2 is scoped in #129 with sub-issues #134, #135, #136 and #137.
