### PR TITLE
fix: ThrowIfNoHandlerFound governs every way a publish reaches nobody (F3)

### DIFF
--- a/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
@@ -10,6 +10,13 @@ public sealed class EventMediationSettings
     /// Gets or sets a value indicating whether an exception should be thrown
     /// if no handlers are found for a published event.
     /// </summary>
+    /// <remarks>
+    /// Covers every way a publish can reach nobody: an event type absent from the
+    /// registry, a registered one with no handlers, and a registered one whose handlers
+    /// are all filtered out. Left unset, a publish that reaches nobody is a silent no-op —
+    /// fire-and-forget is the point of an event, and a publisher that must know whether
+    /// anyone listened wants this flag.
+    /// </remarks>
     public bool ThrowIfNoHandlerFound { get; init; }
 
 

--- a/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
+++ b/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
@@ -80,7 +80,11 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 // filtering requested, loop the handler arrays directly — synchronously
                 // while handlers complete synchronously, bailing to an awaiting helper on
                 // the first suspension. No strategy or per-stage async frames.
-                if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+                if (dependencies is null)
+                {
+                    task = NoPipeline(settings?.ThrowIfNoHandlerFound ?? false);
+                }
+                else if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
                     && (settings is null
                         || ReferenceEquals(settings.Filters.HandlerPredicate,
                             EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
@@ -93,6 +97,13 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 {
                     task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
                 }
+            }
+            else if (resolveStrategy.Find(typeof(TEvent)) is null)
+            {
+                // Foreign mediator implementation: the Mediate path would raise
+                // NoHandlerFoundException from its own descriptor lookup whatever the
+                // caller asked for. Answer the flag here so every publish route agrees.
+                task = NoPipeline(settings?.ThrowIfNoHandlerFound ?? false);
             }
             else
             {
@@ -166,7 +177,11 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 ? GetPlan(engine.DependenciesFactory, resolveStrategy)
                 : GetGroupedPlan(engine.DependenciesFactory, resolveStrategy, groups);
 
-            if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+            if (dependencies is null)
+            {
+                task = NoPipeline(settings?.ThrowIfNoHandlerFound ?? false);
+            }
+            else if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
                 && (settings is null
                     || ReferenceEquals(settings.Filters.HandlerPredicate,
                         EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
@@ -231,7 +246,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     private MessageDependenciesFactory? _cachedFactory;
     private int _cachedVersion = int.MinValue;
 
-    private IMessageDependencies GetPlan(
+    private IMessageDependencies? GetPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
     {
@@ -256,6 +271,17 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             }
 
             var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
+
+            if (dependencies is null)
+            {
+                // A missing descriptor is not cached here. The resolve strategy already
+                // caches its own negative lookup against the registry size, so the repeat
+                // cost is a dictionary hit — and leaving the slot untouched keeps the
+                // three cache fields consistent for concurrent readers, which a
+                // "cached null" would need a fourth field to express.
+                return null;
+            }
+
             _cachedDependencies = dependencies;
             _cachedFactory = typedFactory;
             _cachedVersion = registryVersion;
@@ -292,7 +318,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         public readonly int Version = version;
     }
 
-    private IMessageDependencies GetGroupedPlan(
+    private IMessageDependencies? GetGroupedPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IEnumerable<string> groups)
@@ -319,6 +345,13 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             // ReSharper disable once PossibleMultipleEnumeration
             var materialized = canonical?.Names ?? [.. groups];
             var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
+
+            if (dependencies is null)
+            {
+                // Not slotted, for the reason GetPlan gives.
+                return null;
+            }
+
             _cachedGroupedPlan = new GroupedPlanSlot(
                 typedFactory, materialized, canonical, dependencies, registryVersion);
             return dependencies;
@@ -429,17 +462,34 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         }
     }
 
-    private static IMessageDependencies BuildPlan(
+    /// <summary>
+    /// The pipeline plan for <typeparamref name="TEvent"/>, or <c>null</c> when the event
+    /// type has no descriptor at all.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than an exception on purpose: an unregistered event type is the same
+    /// "nothing will handle this" as a registered one whose handlers are all filtered out,
+    /// and both are the caller's <see cref="EventMediationSettings.ThrowIfNoHandlerFound"/>
+    /// to answer. Only the publish site knows what the caller asked for, so the decision
+    /// belongs there and not here.
+    /// </remarks>
+    private static IMessageDependencies? BuildPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory factory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         string[] groups)
     {
-        // Mirrors MessageMediator.Mediate's descriptor handling for the options the old
-        // path used: RegisterPlainMessagesOnSpot was never set for events, so an
-        // unregistered event type throws NoHandlerFoundException here as it did there.
-        var descriptor = resolveStrategy.Find(typeof(TEvent))
-                         ?? throw new NoHandlerFoundException(typeof(TEvent));
+        var descriptor = resolveStrategy.Find(typeof(TEvent));
 
-        return factory.Create(typeof(TEvent), descriptor, groups);
+        return descriptor is null ? null : factory.Create(typeof(TEvent), descriptor, groups);
     }
+
+    /// <summary>
+    /// The publish outcome for an event nothing will handle: the caller's flag decides,
+    /// and it decides the same way whether the event type is unregistered or merely
+    /// unhandled.
+    /// </summary>
+    private static ValueTask NoPipeline(bool throwIfNoHandlerFound)
+        => throwIfNoHandlerFound
+            ? ValueTask.FromException(new NoHandlerFoundException(typeof(TEvent)))
+            : default;
 }

--- a/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
@@ -117,14 +117,17 @@ public sealed class EventPublishTests
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Publishing_an_unregistered_event_type_throws_even_without_asking()
+    public async Task Publishing_an_unregistered_event_type_is_a_no_op_like_a_registered_one()
     {
         await using var provider = CreateProvider();
-        var mediator = provider.GetRequiredService<IEventMediator>();
+        var recorder = new PipelineRecorder();
 
-        // Unlike NobodyListens, this type is not in the registry at all — see the README.
-        await Assert.ThrowsAsync<NoHandlerFoundException>(
-            async () => await mediator.PublishAsync(new UnknownEvent()));
+        // UnknownEvent is not in the registry at all, NobodyListens is registered with no
+        // handlers. Both reach nobody, and both are silent unless the caller asks — the
+        // flag used to govern only the second.
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new UnknownEvent(), recorder.Events());
+
+        recorder.AssertStages();
     }
 
     [Fact]
@@ -151,5 +154,21 @@ public sealed class EventPublishTests
         await provider.GetRequiredService<IEventMediator>().PublishAsync(new StockChanged(), settings);
 
         recorder.AssertStages("reporting");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publishing_an_unregistered_event_type_throws_when_the_caller_asks_it_to()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings { ThrowIfNoHandlerFound = true };
+
+        // The other half of the flag's new reach: what the unregistered case used to do
+        // unconditionally, it now does on request — the same as the registered-but-unhandled
+        // case two scenarios up. Appended rather than placed beside its sibling: a member
+        // inserted above renumbers the state machines below it and churns the lane map.
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.PublishAsync(new UnknownEvent(), settings));
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -233,10 +233,28 @@ than change by accident.
    it — and the two stay told apart by the message alone. Pinned by the group-filtering
    scenarios and `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right`.
 
-3. **Events invert the default for "no handler."** Publishing a *registered* event nobody
-   handles is a silent no-op unless `ThrowIfNoHandlerFound` is set; publishing an
-   *unregistered* event type throws `NoHandlerFoundException` regardless of that flag. The
-   setting only controls the first case.
+3. ~~**Events invert the default for "no handler."**~~ *Fixed.* Publishing an
+   *unregistered* event type used to throw `NoHandlerFoundException` whatever the caller
+   asked for, while a *registered* event nobody handles was a silent no-op unless
+   `ThrowIfNoHandlerFound` was set — so the flag governed one of the two ways a publish
+   reaches nobody. Both obey it now, and the default for both is the silent no-op that
+   fire-and-forget implies. Pinned by
+   `Publishing_an_unregistered_event_type_is_a_no_op_like_a_registered_one` and
+   `Publishing_an_unregistered_event_type_throws_when_the_caller_asks_it_to`.
+
+   The cost is real and was taken deliberately: a misspelled or never-registered event
+   type used to announce itself and now goes quietly. `ThrowIfNoHandlerFound` is the way
+   to get that back for a publisher that must know someone listened.
+
+   What the old behavior really depended on is worth recording, because it is a trap for
+   anyone writing event tests anywhere: **"unregistered" is not a property of the event
+   type, it is a property of the whole process.** The resolve strategy falls back to the
+   first *assignable* descriptor, so a single participant registered against the `IEvent`
+   marker — a non-generic `IEventPreInterceptor`, say — gives every event type in the
+   process a descriptor, and nothing is unregistered from then on. The old throw therefore
+   fired or did not fire depending on whether such a participant existed anywhere in the
+   app. This area keeps its own `[ExcludeFromDiscovery]` types and registers nothing at
+   marker level (rule 3 above), which is what makes `UnknownEvent` mean what it says here.
 
 4. **Covariance applies to interceptors but not to main handlers.** An interceptor
    registered against a supertype joins a derived message's pipeline. A *handler*

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -2329,6 +2329,8 @@ RuntimeRegistrationSyncTests — stages: [pre]
 
 stages: []
 
+stages: []
+
 stages: [default]
   1. default
      | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.A_default_publish_skips_grouped_handlers

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -1,7 +1,12 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
@@ -414,5 +419,87 @@ public class BroadcastFastLaneTests
             .PublishAsync(new ScopedEvent(), settings);
 
         Assert.Same(expected, settings.Items["probe"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class NeverRegisteredEvent : IEvent { }
+
+    /// <summary>
+    /// An <see cref="IMessageMediator"/> that is not the concrete <c>MessageMediator</c>,
+    /// so the invoker takes its foreign-mediator branch. Every member throws: an
+    /// unregistered event must be answered by the caller's flag before the Mediate path —
+    /// which raises unconditionally — is ever reached.
+    /// </summary>
+    private sealed class UnreachableMediator : IMessageMediator
+    {
+        public ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null,
+            CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public ValueTask<TResult> DispatchAsync<TResult>(object message, IDictionary<object, object?>? items = null,
+            CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public ValueTask DispatchAsync(object message, IExecutionContext context, IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public ValueTask<TResult> DispatchAsync<TResult>(object message, IExecutionContext context,
+            IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public TMessageResult Mediate<TMessage, TMessageResult>(TMessage message,
+            MediateOptions<TMessage, TMessageResult> options) where TMessage : notnull
+            => throw new UnreachableException();
+    }
+
+    /// <summary>
+    /// An empty registry, so "this type has no descriptor" is true by construction.
+    /// </summary>
+    /// <remarks>
+    /// The shared registry cannot express it: this assembly registers
+    /// <c>ExcludeFromPipelineTests.BroadPre</c>, a non-generic <c>IEventPreInterceptor</c>
+    /// and therefore a descriptor for <c>IEvent</c> itself. From that registration onward
+    /// the resolve strategy's assignable fallback answers for *every* event type, and
+    /// nothing in the process is unregistered any more. Which test ran first would decide
+    /// this one's outcome.
+    /// </remarks>
+    private sealed class EmptyRegistry : IMessageRegistry
+    {
+        public int Count => 0;
+
+        public IEnumerator<IMessageDescriptor> GetEnumerator()
+            => Enumerable.Empty<IMessageDescriptor>().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Register(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicConstructors)]
+            Type type)
+            => throw new UnreachableException();
+
+        public void RegisterDescriptors(IEnumerable<IHandlerDescriptor> descriptors)
+            => throw new UnreachableException();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldHonorThrowIfNoHandlerFound_ForAnUnregisteredType_OnAForeignMediator()
+    {
+        await using var provider = Build();
+
+        var mediator = new EventMediator(
+            new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(new EmptyRegistry()),
+            provider.GetRequiredService<IResultAdapterService>(),
+            new UnreachableMediator());
+
+        // Default: silent, exactly as for a registered event nobody handles. Reaching the
+        // Mediate path at all is the failure — it raises whatever the caller asked for.
+        await mediator.PublishAsync(new NeverRegisteredEvent());
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(async () =>
+            await mediator.PublishAsync(
+                new NeverRegisteredEvent(),
+                new EventMediationSettings { ThrowIfNoHandlerFound = true }));
     }
 }


### PR DESCRIPTION
Closes #136 · Phase 2 sub-PR 3 of 4 · targets `fix/modernization-phase-2`, not `preview-dev`

**This one changes behavior a caller can see.** Details and the cost taken, below.

## The defect

`ThrowIfNoHandlerFound` governed one of the two ways a publish reaches nobody:

| Case | Before | After |
| --- | --- | --- |
| Registered event, no handlers | silent; throws if the flag is set | unchanged |
| **Unregistered event type** | **throws, whatever the caller asked** | **silent; throws if the flag is set** |

## It was not merely inconsistent — it was unstable across applications

The resolve strategy falls back to the first **assignable** descriptor. One participant
registered against the `IEvent` marker — a non-generic `IEventPreInterceptor`, say — gives
*every* event type in the process a descriptor, and nothing is unregistered from then on.
So whether an unregistered publish threw depended on whether such a participant existed
somewhere in the app: with one, the publish already fell through to a zero-handler pipeline
and was already silent.

The behavior this PR settles on is the one those applications already had. It is also what
found the bug in my own new test — see below.

## The fix

`BuildPlan` returns `null` rather than throwing, because only the publish site knows what
the caller asked for. All three publish routes then agree:

| Route | Before | After |
| --- | --- | --- |
| Straight-through fast lane | honored the flag | unchanged |
| `AsyncBroadcastMediationStrategy` | honored the flag | unchanged |
| Foreign `IMessageMediator` | raised unconditionally from `MessageMediator`'s own descriptor lookup | short-circuits on the flag before delegating |

A missing descriptor is deliberately **not** cached on the invoker. The resolve strategy
already caches its own negative lookup against the registry size, so a repeat is a
dictionary hit — and leaving the slot untouched keeps the invoker's three cache fields
consistent for concurrent readers, which a "cached null" would need a fourth field to
express.

## The cost, taken deliberately

A misspelled or never-registered event type used to announce itself and now goes quietly.
That was the only thing catching the mistake.

I considered adding a diagnostic to compensate and did not: a debug-only log needs a
logging dependency `Events` does not have, and an analyzer cannot see runtime
registrations. `ThrowIfNoHandlerFound` is the honest answer — a publisher that must know
someone listened sets it, and its doc comment now says exactly what it covers. Say the
word if you want a diagnostic anyway and it can be its own issue.

## Suite and test changes

**Contract suite — one scenario inverts, deliberately.**
`Publishing_an_unregistered_event_type_throws_even_without_asking` becomes
`Publishing_an_unregistered_event_type_is_a_no_op_like_a_registered_one`, rewritten **in
place** so no state machine below it renumbers. Its other half,
`Publishing_an_unregistered_event_type_throws_when_the_caller_asks_it_to`, is **appended at
the end** of the class for the same reason.

**Events.Test — one scenario added**, for the foreign-mediator short circuit, which nothing
else reaches. Verified as a real gate: reverting `EventBroadcastInvoker` alone fails it
with `UnreachableException` from the stub mediator.

**README** — finding 3 struck through and marked fixed, plus the marker-descriptor trap
recorded, because it bites anyone writing event tests, not just this change.

## The flake this PR nearly shipped

The first version of the Events.Test scenario used the shared registry and failed **four
runs in five**, ordering-dependent. Cause: this assembly registers
`ExcludeFromPipelineTests.BroadPre`, a non-generic `IEventPreInterceptor` and therefore a
descriptor for `IEvent` itself — after which `NeverRegisteredEvent` resolves through the
assignable fallback and the short circuit never fires.

The scenario now builds its resolve strategy over an empty `IMessageRegistry`, so "this
type has no descriptor" is true by construction. Confirmed with six consecutive net10.0
runs. This is the same hazard the contract suite's rule 3 exists to prevent, showing up in
an assembly that has no such rule.

## Verification

| Gate | Result |
| --- | --- |
| Contract suite, net9.0 / net10.0 | 155/155 each |
| Events.Test, net10.0 | 42/42, six consecutive runs |
| Full solution, both TFMs | green |
| Clean solution build | 0 warnings |
| Lane map | `+2 / -0`, two runs and both TFMs byte-identical |

**Lane-map diff explained:** two added lines, an empty section for the inverted scenario,
which now records a publish that reaches nobody instead of an exception that never got that
far. No removals, no `StagedPlanN` renumbering, no section changed shape. Re-captured in
its own commit.

## Note

No CHANGELOG entry — written per release in its own docs commit. This is the second item
this phase a consumer can notice, after `NoHandlerFoundException`'s base type, and the
louder of the two.
