### PR TITLE
fix: name the unresolvable participant when a pipeline cannot be built (F5)

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
@@ -1,0 +1,34 @@
+
+namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
+
+/// <summary>
+/// Exception thrown when a message's pipeline names a participant the dispatching
+/// container cannot resolve — typically a type added to the process-wide message registry
+/// after that container was built.
+/// </summary>
+/// <remarks>
+/// Raised while the pipeline is being built rather than part-way through a dispatch, so no
+/// participant runs before the failure. Nothing is cached for the failed build: registering
+/// the participant with a container and dispatching again works, which is the only way back
+/// since the registry has no removal.
+/// </remarks>
+/// <param name="messageType">The message type whose pipeline could not be built.</param>
+/// <param name="participantType">The participant the container cannot resolve.</param>
+[Serializable]
+public class UnresolvableParticipantException(Type messageType, Type participantType)
+    : InvalidOperationException(
+        $"The pipeline for '{messageType.Name}' includes '{participantType.FullName ?? participantType.Name}', " +
+        "which this container cannot resolve. Register it with the container: adding a type to the message " +
+        "registry does not register it for dependency injection, and the registry is process-wide while " +
+        "containers are not.")
+{
+    /// <summary>
+    /// Gets the message type whose pipeline could not be built.
+    /// </summary>
+    public Type MessageType => messageType;
+
+    /// <summary>
+    /// Gets the participant the container cannot resolve.
+    /// </summary>
+    public Type ParticipantType => participantType;
+}

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
@@ -29,6 +30,7 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
     private HandlerLifetimeRegistry? _handlerLifetimes;
     private ErgosfareRuntimeOptions? _runtimeOptions;
     private IServiceProvider? _memoizedGraphProvider;
+    private IServiceProviderIsService? _resolvabilityProbe;
     private bool _servicesResolved;
 
     /// <summary>
@@ -66,6 +68,7 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
             _handlerLifetimes = serviceProvider.GetService<HandlerLifetimeRegistry>();
             _runtimeOptions = serviceProvider.GetService<ErgosfareRuntimeOptions>();
             _memoizedGraphProvider = serviceProvider.GetService<RootServiceProviderAccessor>()?.RootProvider ?? serviceProvider;
+            _resolvabilityProbe = serviceProvider.GetService<IServiceProviderIsService>();
             _servicesResolved = true;
         }
 
@@ -93,6 +96,14 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
 
         var shape = cache.GetOrAddShape(messageType, groupsArray, descriptor, registryVersion);
 
+        // Fail fast here rather than in IMessageRegistry.Register: the registry is
+        // process-wide while containers are per-application, so the same participant can
+        // be resolvable in one container and absent from another — only a pipeline being
+        // built in a container's context can answer. Nothing is cached before this
+        // returns, so the failure is not sticky: a container that does register the
+        // participant builds the same pipeline and dispatches normally.
+        EnsureParticipantsResolvable(shape, messageType, _resolvabilityProbe);
+
         // Pipelines that are fully singleton-registered (or forced via MemoizeAllHandlers)
         // cache handler instances inside their references, pinned to the root provider.
         var memoizeInstances = (_runtimeOptions?.MemoizeAllHandlers ?? false)
@@ -104,5 +115,45 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
         cache.AddDependencies(messageType, groupsArray, dependencies, registryVersion);
 
         return dependencies;
+    }
+
+    /// <summary>
+    /// Verifies every planned participant is something the container knows how to build,
+    /// before any of them is asked for.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="IServiceProviderIsService"/>, which answers from the registrations
+    /// without constructing anything — a plain resolution attempt would instantiate the
+    /// whole pipeline on every rebuild. Containers that do not offer it are left alone:
+    /// the participant then fails at resolution time, exactly as before this check
+    /// existed.
+    /// </remarks>
+    private static void EnsureParticipantsResolvable(
+        MessagePipelineShape shape, Type messageType, IServiceProviderIsService? probe)
+    {
+        if (probe is null)
+        {
+            return;
+        }
+
+        Check(shape.Handlers, messageType, probe);
+        Check(shape.IndirectHandlers, messageType, probe);
+        Check(shape.PreInterceptors, messageType, probe);
+        Check(shape.PostInterceptors, messageType, probe);
+        Check(shape.ExceptionInterceptors, messageType, probe);
+        Check(shape.FinalInterceptors, messageType, probe);
+
+        static void Check<TDescriptor>(
+            PlannedHandler<TDescriptor>[] planned, Type messageType, IServiceProviderIsService probe)
+            where TDescriptor : IHandlerDescriptor
+        {
+            for (var i = 0; i < planned.Length; i++)
+            {
+                if (!probe.IsService(planned[i].HandlerType))
+                {
+                    throw new UnresolvableParticipantException(messageType, planned[i].HandlerType);
+                }
+            }
+        }
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -264,12 +264,24 @@ than change by accident.
    never considers, so the dispatch fails. Pinned by the two
    `A_base_typed_handler_*` scenarios.
 
-5. **Runtime registry mutation is half-supported.** Registering an interceptor type after
-   the container is built does change the next dispatch — but only if that type was already
-   in DI. Otherwise the next dispatch throws `InvalidOperationException: No service for
-   type ...`, and because the registry has no removal, that message type stays broken for
-   the rest of the process. Pinned by
-   `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`.
+5. ~~**Runtime registry mutation is half-supported.**~~ *Partly fixed — the diagnosis, not
+   the constraint.* Registering an interceptor type after the container is built changes
+   the next dispatch only if that type is also in DI. It used to fail with an opaque
+   `InvalidOperationException: No service for type ...`, raised part-way through the
+   dispatch by whichever stage first asked for the participant. Pipeline construction now
+   checks every planned participant against the container up front and raises
+   `UnresolvableParticipantException`, which names the message, names the participant and
+   states the remedy, before any stage runs.
+
+   **The underlying constraint stands and cannot be fixed here:** the registry is
+   process-wide, has no removal, and a container is per-application, so a participant
+   resolvable in one container may be absent from another. That is also why the check
+   cannot live in `Register` — only a pipeline being built in a container's context can
+   answer the question. What the fix does guarantee is that the failure is not sticky:
+   nothing is cached for a failed build, so a container that does register the participant
+   builds the pipeline the broken one could not. Pinned by
+   `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`
+   and `A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not`.
 
 6. **A void pipeline's "result" is a `ValueTask` sentinel, except on abort.** Post, final
    and exception interceptors of a void command are handed a non-null `ValueTask` as the

--- a/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
@@ -4,6 +4,7 @@ using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Generated;
@@ -164,10 +165,78 @@ public sealed class RuntimeRegistrationMutationTests
         // pipeline that now includes it cannot be constructed. See the README.
         provider.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableLatePre));
 
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        var thrown = await Assert.ThrowsAsync<UnresolvableParticipantException>(
             async () => await mediator.SendAsync(new PoisonTarget()));
 
         Assert.Contains(nameof(UnresolvableLatePre), thrown.Message, StringComparison.Ordinal);
+        Assert.Equal(typeof(PoisonTarget), thrown.MessageType);
+        Assert.Equal(typeof(UnresolvableLatePre), thrown.ParticipantType);
+    }
+
+    // --- recovery from an unresolvable late registration -----------------------
+
+    /// <summary>
+    /// The recovery scenario keeps types of its own. Sharing <see cref="PoisonTarget"/>
+    /// would make each scenario's outcome depend on which ran first: the registry is
+    /// process-wide and never forgets, so whichever registered the unresolvable
+    /// interceptor first would break the other's opening dispatch.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    public sealed class RecoveryTarget : ICommand;
+
+    /// <inheritdoc cref="RecoveryTarget"/>
+    [ExcludeFromDiscovery]
+    public sealed class RecoveryTargetHandler : ICommandHandler<RecoveryTarget>
+    {
+        public ValueTask HandleAsync(RecoveryTarget command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="RecoveryTarget"/>
+    [ExcludeFromDiscovery]
+    public sealed class UnresolvableRecoveryPre : ICommandPreInterceptor<RecoveryTarget>
+    {
+        public ValueTask<RecoveryTarget> HandleAsync(RecoveryTarget command, IExecutionContext context)
+        {
+            context.Mark("late");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not()
+    {
+        await using var missing = new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.Register<RecoveryTargetHandler>()))
+            .BuildServiceProvider();
+
+        await missing.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget());
+
+        missing.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableRecoveryPre));
+
+        await Assert.ThrowsAsync<UnresolvableParticipantException>(
+            async () => await missing.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget()));
+
+        // The registry entry is permanent, so registering the participant with a container
+        // is the only way back — and it has to work. Nothing about the failed build is
+        // cached, so this container reaches the same pipeline the broken one could not,
+        // interceptor included.
+        await using var repaired = new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<RecoveryTargetHandler>()
+                    .Register<UnresolvableRecoveryPre>()))
+            .BuildServiceProvider();
+
+        var recorder = new PipelineRecorder();
+        await repaired.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget(), recorder.Commands());
+
+        recorder.AssertStages("late", "handler");
     }
 }
 

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -2453,6 +2453,33 @@ stages: [invoice, warehouse]
 
 stages: [late, handler]
   1. late
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+UnresolvableRecoveryPre.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RecoveryTargetHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [late, handler]
+  1. late
      | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
        | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync

--- a/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
@@ -45,9 +45,13 @@ public class FinalInterceptorInvocationStrategyTests:
     public async Task Invoke_ShouldExecuteDirectAndIndirectFinalInterceptors()
     {
         _messageDependencyFixture = _messageDependencyFixture.New;
-        _messageDependencyFixture.MessageRegistry.Register(typeof(StubIndirectMessage));
-        _messageDependencyFixture.MessageRegistry.Register(typeof(StubFinalInterceptor));
-        _messageDependencyFixture.MessageRegistry.Register(typeof(StubIndirectFinalInterceptor));
+
+        // RegisterHandler rather than MessageRegistry.Register: it registers with the
+        // container as well, and building a pipeline now verifies its participants are
+        // resolvable there. Registry-only setup described a pipeline that could never
+        // have dispatched.
+        _messageDependencyFixture.RegisterHandler(
+            typeof(StubIndirectMessage), typeof(StubFinalInterceptor), typeof(StubIndirectFinalInterceptor));
 
         
         


### PR DESCRIPTION
Closes #137 · Phase 2 sub-PR 4 of 4 · targets `fix/modernization-phase-2`, not `preview-dev`

## The defect

Registering a participant type into the process-wide registry after a container is built
leaves that container unable to serve it. The failure arrived **part-way through the next
dispatch**, from whichever stage first asked for the type:

```
InvalidOperationException: No service for type 'Some.Namespace.LatePre' has been registered.
```

Nothing about which message it belonged to, nothing about what to do, and the stages before
it had already run.

## The fix

`MessageDependenciesFactory.Create` checks every planned participant against the container
before building the graph, and raises `UnresolvableParticipantException` — which names the
message, names the participant, and states the remedy — **before any stage runs**.

It derives from `InvalidOperationException`, so callers catching what `GetRequiredService`
used to throw keep catching it. Same reasoning as #135, and the same precedent.

### Why `Create`, and why nowhere else

`Create` is the single funnel every dispatch route goes through — the void, result, staged
and generated executors, the event broadcast invoker, the query stream invoker, and
`MessageMediator` itself — and it is the earliest point holding **both** the group-filtered
pipeline shape and the container.

The check cannot live in `IMessageRegistry.Register`, which #137 called out as the design
constraint: the registry is process-wide while containers are per-application, so the same
participant can be resolvable in one and absent from another, and `Register` has no
container to ask.

### Cost

Resolvability is answered by `IServiceProviderIsService`, which reads the registrations
without constructing anything — a plain resolution attempt would instantiate the whole
pipeline on every rebuild. Containers that do not offer it are left alone and keep the old
resolution-time failure.

The check runs on the same cache miss the graph build already costs: once per (message
type, group set, registry version), **never on the dispatch path**. A cache hit returns
before it.

## Rebuildability, which #137 asked to pin

The failure is deliberately not sticky: nothing is cached before the check passes, so a
container that *does* register the participant builds the same pipeline normally. Since the
registry never forgets, that is the only way back, and it now has an end-to-end scenario —
dispatch, poison the registry, fail, then reach the full pipeline, interceptor included,
from a container that has the type.

**The underlying constraint stands and is not fixable here.** The registry is process-wide
and has no removal. This PR fixes the diagnosis, not that.

## Suite and test changes

| Change | Why |
| --- | --- |
| `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch` → `UnresolvableParticipantException` | the new type; also asserts `MessageType` and `ParticipantType` |
| **New:** `A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not` | the rebuildability guarantee #137 asked for |
| `Core.Test` `FinalInterceptorInvocationStrategyTests` | see below |

The new scenario carries **its own** message and participant types rather than reusing
`PoisonTarget`. Sharing them would have made each scenario's outcome depend on which ran
first: the registry is process-wide and never forgets, so whichever registered the
unresolvable interceptor first would break the other's opening dispatch. Appended at the end
of its class so no state machine below it renumbers.

`FinalInterceptorInvocationStrategyTests.Invoke_ShouldExecuteDirectAndIndirectFinalInterceptors`
registered its participants into the registry **alone** and inspected the resulting graph.
That described a pipeline that could never have dispatched — it passed only because
resolution was lazy and the test never dispatched. It now uses the fixture's
`RegisterHandler`, which registers with the container too. **This was not in #137's
inventory**; the full-solution run found it, and it is the one place where the new check
changes an existing test's premise rather than its expected exception.

## Verification

| Gate | Result |
| --- | --- |
| Contract suite, net9.0 / net10.0 | 156/156 each |
| Flake sweep | net9.0 ×12, net10.0 ×10, zero failures |
| Full solution, both TFMs | green |
| Clean solution build | 0 warnings |
| Lane map | `+27 / -0`, two runs and both TFMs byte-identical |

**Lane-map diff explained:** one added section for the recovery scenario, whose repaired
container reaches the full pipeline through the reflective executor and strategy. No
removals, no `StagedPlanN` renumbering, and the new test took the next `d__N` ordinal
because it sits at the end of its class. Re-captured in its own commit.

The flake sweep is not ceremony here: this scenario mutates the process-wide registry, the
one thing in the suite that can make unrelated tests order-dependent.

## Note

No CHANGELOG entry — written per release in its own docs commit. Consumer-visible surface
from this PR: the new `UnresolvableParticipantException` type, and an earlier, clearer
failure where an opaque mid-dispatch one used to be.
