### PR TITLE
fix: staged-plan stages take the nullable annotation their own contract declares (F7)

### DIFF
--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -519,11 +519,25 @@ internal static class RegistrationEmitter
         }
     }
 
-    /// <summary>The strategy/invoker-parity cast of the chained object result back to the pipeline result type.</summary>
-    private static string ResultCast(string resultExpression, bool resultIsValueType, string operand)
+    /// <summary>
+    ///     The strategy/invoker-parity cast of the chained object result back to the
+    ///     pipeline result type.
+    /// </summary>
+    /// <param name="targetAcceptsNull">
+    ///     Whether the stage being called declares its result parameter as
+    ///     <c>TResult?</c>. Exception and final interceptors do; post interceptors declare
+    ///     a plain <c>TResult</c>. The distinction is load-bearing for reference-typed
+    ///     results: a cast to <c>TResult?</c> resets the expression's nullable state to
+    ///     maybe-null however non-null the chain variable is, so handing one to a post
+    ///     interceptor is CS8604 in the consumer's build — and a build failure outright
+    ///     where warnings are errors.
+    /// </param>
+    private static string ResultCast(string resultExpression, bool resultIsValueType, bool targetAcceptsNull, string operand)
         => resultIsValueType
             ? "(" + resultExpression + ")" + operand + "!"
-            : "(" + resultExpression + "?)" + operand;
+            : targetAcceptsNull
+                ? "(" + resultExpression + "?)" + operand
+                : "(" + resultExpression + ")" + operand;
 
     private static void EmitPreCalls(StringBuilder sb, StagedPlanModel plan, bool direct, string indent)
     {
@@ -564,6 +578,11 @@ internal static class RegistrationEmitter
         var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
         var extraArgument = exceptionArgument is null ? string.Empty : ", " + exceptionArgument;
 
+        // The exception argument doubles as the stage discriminator: only the exception
+        // stage carries one, and only the exception stage declares its result parameter
+        // nullable. The post stage takes TResult and object, not TResult? and object?.
+        var targetAcceptsNull = exceptionArgument is not null;
+
         sb.Append(indent).Append(chainVariable).Append(" = ");
 
         switch (call.Arm)
@@ -573,7 +592,7 @@ internal static class RegistrationEmitter
                   .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                 AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").HandleAsync(message, ")
-                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
+                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, chainVariable))
                   .Append(extraArgument).AppendLine(", context);");
                 break;
             case StagedCallArm.AsyncAgnostic:
@@ -589,7 +608,7 @@ internal static class RegistrationEmitter
                   .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                 AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").Handle(message, ")
-                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
+                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, chainVariable))
                   .Append(extraArgument).AppendLine(", context);");
                 break;
         }
@@ -600,6 +619,10 @@ internal static class RegistrationEmitter
         var pipelineResult = plan.ResultTypeExpression ?? ValueTaskFullName;
         var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
 
+        // Final interceptors declare `TResult? result` — the stage runs from a finally,
+        // so the pipeline may never have produced one.
+        const bool targetAcceptsNull = true;
+
         foreach (var call in plan.FinalCalls)
         {
             switch (call.Arm)
@@ -609,7 +632,7 @@ internal static class RegistrationEmitter
                       .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                     AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").HandleAsync(message, ")
-                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
+                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, resultExpressionText))
                       .AppendLine(", exception, context);");
                     break;
                 case StagedCallArm.AsyncAgnostic:
@@ -623,7 +646,7 @@ internal static class RegistrationEmitter
                       .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                     AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").Handle(message, ")
-                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
+                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, resultExpressionText))
                       .AppendLine(", exception, context);");
                     break;
             }

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -256,17 +256,18 @@ than change by accident.
    the final interceptor gets `null`. Three different values (`ValueTask`, `null` from the
    exception stage, `null` on abort) for "there is no result."
 
-7. **The generated staged-plan code emits nullable warnings into the consumer's build.**
-   Building this project surfaces `CS8604` eight times per TFM in
-   `ErgosfareRegistrations.g.cs` — the emitted staged result plan passes a
-   possibly-null `string` into the post-interceptor's non-nullable `messageResult`
-   parameter. It appears once per reference-typed post interceptor per emitted plan body
-   (the direct and the provider-resolved one), so the count tracks how many staged result
-   plans carry post interceptors: two for `PipelineResultCommand`, two for the synchronous
-   `SyncResultCommand`, four for `AbortResultCommand`'s two post slots. The synchronous
-   ones prove the arm is not async-only: `IPostInterceptor<TMessage, TResult>.Handle` has
-   the same non-nullable parameter. Left unsuppressed on purpose: these are the only
-   warnings in this project and they are evidence the staged-plan lane is being exercised.
+7. ~~**The generated staged-plan code emits nullable warnings into the consumer's
+   build.**~~ *Fixed.* Building this project used to surface `CS8604` eight times per TFM
+   in `ErgosfareRegistrations.g.cs`: the emitted staged result plan cast its post chain to
+   `TResult?` and handed that to the post interceptor's non-nullable `messageResult`
+   parameter, which broke consumers building with `TreatWarningsAsErrors`. The emitter now
+   picks the cast from the stage contract — post takes `TResult`, exception and final take
+   `TResult?` — so **this project builds with zero warnings**, and a warning appearing here
+   again is a regression rather than a curiosity.
+
+   The count used to double as evidence that the staged-plan lane was being exercised.
+   That job belongs to the [lane-map baseline](#lane-map-baseline) now, which names the
+   lane that ran instead of inferring it from a warning.
 
 8. **A synchronous exception or final interceptor throws `NullReferenceException` on a
    void pipeline.** The void pipeline carries a `ValueTask` in its result slot, but the

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
@@ -170,6 +170,60 @@ public class StagedPlanEmissionTests
     }
 
     [Fact]
+    public void ReferenceTypedStages_EachTakeTheCastTheirOwnContractDeclares()
+    {
+        var result = GeneratorTestHost.Run("""
+            using System;
+            using System.Threading.Tasks;
+            using Stella.Ergosfare.Queries.Abstractions;
+
+            namespace TestApp
+            {
+                public sealed record StagedTextQuery : IQuery<string>;
+
+                public sealed class StagedTextQueryHandler : IQueryHandler<StagedTextQuery, string>
+                {
+                    public ValueTask<string> HandleAsync(StagedTextQuery message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult("ok");
+                }
+
+                public sealed class StagedTextQueryPost : IQueryPostInterceptor<StagedTextQuery, string>
+                {
+                    public ValueTask<string> HandleAsync(StagedTextQuery query, string queryResult, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(queryResult);
+                }
+
+                public sealed class StagedTextQueryException : IQueryExceptionInterceptor<StagedTextQuery, string>
+                {
+                    public ValueTask<string?> HandleAsync(StagedTextQuery query, string? result, Exception exception, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(result);
+                }
+
+                public sealed class StagedTextQueryFinal : IQueryFinalInterceptor<StagedTextQuery, string>
+                {
+                    public ValueTask HandleAsync(StagedTextQuery query, string? result, Exception? exception, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+
+        // Every stage used to be cast to TResult?, and a cast to a nullable type resets
+        // the expression's nullable state to maybe-null however non-null the chain
+        // variable is. The post stage declares `TResult messageResult`, so that produced
+        // CS8604 in every consumer's build — an outright failure where warnings are
+        // errors. Value-typed results never showed it, which is why it survived so long.
+        Assert.DoesNotContain(result.OutputCompilation.GetDiagnostics(), d => d.Id == "CS8604");
+
+        // Post takes TResult; exception and final take TResult?.
+        Assert.Contains("(string)postChain, context);", result.GeneratedSource);
+        Assert.Contains("(string?)exceptionChain, e, context);", result.GeneratedSource);
+        Assert.Contains("(string?)result, exception, context);", result.GeneratedSource);
+    }
+
+    [Fact]
     public void ConstructibleParticipants_EmitTheDirectConstructionVariant()
     {
         var result = GeneratorTestHost.Run("""


### PR DESCRIPTION
Closes #134 · Phase 2 sub-PR 1 of 4 · targets `fix/modernization-phase-2`, not `preview-dev`

## The defect

The emitted staged **result** plan carries its post/exception/final chain in an `object`
local and casts it back to the pipeline result type at every call. `ResultCast` always cast
to `TResult?` for reference-typed results — and **a cast to a nullable type resets the
expression's nullable state to maybe-null**, however non-null the chain variable provably
is. Post interceptors declare `TResult messageResult`, not `TResult?`:

```csharp
ValueTask<object> HandleAsync(TMessage message, TResult messageResult, IExecutionContext context);
```

So every reference-typed staged result plan emitted `CS8604` into the consumer's build —
once per reference-typed post interceptor in each of the two emitted bodies (the direct and
the provider-resolved one), which is why this repository saw eight per TFM. Anyone
compiling with `TreatWarningsAsErrors` did not build at all.

Value-typed results were clean, which is why it survived: those take the unbox arm, which
casts to `TResult` and suppresses.

## The fix

`ResultCast` takes the stage's annotation instead of assuming one. The three stages do not
agree, and now the emitter says so out loud:

| Stage | Contract | Emitted cast |
| --- | --- | --- |
| Post | `IAsyncPostInterceptor<T,TResult>.HandleAsync(T, TResult, ...)` | `(string)postChain` |
| Exception | `IAsyncExceptionHandler<T,TResult>.HandleAsync(T, TResult?, ...)` | `(string?)exceptionChain` |
| Final | `IAsyncFinalInterceptor<T,TResult>.HandleAsync(T, TResult?, ...)` | `(string?)result` |

**On the exception chain**, which #134 asked about explicitly: it needed no repair. Its
parameter really is `TResult?`, so `(TResult?)` was already the right cast — but by
coincidence, since the emitter cast everything that way. It is now right for a stated
reason, from the same table.

No `!` was added. The value-type arm is untouched, including the suppression it genuinely
needs: on a **void** plan the exception chain reaches its cast with the result slot
possibly never assigned, so `(ValueTask)result!` is load-bearing there.

## Behavior

Unchanged. `(string?)x` and `(string)x` produce the same reference at run time; only the
compile-time annotation differs. Confirmed by the safety net: **the lane map is
byte-identical to the baseline on both TFMs**, and all 153 contract scenarios pass on both
axes.

## Regression gate

`StagedPlanEmissionTests.ReferenceTypedStages_EachTakeTheCastTheirOwnContractDeclares` — a
reference-typed query carrying all three result-carrying stages. It asserts no `CS8604` in
the generated compilation plus the per-stage cast each contract declares.

Verified as a real gate, not a tautology: reverting `RegistrationEmitter.cs` alone fails it
with `Assert.DoesNotContain() Failure: Filter matched in collection`.

Without this, nothing would have caught a regression — a warning count is not a test, and
the suite's zero-warning state is only visible to someone reading build output.

## Suite test changes

**None.** No contract scenario pins the old behavior, because the defect was never
observable at run time. The only suite change is prose:

- README finding 7 is struck through and marked *fixed*, with what it used to prove
  reassigned. The count doubled as evidence that the staged-plan lane was being exercised;
  that job belongs to the lane-map baseline, which names the lane instead of inferring it
  from a warning.

## Verification

| Gate | Result |
| --- | --- |
| Contract suite, net9.0 / net10.0 | 153/153 each |
| Full solution, both TFMs | green (58 generator tests, up from 57) |
| Clean solution build | **0 warnings**, down from 8 per TFM |
| Lane map, both TFMs | byte-identical to baseline |
| New gate against the old emitter | fails, as intended |

## Notes for the phase

- **No CHANGELOG entry here.** This repository writes the changelog per release in its own
  docs commit, not per PR. The consumer-facing note — generated code no longer warns —
  belongs to the phase-2 closeout or the next release entry.
- The generator's emission tests carry no `Category` trait, so the `UnitTests` job's
  `Category=Unit|Category=Contract` filter skips that whole file; Coverage, which runs
  unfiltered, is what actually executes them. Left as found. Worth a decision at some
  point, not in this PR.
