### PR TITLE
fix: one exception type for "nothing will handle this" (F2)

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/NoHandlerFoundException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/NoHandlerFoundException.cs
@@ -1,10 +1,39 @@
-﻿
+
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 
 /// <summary>
-/// Exception thrown when no handler is found for a specific message type.
+/// Exception thrown when nothing will handle a message: either the message type has no
+/// descriptor at all, or it has one whose handlers are every one excluded from this
+/// dispatch. The <see cref="Exception.Message"/> says which.
 /// </summary>
-/// <param name="messageType">The type of the message for which no handler was found.</param>
-public class NoHandlerFoundException(Type messageType): Exception(
-    $"Handler for message type '{messageType.Name}'  was not found.");
+/// <remarks>
+/// Derives from <see cref="InvalidOperationException"/> because the second case used to
+/// throw one of those directly, so callers catching it keep catching it. Callers wanting
+/// the specific failure now catch one type for both cases instead of two.
+/// </remarks>
+public class NoHandlerFoundException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes the exception for a message type nothing is registered against.
+    /// </summary>
+    /// <param name="messageType">The type of the message for which no handler was found.</param>
+    public NoHandlerFoundException(Type messageType)
+        : this(messageType, $"Handler for message type '{messageType.Name}' was not found.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes the exception with a message describing why nothing will handle
+    /// <paramref name="messageType"/>.
+    /// </summary>
+    /// <param name="messageType">The type of the message for which no handler was found.</param>
+    /// <param name="message">The message that describes the error.</param>
+    public NoHandlerFoundException(Type messageType, string message) : base(message)
+        => MessageType = messageType;
+
+    /// <summary>
+    /// Gets the type of the message that caused the exception.
+    /// </summary>
+    public Type MessageType { get; }
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -30,7 +30,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="messageDependencies"/> is null.</exception>
     /// <exception cref="MultipleHandlerFoundException">Thrown if more than one handler is registered for the message.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if no handler is registered for the message.</exception>
+    /// <exception cref="NoHandlerFoundException">Thrown if no handler is registered for the message.</exception>
     /// <remarks>
     /// <para>The mediation process follows this sequence:</para>
     /// <list type="number">
@@ -62,7 +62,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
 
         if (messageDependencies.Handlers.Count == 0)
         {
-            throw new InvalidOperationException($"No handler is registered for {typeof(TMessage).Name}.");
+            throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
         var preInterceptorCount = messageDependencies.PreInterceptors.Count;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -34,7 +34,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
     /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>A task representing the asynchronous mediation operation.</returns>
     /// <exception cref="MultipleHandlerFoundException">Thrown when more than one handler is found for the message type.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when no handler is registered for the message type.</exception>
+    /// <exception cref="NoHandlerFoundException">Thrown when no handler is registered for the message type.</exception>
     /// <remarks>
     ///     Pre-interceptors, the main handler and post-interceptors run in sequence; with no
     ///     interceptors registered the handler is invoked directly on a fast path. If an
@@ -55,7 +55,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
 
         if (messageDependencies.Handlers.Count == 0)
         {
-            throw new InvalidOperationException($"No handler is registered for {typeof(TMessage).Name}.");
+            throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
         var preInterceptorCount = messageDependencies.PreInterceptors.Count;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
@@ -41,7 +41,7 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
     /// An <see cref="IAsyncEnumerable{TResult}"/> representing the asynchronous stream of results produced by the handler.
     /// </returns>
     /// <exception cref="MultipleHandlerFoundException">Thrown if more than one handler is registered for the message.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if no handler is registered for the message.</exception>
+    /// <exception cref="NoHandlerFoundException">Thrown if no handler is registered for the message.</exception>
     public async IAsyncEnumerable<TResult> Mediate(TMessage message, IMessageDependencies messageDependencies,
         IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -52,7 +52,7 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
 
         if (messageDependencies.Handlers.Count == 0)
         {
-            throw new InvalidOperationException($"No handler is registered for {typeof(TMessage).Name}.");
+            throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
         var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);

--- a/test/Stella.Ergosfare.Contract.Test/Groups/GroupFilteringTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Groups/GroupFilteringTests.cs
@@ -4,6 +4,7 @@ using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Generated;
 
@@ -92,9 +93,9 @@ public sealed class GroupFilteringTests
         await using var provider = CreateProvider();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        // A registered message whose handlers are all filtered out reports differently
-        // from a message type that was never registered at all — see the README.
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        // A registered message whose handlers are all filtered out reports the same type
+        // as a message that was never registered at all; only the message differs.
+        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new ReportingOnly()));
 
         Assert.Contains(nameof(ReportingOnly), thrown.Message, StringComparison.Ordinal);
@@ -122,7 +123,7 @@ public sealed class GroupFilteringTests
         var mediator = provider.GetRequiredService<ICommandMediator>();
         var settings = new CommandMediationSettings { Filters = { Groups = new[] { Reporting } } };
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new Mixed(), settings));
     }
 
@@ -167,7 +168,7 @@ public sealed class GroupFilteringTests
         await using var provider = CreateProvider();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new ReportingOnly(), GroupSet.Empty));
     }
 
@@ -181,5 +182,23 @@ public sealed class GroupFilteringTests
         await provider.GetRequiredService<ICommandMediator>().SendAsync(command, new[] { Reporting });
 
         Assert.True(command.Handled);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_filtered_out_dispatch_is_still_catchable_as_an_InvalidOperationException()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // This case threw a plain InvalidOperationException before the two "nothing will
+        // handle this" exceptions were unified. NoHandlerFoundException derives from it so
+        // that callers who were catching that keep catching it — the compatibility half of
+        // the unification, which nothing else here would notice losing.
+        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.SendAsync(new ReportingOnly()));
+
+        Assert.IsAssignableFrom<InvalidOperationException>(thrown);
+        Assert.Equal(typeof(ReportingOnly), thrown.MessageType);
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
@@ -4,6 +4,7 @@ using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
@@ -168,7 +169,7 @@ public sealed class PolymorphicDispatchTests
         // Covariant command dispatch is resolution-time only: once the derived type has a
         // descriptor of its own, the base-typed handler is an indirect handler there and
         // single-handler mediation never considers it. See the README.
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new DepositEntry()));
 
         Assert.Contains(nameof(DepositEntry), thrown.Message, StringComparison.Ordinal);

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -224,11 +224,14 @@ than change by accident.
    `null` (or the result type's default). Pinned by
    `Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value`.
 
-2. **Two different exceptions mean "nothing will handle this."** A message type that is not
-   in the registry produces `NoHandlerFoundException`; a registered message whose handlers
-   are all filtered out by a group filter produces a plain
-   `InvalidOperationException("No handler is registered for X.")`. Callers cannot catch
-   both with one type.
+2. ~~**Two different exceptions mean "nothing will handle this."**~~ *Fixed.* A message
+   type absent from the registry used to produce `NoHandlerFoundException` while a
+   registered message whose handlers were all filtered out produced a plain
+   `InvalidOperationException("No handler is registered for X.")`, so no single `catch`
+   covered both. Both now raise `NoHandlerFoundException` — which derives from
+   `InvalidOperationException`, so callers who were catching the second case keep catching
+   it — and the two stay told apart by the message alone. Pinned by the group-filtering
+   scenarios and `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right`.
 
 3. **Events invert the default for "no handler."** Publishing a *registered* event nobody
    handles is a silent no-op unless `ThrowIfNoHandlerFound` is set; publishing an
@@ -286,7 +289,7 @@ than change by accident.
    that marker themselves — `ICommandPreInterceptor<T> : ICommand`. The synchronous
    contracts in `Core.Abstractions.Handlers` have no such facade, so a bare
    `IPreInterceptor<T>` is silently skipped by `RegisterGenerated`, and the dispatch fails
-   later with `InvalidOperationException: No handler is registered for X`. The silence is
+   later with `NoHandlerFoundException: No handler is registered for X`. The silence is
    the scan path's alone: handing the same bare type to the explicit `Register<T>()` throws
    `NotSupportedException` at registration instead. Every synchronous participant in this
    suite therefore declares `: ICommand, IPreInterceptor<T>` — see `Sync/SyncContracts.cs`

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions.Exceptions;
+﻿using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
@@ -111,7 +111,7 @@ public class SingleAsyncHandlerMediationStrategyTMessageTResultTests :
 
     /// <summary>
     /// A message with a descriptor but no direct handler must fail with an explicit
-    /// <see cref="InvalidOperationException"/>.
+    /// <see cref="NoHandlerFoundException"/>.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
@@ -130,7 +130,7 @@ public class SingleAsyncHandlerMediationStrategyTMessageTResultTests :
                 new StubMessage(), dependencies, _executionContextFixture.Ctx, _messageDependencyFixture.ServiceProvider));
 
         // assert
-        Assert.IsType<InvalidOperationException>(exception);
+        Assert.IsType<NoHandlerFoundException>(exception);
 
         // cleanup
         _messageDependencyFixture.Dispose();

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage,TResult]TestS.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage,TResult]TestS.cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions.Exceptions;
+﻿using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Stream;
@@ -89,7 +89,7 @@ public class SingleStreamHandlerMediationStrategyTMessageTResultTests :
 
     /// <summary>
     /// A message with a descriptor but no direct stream handler must fail with an explicit
-    /// <see cref="InvalidOperationException"/> when enumeration starts.
+    /// <see cref="NoHandlerFoundException"/> when enumeration starts.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
@@ -112,7 +112,7 @@ public class SingleStreamHandlerMediationStrategyTMessageTResultTests :
         });
 
         // assert
-        Assert.IsType<InvalidOperationException>(exception);
+        Assert.IsType<NoHandlerFoundException>(exception);
 
         // cleanup
         _messageDependencyFixture.Dispose();

--- a/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
@@ -138,12 +138,13 @@ public class StreamFastLaneTests
         // process-wide, though: another suite's marker-targeted (IQuery-assignable)
         // interceptor may have given every query a descriptor, in which case both paths
         // defer and fail at enumeration with the strategy's no-handler error instead —
-        // the fast-lane/Mediate parity this test guards holds either way.
+        // the fast-lane/Mediate parity this test guards holds either way. Both timings now
+        // raise NoHandlerFoundException; only the timing tells them apart.
         try
         {
             var stream = mediator.StreamAsync(new UnhandledStream());
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await Assert.ThrowsAsync<NoHandlerFoundException>(async () =>
             {
                 await foreach (var _ in stream)
                 {


### PR DESCRIPTION
Closes #135 · Phase 2 sub-PR 2 of 4 · targets `fix/modernization-phase-2`, not `preview-dev`

## The defect

Two failures said the same thing in two types:

| Case | Before | After |
| --- | --- | --- |
| Message type absent from the registry | `NoHandlerFoundException` | `NoHandlerFoundException` |
| Registered message, every handler excluded from this dispatch | `InvalidOperationException("No handler is registered for X.")` | `NoHandlerFoundException`, same message |

No caller could catch both with one type. The asymmetry was local rather than principled —
the neighbouring branch in the very same guard, *two* handlers where one is allowed, has
raised `MultipleHandlerFoundException` all along.

Three sites, all in `Core.Abstractions`: `SingleAsyncHandlerMediationStrategy[TMessage]`,
`SingleAsyncHandlerMediationStrategy[TMessage,TResult]`, `SingleStreamHandlerMediationStrategy`.

## The decision #135 asked for: derive, and why

`NoHandlerFoundException` now derives from `InvalidOperationException`.

**The derivation is the point, not a detail.** Unifying without it would have replaced one
split with another: every consumer whose `catch (InvalidOperationException)` handles a
filtered-out dispatch today would silently stop catching it. Widening a type cannot break
a compile, and .NET's own meaning for `InvalidOperationException` — the operation is not
valid for the object's current state — is exactly what a pipeline with every handler
filtered out is.

It does mean a `catch (InvalidOperationException)` around a dispatch now also catches the
unregistered-type case, which used to escape. That is the unification working: the two are
the same category of problem, which is the premise of #135.

Consumer-visible surface change, for the release notes: `NoHandlerFoundException`'s base
type, plus a new `MessageType` property and a message-carrying constructor.

## What is kept

- **The diagnostic distinction.** The strategies keep their `"No handler is registered for
  X."` wording verbatim, through the new message-carrying constructor. Only the type
  converges; the message still says which of the two happened.
- **The value-add of the sibling type.** `MessageType` matches
  `MultipleHandlerFoundException`.
- The default message loses its stray double space (`'X'  was not` → `'X' was not`). No
  test asserted that text.

Not added: `[Serializable]`, which `MultipleHandlerFoundException` carries. It is legacy
serialization surface and propagating it is not an improvement. Flagging rather than
deciding unilaterally — say the word and it goes in for symmetry.

## Suite and test changes, each deliberate

**Contract suite — four scenarios move to the new type.** xUnit's `ThrowsAsync` matches the
*exact* type, so the derivation does not spare them:

| Scenario | File |
| --- | --- |
| `A_grouped_handler_is_unreachable_from_a_default_dispatch` | `Groups/GroupFilteringTests.cs` |
| `A_grouped_dispatch_excludes_the_ungrouped_handler` | `Groups/GroupFilteringTests.cs` |
| `An_empty_GroupSet_dispatches_the_default_pipeline` | `Groups/GroupFilteringTests.cs` |
| `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right` | `Polymorphism/PolymorphicDispatchTests.cs` |

**Contract suite — one scenario added:**
`A_filtered_out_dispatch_is_still_catchable_as_an_InvalidOperationException`. The
compatibility promise is the load-bearing half of this change and nothing else here would
have noticed losing it — a later "cleanup" of the base type would pass every other test.
Placed at the end of its class so no state machine below it renumbers.

**Core.Test — two tests.** The `[TMessage,TResult]` async and stream strategies'
no-handler tests assert the exact type through `Assert.IsType`. These were **not** in
#135's inventory; the full-solution run found them.

**Queries.Test — `StreamFastLaneTests.UnregisteredStreamQuery_ThrowsAtCallTime_LikeTheMediatePath`.**
As #135 predicted, its outer `catch (NoHandlerFoundException)` never protected the inner
assertion: a wrong-type `ThrowsAsync` raises xUnit's own exception, which that catch does
not match. The test's two-timing structure is preserved; only the expected type changes.

**README** — finding 2 struck through and marked fixed; finding 9's trailing reference to
the old type corrected.

## Verification

| Gate | Result |
| --- | --- |
| Contract suite, net9.0 / net10.0 | 154/154 each (153 + the new scenario) |
| Full solution, both TFMs | green, 14 test assemblies |
| Clean solution build | 0 warnings |
| Lane map, both TFMs | byte-identical to baseline |

The lane map is unchanged because every affected scenario asserts an exception and never
reaches `AssertStages`, so none of them publishes a section.

## Note

No CHANGELOG entry — this repository writes the changelog per release in its own docs
commit. The base-type change belongs in the phase-2 closeout or the next release entry,
and it is the one item in this phase so far that a consumer could notice.
