### PR TITLE
fix: phase 2 — low-risk contract cleanups (F7, F2, F3, F5)

### DIFF
--- a/.github/workflows/aot_smoke.yml
+++ b/.github/workflows/aot_smoke.yml
@@ -6,9 +6,11 @@ on:
     branches:
       - "*"
   pull_request:
+    # "**" rather than "*": a single star does not match a slash, so a base branch
+    # like fix/modernization-phase-2 selects no workflow at all. Every pull request
+    # gets the gate regardless of what it targets.
     branches:
-      - main
-      - preview
+      - "**"
 
 jobs:
   aot-smoke:

--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -9,8 +9,11 @@ on:
     paths-ignore:
       - '.badges/chore_workflows/coverage.svg'
   pull_request:
+    # '**' rather than '*': a single star does not match a slash, so a base branch
+    # like fix/modernization-phase-2 selects no workflow at all. Every pull request
+    # gets the gate regardless of what it targets.
     branches:
-      - '*'
+      - '**'
     paths-ignore:
       - '.badges/chore_workflows/coverage.svg'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,9 +6,11 @@ on:
     branches:
       - "*"
   pull_request:
+    # "**" rather than "*": a single star does not match a slash, so a base branch
+    # like fix/modernization-phase-2 selects no workflow at all. Every pull request
+    # gets the gate regardless of what it targets.
     branches:
-      - main
-      - preview
+      - "**"
 
 jobs:
   unit-tests:

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/NoHandlerFoundException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/NoHandlerFoundException.cs
@@ -1,10 +1,39 @@
-﻿
+
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 
 /// <summary>
-/// Exception thrown when no handler is found for a specific message type.
+/// Exception thrown when nothing will handle a message: either the message type has no
+/// descriptor at all, or it has one whose handlers are every one excluded from this
+/// dispatch. The <see cref="Exception.Message"/> says which.
 /// </summary>
-/// <param name="messageType">The type of the message for which no handler was found.</param>
-public class NoHandlerFoundException(Type messageType): Exception(
-    $"Handler for message type '{messageType.Name}'  was not found.");
+/// <remarks>
+/// Derives from <see cref="InvalidOperationException"/> because the second case used to
+/// throw one of those directly, so callers catching it keep catching it. Callers wanting
+/// the specific failure now catch one type for both cases instead of two.
+/// </remarks>
+public class NoHandlerFoundException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes the exception for a message type nothing is registered against.
+    /// </summary>
+    /// <param name="messageType">The type of the message for which no handler was found.</param>
+    public NoHandlerFoundException(Type messageType)
+        : this(messageType, $"Handler for message type '{messageType.Name}' was not found.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes the exception with a message describing why nothing will handle
+    /// <paramref name="messageType"/>.
+    /// </summary>
+    /// <param name="messageType">The type of the message for which no handler was found.</param>
+    /// <param name="message">The message that describes the error.</param>
+    public NoHandlerFoundException(Type messageType, string message) : base(message)
+        => MessageType = messageType;
+
+    /// <summary>
+    /// Gets the type of the message that caused the exception.
+    /// </summary>
+    public Type MessageType { get; }
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
@@ -1,0 +1,34 @@
+
+namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
+
+/// <summary>
+/// Exception thrown when a message's pipeline names a participant the dispatching
+/// container cannot resolve — typically a type added to the process-wide message registry
+/// after that container was built.
+/// </summary>
+/// <remarks>
+/// Raised while the pipeline is being built rather than part-way through a dispatch, so no
+/// participant runs before the failure. Nothing is cached for the failed build: registering
+/// the participant with a container and dispatching again works, which is the only way back
+/// since the registry has no removal.
+/// </remarks>
+/// <param name="messageType">The message type whose pipeline could not be built.</param>
+/// <param name="participantType">The participant the container cannot resolve.</param>
+[Serializable]
+public class UnresolvableParticipantException(Type messageType, Type participantType)
+    : InvalidOperationException(
+        $"The pipeline for '{messageType.Name}' includes '{participantType.FullName ?? participantType.Name}', " +
+        "which this container cannot resolve. Register it with the container: adding a type to the message " +
+        "registry does not register it for dependency injection, and the registry is process-wide while " +
+        "containers are not.")
+{
+    /// <summary>
+    /// Gets the message type whose pipeline could not be built.
+    /// </summary>
+    public Type MessageType => messageType;
+
+    /// <summary>
+    /// Gets the participant the container cannot resolve.
+    /// </summary>
+    public Type ParticipantType => participantType;
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -30,7 +30,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="messageDependencies"/> is null.</exception>
     /// <exception cref="MultipleHandlerFoundException">Thrown if more than one handler is registered for the message.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if no handler is registered for the message.</exception>
+    /// <exception cref="NoHandlerFoundException">Thrown if no handler is registered for the message.</exception>
     /// <remarks>
     /// <para>The mediation process follows this sequence:</para>
     /// <list type="number">
@@ -62,7 +62,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
 
         if (messageDependencies.Handlers.Count == 0)
         {
-            throw new InvalidOperationException($"No handler is registered for {typeof(TMessage).Name}.");
+            throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
         var preInterceptorCount = messageDependencies.PreInterceptors.Count;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -34,7 +34,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
     /// <param name="serviceProvider">The provider of the scope this dispatch runs in; handlers and interceptors resolve from it.</param>
     /// <returns>A task representing the asynchronous mediation operation.</returns>
     /// <exception cref="MultipleHandlerFoundException">Thrown when more than one handler is found for the message type.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when no handler is registered for the message type.</exception>
+    /// <exception cref="NoHandlerFoundException">Thrown when no handler is registered for the message type.</exception>
     /// <remarks>
     ///     Pre-interceptors, the main handler and post-interceptors run in sequence; with no
     ///     interceptors registered the handler is invoked directly on a fast path. If an
@@ -55,7 +55,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
 
         if (messageDependencies.Handlers.Count == 0)
         {
-            throw new InvalidOperationException($"No handler is registered for {typeof(TMessage).Name}.");
+            throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
         var preInterceptorCount = messageDependencies.PreInterceptors.Count;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
@@ -41,7 +41,7 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
     /// An <see cref="IAsyncEnumerable{TResult}"/> representing the asynchronous stream of results produced by the handler.
     /// </returns>
     /// <exception cref="MultipleHandlerFoundException">Thrown if more than one handler is registered for the message.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if no handler is registered for the message.</exception>
+    /// <exception cref="NoHandlerFoundException">Thrown if no handler is registered for the message.</exception>
     public async IAsyncEnumerable<TResult> Mediate(TMessage message, IMessageDependencies messageDependencies,
         IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -52,7 +52,7 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
 
         if (messageDependencies.Handlers.Count == 0)
         {
-            throw new InvalidOperationException($"No handler is registered for {typeof(TMessage).Name}.");
+            throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
         var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);

--- a/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Factories/MessageDependenciesFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
@@ -29,6 +30,7 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
     private HandlerLifetimeRegistry? _handlerLifetimes;
     private ErgosfareRuntimeOptions? _runtimeOptions;
     private IServiceProvider? _memoizedGraphProvider;
+    private IServiceProviderIsService? _resolvabilityProbe;
     private bool _servicesResolved;
 
     /// <summary>
@@ -66,6 +68,7 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
             _handlerLifetimes = serviceProvider.GetService<HandlerLifetimeRegistry>();
             _runtimeOptions = serviceProvider.GetService<ErgosfareRuntimeOptions>();
             _memoizedGraphProvider = serviceProvider.GetService<RootServiceProviderAccessor>()?.RootProvider ?? serviceProvider;
+            _resolvabilityProbe = serviceProvider.GetService<IServiceProviderIsService>();
             _servicesResolved = true;
         }
 
@@ -93,6 +96,14 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
 
         var shape = cache.GetOrAddShape(messageType, groupsArray, descriptor, registryVersion);
 
+        // Fail fast here rather than in IMessageRegistry.Register: the registry is
+        // process-wide while containers are per-application, so the same participant can
+        // be resolvable in one container and absent from another — only a pipeline being
+        // built in a container's context can answer. Nothing is cached before this
+        // returns, so the failure is not sticky: a container that does register the
+        // participant builds the same pipeline and dispatches normally.
+        EnsureParticipantsResolvable(shape, messageType, _resolvabilityProbe);
+
         // Pipelines that are fully singleton-registered (or forced via MemoizeAllHandlers)
         // cache handler instances inside their references, pinned to the root provider.
         var memoizeInstances = (_runtimeOptions?.MemoizeAllHandlers ?? false)
@@ -104,5 +115,45 @@ internal sealed class MessageDependenciesFactory(IServiceProvider serviceProvide
         cache.AddDependencies(messageType, groupsArray, dependencies, registryVersion);
 
         return dependencies;
+    }
+
+    /// <summary>
+    /// Verifies every planned participant is something the container knows how to build,
+    /// before any of them is asked for.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="IServiceProviderIsService"/>, which answers from the registrations
+    /// without constructing anything — a plain resolution attempt would instantiate the
+    /// whole pipeline on every rebuild. Containers that do not offer it are left alone:
+    /// the participant then fails at resolution time, exactly as before this check
+    /// existed.
+    /// </remarks>
+    private static void EnsureParticipantsResolvable(
+        MessagePipelineShape shape, Type messageType, IServiceProviderIsService? probe)
+    {
+        if (probe is null)
+        {
+            return;
+        }
+
+        Check(shape.Handlers, messageType, probe);
+        Check(shape.IndirectHandlers, messageType, probe);
+        Check(shape.PreInterceptors, messageType, probe);
+        Check(shape.PostInterceptors, messageType, probe);
+        Check(shape.ExceptionInterceptors, messageType, probe);
+        Check(shape.FinalInterceptors, messageType, probe);
+
+        static void Check<TDescriptor>(
+            PlannedHandler<TDescriptor>[] planned, Type messageType, IServiceProviderIsService probe)
+            where TDescriptor : IHandlerDescriptor
+        {
+            for (var i = 0; i < planned.Length; i++)
+            {
+                if (!probe.IsService(planned[i].HandlerType))
+                {
+                    throw new UnresolvableParticipantException(messageType, planned[i].HandlerType);
+                }
+            }
+        }
     }
 }

--- a/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/EventMediationSettiongs.cs
@@ -10,6 +10,13 @@ public sealed class EventMediationSettings
     /// Gets or sets a value indicating whether an exception should be thrown
     /// if no handlers are found for a published event.
     /// </summary>
+    /// <remarks>
+    /// Covers every way a publish can reach nobody: an event type absent from the
+    /// registry, a registered one with no handlers, and a registered one whose handlers
+    /// are all filtered out. Left unset, a publish that reaches nobody is a silent no-op —
+    /// fire-and-forget is the point of an event, and a publisher that must know whether
+    /// anyone listened wants this flag.
+    /// </remarks>
     public bool ThrowIfNoHandlerFound { get; init; }
 
 

--- a/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
+++ b/src/Stella.Ergosfare.Events/EventBroadcastInvoker[TEvent].cs
@@ -80,7 +80,11 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 // filtering requested, loop the handler arrays directly — synchronously
                 // while handlers complete synchronously, bailing to an awaiting helper on
                 // the first suspension. No strategy or per-stage async frames.
-                if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+                if (dependencies is null)
+                {
+                    task = NoPipeline(settings?.ThrowIfNoHandlerFound ?? false);
+                }
+                else if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
                     && (settings is null
                         || ReferenceEquals(settings.Filters.HandlerPredicate,
                             EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
@@ -93,6 +97,13 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 {
                     task = strategy.Mediate((TEvent)@event, dependencies, context, concreteMediator.ScopeProvider);
                 }
+            }
+            else if (resolveStrategy.Find(typeof(TEvent)) is null)
+            {
+                // Foreign mediator implementation: the Mediate path would raise
+                // NoHandlerFoundException from its own descriptor lookup whatever the
+                // caller asked for. Answer the flag here so every publish route agrees.
+                task = NoPipeline(settings?.ThrowIfNoHandlerFound ?? false);
             }
             else
             {
@@ -166,7 +177,11 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
                 ? GetPlan(engine.DependenciesFactory, resolveStrategy)
                 : GetGroupedPlan(engine.DependenciesFactory, resolveStrategy, groups);
 
-            if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
+            if (dependencies is null)
+            {
+                task = NoPipeline(settings?.ThrowIfNoHandlerFound ?? false);
+            }
+            else if (dependencies is MessageDependencies { HasNoInterceptors: true } plan
                 && (settings is null
                     || ReferenceEquals(settings.Filters.HandlerPredicate,
                         EventMediationSettings.EventMediationFilters.AcceptAllHandlers)))
@@ -231,7 +246,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
     private MessageDependenciesFactory? _cachedFactory;
     private int _cachedVersion = int.MinValue;
 
-    private IMessageDependencies GetPlan(
+    private IMessageDependencies? GetPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy)
     {
@@ -256,6 +271,17 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             }
 
             var dependencies = BuildPlan(typedFactory, resolveStrategy, EmptyGroups);
+
+            if (dependencies is null)
+            {
+                // A missing descriptor is not cached here. The resolve strategy already
+                // caches its own negative lookup against the registry size, so the repeat
+                // cost is a dictionary hit — and leaving the slot untouched keeps the
+                // three cache fields consistent for concurrent readers, which a
+                // "cached null" would need a fourth field to express.
+                return null;
+            }
+
             _cachedDependencies = dependencies;
             _cachedFactory = typedFactory;
             _cachedVersion = registryVersion;
@@ -292,7 +318,7 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         public readonly int Version = version;
     }
 
-    private IMessageDependencies GetGroupedPlan(
+    private IMessageDependencies? GetGroupedPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory dependenciesFactory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         IEnumerable<string> groups)
@@ -319,6 +345,13 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
             // ReSharper disable once PossibleMultipleEnumeration
             var materialized = canonical?.Names ?? [.. groups];
             var dependencies = BuildPlan(typedFactory, resolveStrategy, materialized);
+
+            if (dependencies is null)
+            {
+                // Not slotted, for the reason GetPlan gives.
+                return null;
+            }
+
             _cachedGroupedPlan = new GroupedPlanSlot(
                 typedFactory, materialized, canonical, dependencies, registryVersion);
             return dependencies;
@@ -429,17 +462,34 @@ internal sealed class EventBroadcastInvoker<TEvent> : IEventBroadcastInvoker
         }
     }
 
-    private static IMessageDependencies BuildPlan(
+    /// <summary>
+    /// The pipeline plan for <typeparamref name="TEvent"/>, or <c>null</c> when the event
+    /// type has no descriptor at all.
+    /// </summary>
+    /// <remarks>
+    /// Null rather than an exception on purpose: an unregistered event type is the same
+    /// "nothing will handle this" as a registered one whose handlers are all filtered out,
+    /// and both are the caller's <see cref="EventMediationSettings.ThrowIfNoHandlerFound"/>
+    /// to answer. Only the publish site knows what the caller asked for, so the decision
+    /// belongs there and not here.
+    /// </remarks>
+    private static IMessageDependencies? BuildPlan(
         Core.Abstractions.Factories.IMessageDependenciesFactory factory,
         ActualTypeOrFirstAssignableTypeMessageResolveStrategy resolveStrategy,
         string[] groups)
     {
-        // Mirrors MessageMediator.Mediate's descriptor handling for the options the old
-        // path used: RegisterPlainMessagesOnSpot was never set for events, so an
-        // unregistered event type throws NoHandlerFoundException here as it did there.
-        var descriptor = resolveStrategy.Find(typeof(TEvent))
-                         ?? throw new NoHandlerFoundException(typeof(TEvent));
+        var descriptor = resolveStrategy.Find(typeof(TEvent));
 
-        return factory.Create(typeof(TEvent), descriptor, groups);
+        return descriptor is null ? null : factory.Create(typeof(TEvent), descriptor, groups);
     }
+
+    /// <summary>
+    /// The publish outcome for an event nothing will handle: the caller's flag decides,
+    /// and it decides the same way whether the event type is unregistered or merely
+    /// unhandled.
+    /// </summary>
+    private static ValueTask NoPipeline(bool throwIfNoHandlerFound)
+        => throwIfNoHandlerFound
+            ? ValueTask.FromException(new NoHandlerFoundException(typeof(TEvent)))
+            : default;
 }

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -519,11 +519,25 @@ internal static class RegistrationEmitter
         }
     }
 
-    /// <summary>The strategy/invoker-parity cast of the chained object result back to the pipeline result type.</summary>
-    private static string ResultCast(string resultExpression, bool resultIsValueType, string operand)
+    /// <summary>
+    ///     The strategy/invoker-parity cast of the chained object result back to the
+    ///     pipeline result type.
+    /// </summary>
+    /// <param name="targetAcceptsNull">
+    ///     Whether the stage being called declares its result parameter as
+    ///     <c>TResult?</c>. Exception and final interceptors do; post interceptors declare
+    ///     a plain <c>TResult</c>. The distinction is load-bearing for reference-typed
+    ///     results: a cast to <c>TResult?</c> resets the expression's nullable state to
+    ///     maybe-null however non-null the chain variable is, so handing one to a post
+    ///     interceptor is CS8604 in the consumer's build — and a build failure outright
+    ///     where warnings are errors.
+    /// </param>
+    private static string ResultCast(string resultExpression, bool resultIsValueType, bool targetAcceptsNull, string operand)
         => resultIsValueType
             ? "(" + resultExpression + ")" + operand + "!"
-            : "(" + resultExpression + "?)" + operand;
+            : targetAcceptsNull
+                ? "(" + resultExpression + "?)" + operand
+                : "(" + resultExpression + ")" + operand;
 
     private static void EmitPreCalls(StringBuilder sb, StagedPlanModel plan, bool direct, string indent)
     {
@@ -564,6 +578,11 @@ internal static class RegistrationEmitter
         var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
         var extraArgument = exceptionArgument is null ? string.Empty : ", " + exceptionArgument;
 
+        // The exception argument doubles as the stage discriminator: only the exception
+        // stage carries one, and only the exception stage declares its result parameter
+        // nullable. The post stage takes TResult and object, not TResult? and object?.
+        var targetAcceptsNull = exceptionArgument is not null;
+
         sb.Append(indent).Append(chainVariable).Append(" = ");
 
         switch (call.Arm)
@@ -573,7 +592,7 @@ internal static class RegistrationEmitter
                   .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                 AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").HandleAsync(message, ")
-                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
+                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, chainVariable))
                   .Append(extraArgument).AppendLine(", context);");
                 break;
             case StagedCallArm.AsyncAgnostic:
@@ -589,7 +608,7 @@ internal static class RegistrationEmitter
                   .Append('<').Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                 AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                 sb.Append(").Handle(message, ")
-                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, chainVariable))
+                  .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, chainVariable))
                   .Append(extraArgument).AppendLine(", context);");
                 break;
         }
@@ -600,6 +619,10 @@ internal static class RegistrationEmitter
         var pipelineResult = plan.ResultTypeExpression ?? ValueTaskFullName;
         var pipelineResultIsValueType = plan.ResultTypeExpression is null || plan.ResultIsValueType;
 
+        // Final interceptors declare `TResult? result` — the stage runs from a finally,
+        // so the pipeline may never have produced one.
+        const bool targetAcceptsNull = true;
+
         foreach (var call in plan.FinalCalls)
         {
             switch (call.Arm)
@@ -609,7 +632,7 @@ internal static class RegistrationEmitter
                       .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                     AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").HandleAsync(message, ")
-                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
+                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, resultExpressionText))
                       .AppendLine(", exception, context);");
                     break;
                 case StagedCallArm.AsyncAgnostic:
@@ -623,7 +646,7 @@ internal static class RegistrationEmitter
                       .Append(plan.MessageTypeExpression).Append(", ").Append(pipelineResult).Append(">)");
                     AppendParticipant(sb, call.TypeExpression, direct ? call.ConstructionExpression : null);
                     sb.Append(").Handle(message, ")
-                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, resultExpressionText))
+                      .Append(ResultCast(pipelineResult, pipelineResultIsValueType, targetAcceptsNull, resultExpressionText))
                       .AppendLine(", exception, context);");
                     break;
             }

--- a/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
@@ -117,14 +117,17 @@ public sealed class EventPublishTests
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Publishing_an_unregistered_event_type_throws_even_without_asking()
+    public async Task Publishing_an_unregistered_event_type_is_a_no_op_like_a_registered_one()
     {
         await using var provider = CreateProvider();
-        var mediator = provider.GetRequiredService<IEventMediator>();
+        var recorder = new PipelineRecorder();
 
-        // Unlike NobodyListens, this type is not in the registry at all — see the README.
-        await Assert.ThrowsAsync<NoHandlerFoundException>(
-            async () => await mediator.PublishAsync(new UnknownEvent()));
+        // UnknownEvent is not in the registry at all, NobodyListens is registered with no
+        // handlers. Both reach nobody, and both are silent unless the caller asks — the
+        // flag used to govern only the second.
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new UnknownEvent(), recorder.Events());
+
+        recorder.AssertStages();
     }
 
     [Fact]
@@ -151,5 +154,21 @@ public sealed class EventPublishTests
         await provider.GetRequiredService<IEventMediator>().PublishAsync(new StockChanged(), settings);
 
         recorder.AssertStages("reporting");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Publishing_an_unregistered_event_type_throws_when_the_caller_asks_it_to()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<IEventMediator>();
+        var settings = new EventMediationSettings { ThrowIfNoHandlerFound = true };
+
+        // The other half of the flag's new reach: what the unregistered case used to do
+        // unconditionally, it now does on request — the same as the registered-but-unhandled
+        // case two scenarios up. Appended rather than placed beside its sibling: a member
+        // inserted above renumbers the state machines below it and churns the lane map.
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.PublishAsync(new UnknownEvent(), settings));
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Groups/GroupFilteringTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Groups/GroupFilteringTests.cs
@@ -4,6 +4,7 @@ using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Generated;
 
@@ -92,9 +93,9 @@ public sealed class GroupFilteringTests
         await using var provider = CreateProvider();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        // A registered message whose handlers are all filtered out reports differently
-        // from a message type that was never registered at all — see the README.
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        // A registered message whose handlers are all filtered out reports the same type
+        // as a message that was never registered at all; only the message differs.
+        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new ReportingOnly()));
 
         Assert.Contains(nameof(ReportingOnly), thrown.Message, StringComparison.Ordinal);
@@ -122,7 +123,7 @@ public sealed class GroupFilteringTests
         var mediator = provider.GetRequiredService<ICommandMediator>();
         var settings = new CommandMediationSettings { Filters = { Groups = new[] { Reporting } } };
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new Mixed(), settings));
     }
 
@@ -167,7 +168,7 @@ public sealed class GroupFilteringTests
         await using var provider = CreateProvider();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new ReportingOnly(), GroupSet.Empty));
     }
 
@@ -181,5 +182,23 @@ public sealed class GroupFilteringTests
         await provider.GetRequiredService<ICommandMediator>().SendAsync(command, new[] { Reporting });
 
         Assert.True(command.Handled);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_filtered_out_dispatch_is_still_catchable_as_an_InvalidOperationException()
+    {
+        await using var provider = CreateProvider();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // This case threw a plain InvalidOperationException before the two "nothing will
+        // handle this" exceptions were unified. NoHandlerFoundException derives from it so
+        // that callers who were catching that keep catching it — the compatibility half of
+        // the unification, which nothing else here would notice losing.
+        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
+            async () => await mediator.SendAsync(new ReportingOnly()));
+
+        Assert.IsAssignableFrom<InvalidOperationException>(thrown);
+        Assert.Equal(typeof(ReportingOnly), thrown.MessageType);
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
@@ -4,6 +4,7 @@ using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
@@ -168,7 +169,7 @@ public sealed class PolymorphicDispatchTests
         // Covariant command dispatch is resolution-time only: once the derived type has a
         // descriptor of its own, the base-typed handler is an indirect handler there and
         // single-handler mediation never considers it. See the README.
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
             async () => await mediator.SendAsync(new DepositEntry()));
 
         Assert.Contains(nameof(DepositEntry), thrown.Message, StringComparison.Ordinal);

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -233,10 +233,28 @@ than change by accident.
    it — and the two stay told apart by the message alone. Pinned by the group-filtering
    scenarios and `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right`.
 
-3. **Events invert the default for "no handler."** Publishing a *registered* event nobody
-   handles is a silent no-op unless `ThrowIfNoHandlerFound` is set; publishing an
-   *unregistered* event type throws `NoHandlerFoundException` regardless of that flag. The
-   setting only controls the first case.
+3. ~~**Events invert the default for "no handler."**~~ *Fixed.* Publishing an
+   *unregistered* event type used to throw `NoHandlerFoundException` whatever the caller
+   asked for, while a *registered* event nobody handles was a silent no-op unless
+   `ThrowIfNoHandlerFound` was set — so the flag governed one of the two ways a publish
+   reaches nobody. Both obey it now, and the default for both is the silent no-op that
+   fire-and-forget implies. Pinned by
+   `Publishing_an_unregistered_event_type_is_a_no_op_like_a_registered_one` and
+   `Publishing_an_unregistered_event_type_throws_when_the_caller_asks_it_to`.
+
+   The cost is real and was taken deliberately: a misspelled or never-registered event
+   type used to announce itself and now goes quietly. `ThrowIfNoHandlerFound` is the way
+   to get that back for a publisher that must know someone listened.
+
+   What the old behavior really depended on is worth recording, because it is a trap for
+   anyone writing event tests anywhere: **"unregistered" is not a property of the event
+   type, it is a property of the whole process.** The resolve strategy falls back to the
+   first *assignable* descriptor, so a single participant registered against the `IEvent`
+   marker — a non-generic `IEventPreInterceptor`, say — gives every event type in the
+   process a descriptor, and nothing is unregistered from then on. The old throw therefore
+   fired or did not fire depending on whether such a participant existed anywhere in the
+   app. This area keeps its own `[ExcludeFromDiscovery]` types and registers nothing at
+   marker level (rule 3 above), which is what makes `UnknownEvent` mean what it says here.
 
 4. **Covariance applies to interceptors but not to main handlers.** An interceptor
    registered against a supertype joins a derived message's pipeline. A *handler*

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -224,11 +224,14 @@ than change by accident.
    `null` (or the result type's default). Pinned by
    `Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value`.
 
-2. **Two different exceptions mean "nothing will handle this."** A message type that is not
-   in the registry produces `NoHandlerFoundException`; a registered message whose handlers
-   are all filtered out by a group filter produces a plain
-   `InvalidOperationException("No handler is registered for X.")`. Callers cannot catch
-   both with one type.
+2. ~~**Two different exceptions mean "nothing will handle this."**~~ *Fixed.* A message
+   type absent from the registry used to produce `NoHandlerFoundException` while a
+   registered message whose handlers were all filtered out produced a plain
+   `InvalidOperationException("No handler is registered for X.")`, so no single `catch`
+   covered both. Both now raise `NoHandlerFoundException` — which derives from
+   `InvalidOperationException`, so callers who were catching the second case keep catching
+   it — and the two stay told apart by the message alone. Pinned by the group-filtering
+   scenarios and `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right`.
 
 3. **Events invert the default for "no handler."** Publishing a *registered* event nobody
    handles is a silent no-op unless `ThrowIfNoHandlerFound` is set; publishing an
@@ -286,7 +289,7 @@ than change by accident.
    that marker themselves — `ICommandPreInterceptor<T> : ICommand`. The synchronous
    contracts in `Core.Abstractions.Handlers` have no such facade, so a bare
    `IPreInterceptor<T>` is silently skipped by `RegisterGenerated`, and the dispatch fails
-   later with `InvalidOperationException: No handler is registered for X`. The silence is
+   later with `NoHandlerFoundException: No handler is registered for X`. The silence is
    the scan path's alone: handing the same bare type to the explicit `Register<T>()` throws
    `NotSupportedException` at registration instead. Every synchronous participant in this
    suite therefore declares `: ICommand, IPreInterceptor<T>` — see `Sync/SyncContracts.cs`

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -256,17 +256,18 @@ than change by accident.
    the final interceptor gets `null`. Three different values (`ValueTask`, `null` from the
    exception stage, `null` on abort) for "there is no result."
 
-7. **The generated staged-plan code emits nullable warnings into the consumer's build.**
-   Building this project surfaces `CS8604` eight times per TFM in
-   `ErgosfareRegistrations.g.cs` — the emitted staged result plan passes a
-   possibly-null `string` into the post-interceptor's non-nullable `messageResult`
-   parameter. It appears once per reference-typed post interceptor per emitted plan body
-   (the direct and the provider-resolved one), so the count tracks how many staged result
-   plans carry post interceptors: two for `PipelineResultCommand`, two for the synchronous
-   `SyncResultCommand`, four for `AbortResultCommand`'s two post slots. The synchronous
-   ones prove the arm is not async-only: `IPostInterceptor<TMessage, TResult>.Handle` has
-   the same non-nullable parameter. Left unsuppressed on purpose: these are the only
-   warnings in this project and they are evidence the staged-plan lane is being exercised.
+7. ~~**The generated staged-plan code emits nullable warnings into the consumer's
+   build.**~~ *Fixed.* Building this project used to surface `CS8604` eight times per TFM
+   in `ErgosfareRegistrations.g.cs`: the emitted staged result plan cast its post chain to
+   `TResult?` and handed that to the post interceptor's non-nullable `messageResult`
+   parameter, which broke consumers building with `TreatWarningsAsErrors`. The emitter now
+   picks the cast from the stage contract — post takes `TResult`, exception and final take
+   `TResult?` — so **this project builds with zero warnings**, and a warning appearing here
+   again is a regression rather than a curiosity.
+
+   The count used to double as evidence that the staged-plan lane was being exercised.
+   That job belongs to the [lane-map baseline](#lane-map-baseline) now, which names the
+   lane that ran instead of inferring it from a warning.
 
 8. **A synchronous exception or final interceptor throws `NullReferenceException` on a
    void pipeline.** The void pipeline carries a `ValueTask` in its result slot, but the

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -264,12 +264,24 @@ than change by accident.
    never considers, so the dispatch fails. Pinned by the two
    `A_base_typed_handler_*` scenarios.
 
-5. **Runtime registry mutation is half-supported.** Registering an interceptor type after
-   the container is built does change the next dispatch — but only if that type was already
-   in DI. Otherwise the next dispatch throws `InvalidOperationException: No service for
-   type ...`, and because the registry has no removal, that message type stays broken for
-   the rest of the process. Pinned by
-   `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`.
+5. ~~**Runtime registry mutation is half-supported.**~~ *Partly fixed — the diagnosis, not
+   the constraint.* Registering an interceptor type after the container is built changes
+   the next dispatch only if that type is also in DI. It used to fail with an opaque
+   `InvalidOperationException: No service for type ...`, raised part-way through the
+   dispatch by whichever stage first asked for the participant. Pipeline construction now
+   checks every planned participant against the container up front and raises
+   `UnresolvableParticipantException`, which names the message, names the participant and
+   states the remedy, before any stage runs.
+
+   **The underlying constraint stands and cannot be fixed here:** the registry is
+   process-wide, has no removal, and a container is per-application, so a participant
+   resolvable in one container may be absent from another. That is also why the check
+   cannot live in `Register` — only a pipeline being built in a container's context can
+   answer the question. What the fix does guarantee is that the failure is not sticky:
+   nothing is cached for a failed build, so a container that does register the participant
+   builds the pipeline the broken one could not. Pinned by
+   `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`
+   and `A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not`.
 
 6. **A void pipeline's "result" is a `ValueTask` sentinel, except on abort.** Post, final
    and exception interceptors of a void command are handed a non-null `ValueTask` as the

--- a/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
@@ -4,6 +4,7 @@ using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Generated;
@@ -164,10 +165,78 @@ public sealed class RuntimeRegistrationMutationTests
         // pipeline that now includes it cannot be constructed. See the README.
         provider.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableLatePre));
 
-        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+        var thrown = await Assert.ThrowsAsync<UnresolvableParticipantException>(
             async () => await mediator.SendAsync(new PoisonTarget()));
 
         Assert.Contains(nameof(UnresolvableLatePre), thrown.Message, StringComparison.Ordinal);
+        Assert.Equal(typeof(PoisonTarget), thrown.MessageType);
+        Assert.Equal(typeof(UnresolvableLatePre), thrown.ParticipantType);
+    }
+
+    // --- recovery from an unresolvable late registration -----------------------
+
+    /// <summary>
+    /// The recovery scenario keeps types of its own. Sharing <see cref="PoisonTarget"/>
+    /// would make each scenario's outcome depend on which ran first: the registry is
+    /// process-wide and never forgets, so whichever registered the unresolvable
+    /// interceptor first would break the other's opening dispatch.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    public sealed class RecoveryTarget : ICommand;
+
+    /// <inheritdoc cref="RecoveryTarget"/>
+    [ExcludeFromDiscovery]
+    public sealed class RecoveryTargetHandler : ICommandHandler<RecoveryTarget>
+    {
+        public ValueTask HandleAsync(RecoveryTarget command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="RecoveryTarget"/>
+    [ExcludeFromDiscovery]
+    public sealed class UnresolvableRecoveryPre : ICommandPreInterceptor<RecoveryTarget>
+    {
+        public ValueTask<RecoveryTarget> HandleAsync(RecoveryTarget command, IExecutionContext context)
+        {
+            context.Mark("late");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not()
+    {
+        await using var missing = new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.Register<RecoveryTargetHandler>()))
+            .BuildServiceProvider();
+
+        await missing.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget());
+
+        missing.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableRecoveryPre));
+
+        await Assert.ThrowsAsync<UnresolvableParticipantException>(
+            async () => await missing.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget()));
+
+        // The registry entry is permanent, so registering the participant with a container
+        // is the only way back — and it has to work. Nothing about the failed build is
+        // cached, so this container reaches the same pipeline the broken one could not,
+        // interceptor included.
+        await using var repaired = new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<RecoveryTargetHandler>()
+                    .Register<UnresolvableRecoveryPre>()))
+            .BuildServiceProvider();
+
+        var recorder = new PipelineRecorder();
+        await repaired.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget(), recorder.Commands());
+
+        recorder.AssertStages("late", "handler");
     }
 }
 

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -2329,6 +2329,8 @@ RuntimeRegistrationSyncTests — stages: [pre]
 
 stages: []
 
+stages: []
+
 stages: [default]
   1. default
      | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.A_default_publish_skips_grouped_handlers

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -2453,6 +2453,33 @@ stages: [invoice, warehouse]
 
 stages: [late, handler]
   1. late
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+UnresolvableRecoveryPre.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not>d__16.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RecoveryTargetHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [late, handler]
+  1. late
      | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
        | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync

--- a/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/InvocationStrategies/FinalInterceptorInvocationStrategyTests.cs
@@ -45,9 +45,13 @@ public class FinalInterceptorInvocationStrategyTests:
     public async Task Invoke_ShouldExecuteDirectAndIndirectFinalInterceptors()
     {
         _messageDependencyFixture = _messageDependencyFixture.New;
-        _messageDependencyFixture.MessageRegistry.Register(typeof(StubIndirectMessage));
-        _messageDependencyFixture.MessageRegistry.Register(typeof(StubFinalInterceptor));
-        _messageDependencyFixture.MessageRegistry.Register(typeof(StubIndirectFinalInterceptor));
+
+        // RegisterHandler rather than MessageRegistry.Register: it registers with the
+        // container as well, and building a pipeline now verifies its participants are
+        // resolvable there. Registry-only setup described a pipeline that could never
+        // have dispatched.
+        _messageDependencyFixture.RegisterHandler(
+            typeof(StubIndirectMessage), typeof(StubFinalInterceptor), typeof(StubIndirectFinalInterceptor));
 
         
         

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult]Test.cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions.Exceptions;
+﻿using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Basic;
@@ -111,7 +111,7 @@ public class SingleAsyncHandlerMediationStrategyTMessageTResultTests :
 
     /// <summary>
     /// A message with a descriptor but no direct handler must fail with an explicit
-    /// <see cref="InvalidOperationException"/>.
+    /// <see cref="NoHandlerFoundException"/>.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
@@ -130,7 +130,7 @@ public class SingleAsyncHandlerMediationStrategyTMessageTResultTests :
                 new StubMessage(), dependencies, _executionContextFixture.Ctx, _messageDependencyFixture.ServiceProvider));
 
         // assert
-        Assert.IsType<InvalidOperationException>(exception);
+        Assert.IsType<NoHandlerFoundException>(exception);
 
         // cleanup
         _messageDependencyFixture.Dispose();

--- a/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage,TResult]TestS.cs
+++ b/test/Stella.Ergosfare.Core.Test/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage,TResult]TestS.cs
@@ -1,4 +1,4 @@
-using Stella.Ergosfare.Core.Abstractions.Exceptions;
+﻿using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Test.Fixtures;
 using Stella.Ergosfare.Test.Fixtures.Stubs.Stream;
@@ -89,7 +89,7 @@ public class SingleStreamHandlerMediationStrategyTMessageTResultTests :
 
     /// <summary>
     /// A message with a descriptor but no direct stream handler must fail with an explicit
-    /// <see cref="InvalidOperationException"/> when enumeration starts.
+    /// <see cref="NoHandlerFoundException"/> when enumeration starts.
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
@@ -112,7 +112,7 @@ public class SingleStreamHandlerMediationStrategyTMessageTResultTests :
         });
 
         // assert
-        Assert.IsType<InvalidOperationException>(exception);
+        Assert.IsType<NoHandlerFoundException>(exception);
 
         // cleanup
         _messageDependencyFixture.Dispose();

--- a/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/BroadcastFastLaneTests.cs
@@ -1,7 +1,12 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
 using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Registry;
+using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
+using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;
 using Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection;
@@ -414,5 +419,87 @@ public class BroadcastFastLaneTests
             .PublishAsync(new ScopedEvent(), settings);
 
         Assert.Same(expected, settings.Items["probe"]);
+    }
+
+    [ExcludeFromDiscovery]
+    public sealed class NeverRegisteredEvent : IEvent { }
+
+    /// <summary>
+    /// An <see cref="IMessageMediator"/> that is not the concrete <c>MessageMediator</c>,
+    /// so the invoker takes its foreign-mediator branch. Every member throws: an
+    /// unregistered event must be answered by the caller's flag before the Mediate path —
+    /// which raises unconditionally — is ever reached.
+    /// </summary>
+    private sealed class UnreachableMediator : IMessageMediator
+    {
+        public ValueTask DispatchAsync(object message, IDictionary<object, object?>? items = null,
+            CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public ValueTask<TResult> DispatchAsync<TResult>(object message, IDictionary<object, object?>? items = null,
+            CancellationToken cancellationToken = default, IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public ValueTask DispatchAsync(object message, IExecutionContext context, IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public ValueTask<TResult> DispatchAsync<TResult>(object message, IExecutionContext context,
+            IEnumerable<string>? groups = null)
+            => throw new UnreachableException();
+
+        public TMessageResult Mediate<TMessage, TMessageResult>(TMessage message,
+            MediateOptions<TMessage, TMessageResult> options) where TMessage : notnull
+            => throw new UnreachableException();
+    }
+
+    /// <summary>
+    /// An empty registry, so "this type has no descriptor" is true by construction.
+    /// </summary>
+    /// <remarks>
+    /// The shared registry cannot express it: this assembly registers
+    /// <c>ExcludeFromPipelineTests.BroadPre</c>, a non-generic <c>IEventPreInterceptor</c>
+    /// and therefore a descriptor for <c>IEvent</c> itself. From that registration onward
+    /// the resolve strategy's assignable fallback answers for *every* event type, and
+    /// nothing in the process is unregistered any more. Which test ran first would decide
+    /// this one's outcome.
+    /// </remarks>
+    private sealed class EmptyRegistry : IMessageRegistry
+    {
+        public int Count => 0;
+
+        public IEnumerator<IMessageDescriptor> GetEnumerator()
+            => Enumerable.Empty<IMessageDescriptor>().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Register(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicConstructors)]
+            Type type)
+            => throw new UnreachableException();
+
+        public void RegisterDescriptors(IEnumerable<IHandlerDescriptor> descriptors)
+            => throw new UnreachableException();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Coverage")]
+    public async Task Publish_ShouldHonorThrowIfNoHandlerFound_ForAnUnregisteredType_OnAForeignMediator()
+    {
+        await using var provider = Build();
+
+        var mediator = new EventMediator(
+            new ActualTypeOrFirstAssignableTypeMessageResolveStrategy(new EmptyRegistry()),
+            provider.GetRequiredService<IResultAdapterService>(),
+            new UnreachableMediator());
+
+        // Default: silent, exactly as for a registered event nobody handles. Reaching the
+        // Mediate path at all is the failure — it raises whatever the caller asked for.
+        await mediator.PublishAsync(new NeverRegisteredEvent());
+
+        await Assert.ThrowsAsync<NoHandlerFoundException>(async () =>
+            await mediator.PublishAsync(
+                new NeverRegisteredEvent(),
+                new EventMediationSettings { ThrowIfNoHandlerFound = true }));
     }
 }

--- a/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/StreamFastLaneTests.cs
@@ -138,12 +138,13 @@ public class StreamFastLaneTests
         // process-wide, though: another suite's marker-targeted (IQuery-assignable)
         // interceptor may have given every query a descriptor, in which case both paths
         // defer and fail at enumeration with the strategy's no-handler error instead —
-        // the fast-lane/Mediate parity this test guards holds either way.
+        // the fast-lane/Mediate parity this test guards holds either way. Both timings now
+        // raise NoHandlerFoundException; only the timing tells them apart.
         try
         {
             var stream = mediator.StreamAsync(new UnhandledStream());
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await Assert.ThrowsAsync<NoHandlerFoundException>(async () =>
             {
                 await foreach (var _ in stream)
                 {

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanEmissionTests.cs
@@ -170,6 +170,60 @@ public class StagedPlanEmissionTests
     }
 
     [Fact]
+    public void ReferenceTypedStages_EachTakeTheCastTheirOwnContractDeclares()
+    {
+        var result = GeneratorTestHost.Run("""
+            using System;
+            using System.Threading.Tasks;
+            using Stella.Ergosfare.Queries.Abstractions;
+
+            namespace TestApp
+            {
+                public sealed record StagedTextQuery : IQuery<string>;
+
+                public sealed class StagedTextQueryHandler : IQueryHandler<StagedTextQuery, string>
+                {
+                    public ValueTask<string> HandleAsync(StagedTextQuery message, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult("ok");
+                }
+
+                public sealed class StagedTextQueryPost : IQueryPostInterceptor<StagedTextQuery, string>
+                {
+                    public ValueTask<string> HandleAsync(StagedTextQuery query, string queryResult, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(queryResult);
+                }
+
+                public sealed class StagedTextQueryException : IQueryExceptionInterceptor<StagedTextQuery, string>
+                {
+                    public ValueTask<string?> HandleAsync(StagedTextQuery query, string? result, Exception exception, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => ValueTask.FromResult(result);
+                }
+
+                public sealed class StagedTextQueryFinal : IQueryFinalInterceptor<StagedTextQuery, string>
+                {
+                    public ValueTask HandleAsync(StagedTextQuery query, string? result, Exception? exception, Stella.Ergosfare.Core.Abstractions.IExecutionContext context)
+                        => default;
+                }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Empty(result.CompilationErrors);
+
+        // Every stage used to be cast to TResult?, and a cast to a nullable type resets
+        // the expression's nullable state to maybe-null however non-null the chain
+        // variable is. The post stage declares `TResult messageResult`, so that produced
+        // CS8604 in every consumer's build — an outright failure where warnings are
+        // errors. Value-typed results never showed it, which is why it survived so long.
+        Assert.DoesNotContain(result.OutputCompilation.GetDiagnostics(), d => d.Id == "CS8604");
+
+        // Post takes TResult; exception and final take TResult?.
+        Assert.Contains("(string)postChain, context);", result.GeneratedSource);
+        Assert.Contains("(string?)exceptionChain, e, context);", result.GeneratedSource);
+        Assert.Contains("(string?)result, exception, context);", result.GeneratedSource);
+    }
+
+    [Fact]
     public void ConstructibleParticipants_EmitTheDirectConstructionVariant()
     {
         var result = GeneratorTestHost.Run("""


### PR DESCRIPTION
Closes #129 · Phase 2 of the core modernization · four sub-PRs, all merged into this branch

Four defects documented while the contract suite was built, each shipped on its own branch
and reviewed on its own. This PR is the phase closeout.

| Sub-PR | Issue | What it fixed |
| --- | --- | --- |
| #139 | #134 (F7) | The staged-plan emitter cast every stage to `TResult?`; the post stage declares `TResult`, so consumers got `CS8604` — a build failure under `TreatWarningsAsErrors` |
| #140 | #135 (F2) | "Nothing will handle this" raised two different exception types; callers could not catch both |
| #141 | #136 (F3) | `ThrowIfNoHandlerFound` governed one of the two ways a publish reaches nobody |
| #142 | #137 (F5) | A participant the container cannot resolve failed part-way through a dispatch with an opaque DI error |

Plus one commit that is not a sub-PR: `df2a358`, a CI trigger fix, explained under
[Scope taken beyond the issues](#scope-taken-beyond-the-issues).

## What a consumer can notice

Three things, in descending order of how loud they are. **The changelog entry for the next
release needs all three; none is written yet** — this repository writes the changelog per
release in its own docs commit, not per PR.

**1. Publishing an unregistered event type no longer throws.** It is a silent no-op unless
`ThrowIfNoHandlerFound` is set, matching what a registered-but-unhandled event always did.

The old behavior was not merely inconsistent, it was **unstable across applications**: the
resolve strategy falls back to the first *assignable* descriptor, so a single participant
registered against the `IEvent` marker gives every event type in the process a descriptor,
after which nothing is unregistered and the publish was already silent. Whether the old
throw fired depended on whether such a participant existed anywhere in the app. The
unified behavior is the one those applications already had.

*The cost, taken deliberately:* a misspelled or never-registered event type used to
announce itself and now goes quietly. `ThrowIfNoHandlerFound` is how a publisher that must
know someone listened gets it back. A compensating diagnostic was considered and rejected
in #141 — see [Open items](#open-items).

**2. `NoHandlerFoundException` now derives from `InvalidOperationException`** and covers
the filtered-out case as well as the unregistered one. The derivation is deliberate rather
than incidental: without it, unifying the two types would have silently broken every
consumer whose `catch (InvalidOperationException)` handles what the strategies throw today.
Widening cannot break a compile. The type also gains a `MessageType` property.

**3. New exception type `UnresolvableParticipantException`**, also deriving from
`InvalidOperationException`, replacing the opaque `No service for type ...` that used to
surface mid-dispatch.

Generated code changes shape (F7) but not behavior: `(string?)x` and `(string)x` produce
the same reference at run time.

## Scope taken beyond the issues

**CI triggers (`df2a358`).** Found while watching #138's checks: only `Coverage` ran, and
`UnitTests`/`AotSmoke` had never run on a pull request into `preview-dev` at all. GitHub's
`*` branch filter does not match a slash, so this phase's four sub-PRs — all targeting
`fix/modernization-phase-2` — would have received **no CI whatsoever**, `Coverage`
included. All three workflows now use `**` on `pull_request`. Push triggers were left
alone. Verified on #139: `unit-tests` and `aot-smoke` ran on a slash-named base for the
first time.

**Three tests outside the issues' inventories**, all found by the full-solution run rather
than by grep:

- `Queries.Test/StreamFastLaneTests.cs` — its `try/catch (NoHandlerFoundException)` never
  protected the inner assertion, as #135 predicted.
- `Core.Test` — the `[TMessage,TResult]` async and stream strategies' no-handler tests use
  `Assert.IsType`, which my `ThrowsAsync` grep missed.
- `Core.Test/FinalInterceptorInvocationStrategyTests` — the one place where the new
  validation changed an existing test's *premise* rather than its expected exception. It
  registered participants into the registry alone and inspected the graph, describing a
  pipeline that could never have dispatched; it passed only because resolution was lazy and
  the test never dispatched.

**Regression gates for two fixes that nothing would otherwise have caught:**

- F7: a warning count is not a test. `StagedPlanEmissionTests` gained a reference-typed
  query carrying all three result-carrying stages, asserting no `CS8604` in the generated
  compilation.
- F5's rebuildability guarantee, and F2's derivation — a later "cleanup" of the base type
  would have passed every other test.

Each was verified to fail against the unfixed code, not merely to pass against the fixed
code.

## The suite as the safety net

| | Before phase 2 | After |
| --- | --- | --- |
| Contract scenarios | 153 | **156** |
| Lane-map baseline | 2543 lines | **2572** — `+29 / −0`, two sections added, no renumbering |
| Solution build warnings | 8 per TFM | **0** |
| Other suites | — | `SourceGenerator.Test` 57→58, `Events.Test` 41→42 |

Every sub-PR re-captured the lane map and explained its diff. Every diff this phase was a
pure addition; no phase-2 change moved a dispatch onto a different lane, which is the
property the baseline exists to detect.

Four contract scenarios changed their expected exception type and one inverted its
expected behavior. Each is listed with its justification in its own PR body, which is the
agreed process for deliberate behavior changes.

## Two flakes caught before CI

Both were mine, both from the same root cause — **the registry is process-wide, so
"unregistered" is a property of the whole process, not of a type**:

- #141's first Events.Test scenario failed **four runs in five**. This assembly registers a
  non-generic `IEventPreInterceptor`, an `IEvent`-level descriptor, after which no event
  type is unregistered. It now builds its resolve strategy over an empty registry, so the
  premise is true by construction.
- #142's recovery scenario would have made two tests order-dependent had it reused
  `PoisonTarget`; it carries its own types.

The trap is recorded in the suite README, since it bites anyone writing event tests, not
just this phase.

## Verification on this branch

| Gate | Result |
| --- | --- |
| Contract suite, net9.0 / net10.0 | 156/156 each |
| Flake sweep | net9.0 ×12, net10.0 ×10, zero failures |
| Full solution, both TFMs | green, 14 test assemblies |
| Clean solution build | 0 warnings |
| Lane map | matches the committed baseline; two runs and both TFMs byte-identical |

## Open items

Two decisions this PR deliberately leaves to you rather than settling:

1. **Changelog.** All three consumer-visible changes above are unwritten. Written per
   release here, so it belongs either to this merge or to the next release entry.
2. **A diagnostic for the event type that now goes quietly** (F3's cost). Rejected inside
   #141 as out of scope: a debug-only log needs a logging dependency `Events` does not
   have, and an analyzer cannot see runtime registrations. Worth its own issue if it is
   worth anything.

Carried forward to phase 3 unchanged, all recorded in the suite README: findings 8
(void-pipeline `NullReferenceException`), 10 (`CS0311` on `ValueTask`-shaped synchronous
main handlers), 11 (memoized instance versus registry version), and the broadcast fan-out
ordering policy.
