### PR TITLE
fix: F4 — kovaryans simetrisi, tekil-handler çözümlemesi indirect handler'ları da değerlendirir

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -55,15 +55,23 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
         {
             throw new ArgumentNullException(nameof(messageDependencies));
         }
-        if (messageDependencies.Handlers.Count > 1)
+        // Direct and covariantly matched handlers are one candidate set; see the void
+        // strategy for the reasoning.
+        var handlers = messageDependencies.Handlers;
+        var indirectHandlers = messageDependencies.IndirectHandlers;
+        var handlerCount = handlers.Count + indirectHandlers.Count;
+
+        if (handlerCount > 1)
         {
-            throw new MultipleHandlerFoundException(typeof(TMessage), messageDependencies.Handlers.Count);
+            throw new MultipleHandlerFoundException(typeof(TMessage), handlerCount);
         }
 
-        if (messageDependencies.Handlers.Count == 0)
+        if (handlerCount == 0)
         {
             throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
+
+        var soleHandler = handlers.Count == 1 ? handlers[0] : indirectHandlers[0];
 
         var preInterceptorCount = messageDependencies.PreInterceptors.Count;
         var postInterceptorCount = messageDependencies.PostInterceptors.Count;
@@ -79,7 +87,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
             // derived one — IHandler's `in TMessage` variance covers that), invoke the typed
             // member directly and skip the object-typed DIM bridge. Interface-erased
             // dispatches (TMessage = ICommand<T> etc.) fall back to the bridge.
-            var fastHandler = messageDependencies.Handlers[0].Resolve(serviceProvider);
+            var fastHandler = soleHandler.Resolve(serviceProvider);
 
             var fastResult = await InvokeHandler(fastHandler, message, context);
 
@@ -99,7 +107,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
                     messageDependencies, serviceProvider, message, context);
             }
 
-            var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
+            var handler = soleHandler.Resolve(serviceProvider);
 
             result = await InvokeHandler(handler, message, context);
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -48,15 +48,25 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
             throw new ArgumentNullException(nameof(messageDependencies));
         }
 
-        if (messageDependencies.Handlers.Count > 1)
+        // Direct and covariantly matched handlers are one candidate set: a handler written
+        // against a supertype serves this message whether or not the message has a
+        // descriptor of its own. Counted before anything resolves, so a contested message
+        // runs neither handler.
+        var handlers = messageDependencies.Handlers;
+        var indirectHandlers = messageDependencies.IndirectHandlers;
+        var handlerCount = handlers.Count + indirectHandlers.Count;
+
+        if (handlerCount > 1)
         {
-            throw new MultipleHandlerFoundException(typeof(TMessage), messageDependencies.Handlers.Count);
+            throw new MultipleHandlerFoundException(typeof(TMessage), handlerCount);
         }
 
-        if (messageDependencies.Handlers.Count == 0)
+        if (handlerCount == 0)
         {
             throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
+
+        var soleHandler = handlers.Count == 1 ? handlers[0] : indirectHandlers[0];
 
         var preInterceptorCount = messageDependencies.PreInterceptors.Count;
         var postInterceptorCount = messageDependencies.PostInterceptors.Count;
@@ -71,7 +81,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
             // Typed seam: direct typed invocation when the dispatch TMessage satisfies the
             // handler's message type (`in TMessage` variance; `out TResult` admits ValueTask<T>
             // for a ValueTask slot). Interface-erased dispatches fall back to the DIM bridge.
-            var fastHandler = messageDependencies.Handlers[0].Resolve(serviceProvider);
+            var fastHandler = soleHandler.Resolve(serviceProvider);
 
             await InvokeHandler(fastHandler, message, context);
 
@@ -98,7 +108,7 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
                     messageDependencies, serviceProvider, message, context);
             }
 
-            var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
+            var handler = soleHandler.Resolve(serviceProvider);
 
             await InvokeHandler(handler, message, context);
             result = Unit.Value;

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleStreamHandlerMediationStrategy[TMessage, TResult].cs
@@ -45,17 +45,23 @@ public sealed class SingleStreamHandlerMediationStrategy<TMessage, TResult>(
     public async IAsyncEnumerable<TResult> Mediate(TMessage message, IMessageDependencies messageDependencies,
         IExecutionContext context, IServiceProvider serviceProvider)
     {
-        if (messageDependencies.Handlers.Count > 1)
+        // Direct and covariantly matched handlers are one candidate set; see
+        // SingleAsyncHandlerMediationStrategy{TMessage} for the reasoning.
+        var handlers = messageDependencies.Handlers;
+        var indirectHandlers = messageDependencies.IndirectHandlers;
+        var handlerCount = handlers.Count + indirectHandlers.Count;
+
+        if (handlerCount > 1)
         {
-            throw new MultipleHandlerFoundException(typeof(TMessage), messageDependencies.Handlers.Count);
+            throw new MultipleHandlerFoundException(typeof(TMessage), handlerCount);
         }
 
-        if (messageDependencies.Handlers.Count == 0)
+        if (handlerCount == 0)
         {
             throw new NoHandlerFoundException(typeof(TMessage), $"No handler is registered for {typeof(TMessage).Name}.");
         }
 
-        var handler = messageDependencies.Handlers[0].Resolve(serviceProvider);
+        var handler = (handlers.Count == 1 ? handlers[0] : indirectHandlers[0]).Resolve(serviceProvider);
 
         // enumerator to consume
         IAsyncEnumerable<TResult>? enumerable = null;

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/MessageDependencies.cs
@@ -82,7 +82,13 @@ internal sealed class MessageDependencies : IMessageDependencies
             && ExceptionInterceptors.Count == 0
             && FinalInterceptors.Count == 0;
 
-        FastSingleHandler = HasNoInterceptors && Handlers.Count == 1 ? Handlers[0] : null;
+        // The candidate set the single-handler strategies resolve against is direct plus
+        // indirect, so the executors' short circuit has to count both — a message with one
+        // direct and one covariantly matched handler is contested, and must reach the
+        // strategy to be told so rather than quietly running the direct one.
+        FastSingleHandler = HasNoInterceptors && Handlers.Count + IndirectHandlers.Count == 1
+            ? Handlers.Count == 1 ? Handlers[0] : IndirectHandlers[0]
+            : null;
         MemoizedInstances = memoizedProvider is not null;
     }
 
@@ -101,8 +107,9 @@ internal sealed class MessageDependencies : IMessageDependencies
     internal bool HasNoInterceptors { get; }
 
     /// <summary>
-    /// The sole main handler when the pipeline has exactly one handler and no interceptor
-    /// stages; <c>null</c> otherwise. Computed once at construction.
+    /// The sole main handler — direct or covariantly matched — when the pipeline has
+    /// exactly one and no interceptor stages; <c>null</c> otherwise. Computed once at
+    /// construction.
     /// </summary>
     internal IHandlerReference<IHandler, IMainHandlerDescriptor>? FastSingleHandler { get; }
 

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -1267,6 +1267,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 continue;
             }
 
+            if (HasCovariantMainHandler(type, handlerCounts))
+            {
+                continue;
+            }
+
             var (handler, handlerDescriptor) = soleHandlers[type.TypeofExpression];
 
             if (!handler.IsAccessible || !handler.DiscoveryKeys.IsEmpty || handler.GroupsExpression is not null)
@@ -1746,6 +1751,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             return false;
         }
 
+        if (HasCovariantMainHandler(type, handlerCounts))
+        {
+            return false;
+        }
+
         if (interceptedMessages.Contains(type.TypeofExpression))
         {
             return false;
@@ -1756,6 +1766,34 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         return handler.IsAccessible
                && handler.DiscoveryKeys.IsEmpty
                && handler.GroupsExpression is null;
+    }
+
+    /// <summary>
+    ///     Whether any main handler is registered against a base type or interface of the
+    ///     message. Single-handler mediation treats those as candidates alongside the
+    ///     direct ones, so a message that has both is contested and must fail its dispatch
+    ///     — something a plan, which bakes one handler in, cannot express. Disqualifying
+    ///     here keeps the compiled lane and the reflective one telling the same story.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately blunt: a message whose only handler is covariantly matched is
+    ///     dispatchable and could in principle be planned (<c>IAsyncHandler</c>'s
+    ///     <c>in TMessage</c> variance admits the base-typed handler), but the model has no
+    ///     way to prove the supertype registration is the only one the runtime will see.
+    ///     Those dispatches take the reflective path, as they did before covariance reached
+    ///     main handlers at all.
+    /// </remarks>
+    private static bool HasCovariantMainHandler(RegistrableTypeModel type, Dictionary<string, int> handlerCounts)
+    {
+        foreach (var assignableKey in type.AssignableKeys)
+        {
+            if (handlerCounts.ContainsKey(assignableKey))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void AddModels(

--- a/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Polymorphism/PolymorphicDispatchTests.cs
@@ -161,18 +161,19 @@ public sealed class PolymorphicDispatchTests
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right()
+    public async Task A_base_typed_handler_serves_a_derived_message_registered_in_its_own_right()
     {
         await using var provider = CreateProvider();
-        var mediator = provider.GetRequiredService<ICommandMediator>();
+        var recorder = new PipelineRecorder();
+        var command = new DepositEntry();
 
-        // Covariant command dispatch is resolution-time only: once the derived type has a
-        // descriptor of its own, the base-typed handler is an indirect handler there and
-        // single-handler mediation never considers it. See the README.
-        var thrown = await Assert.ThrowsAsync<NoHandlerFoundException>(
-            async () => await mediator.SendAsync(new DepositEntry()));
+        // Registering the derived type in its own right files the base-typed handler as an
+        // indirect one for it. Single-handler mediation considers those too, so whether the
+        // message has a descriptor of its own no longer decides who serves it.
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command, recorder.Commands());
 
-        Assert.Contains(nameof(DepositEntry), thrown.Message, StringComparison.Ordinal);
+        recorder.AssertStages("handler:base");
+        Assert.Equal(nameof(DepositEntry), command.SeenType);
     }
 
     [Fact]
@@ -186,5 +187,47 @@ public sealed class PolymorphicDispatchTests
             .PublishAsync(new ShipmentDispatched(), recorder.Events());
 
         recorder.AssertStages("direct:audit", "direct:notify", "indirect:interface");
+    }
+
+    // --- a derived message claimed from both sides -----------------------------
+    //
+    // Appended rather than filed beside the other ledger types: a member inserted above
+    // renumbers the state machines below it and churns the lane map for no reason.
+
+    /// <summary>Registered in its own right and handled in its own right, under a handled base.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class WithdrawalEntry : LedgerEntry;
+
+    /// <summary>The direct claim on <see cref="WithdrawalEntry"/>; the base handler is the other one.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class WithdrawalEntryHandler : ICommandHandler<WithdrawalEntry>
+    {
+        public ValueTask HandleAsync(WithdrawalEntry command, IExecutionContext context)
+        {
+            command.SeenType = command.GetType().Name;
+            context.Mark("handler:direct");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_direct_and_a_base_typed_handler_claiming_one_message_fail_the_dispatch()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Covariance reaching main handlers means a derived message can be claimed twice:
+        // directly and through its base. That is the same contest two direct handlers
+        // create, and it fails the same way rather than picking a winner.
+        var thrown = await Assert.ThrowsAsync<MultipleHandlerFoundException>(
+            async () => await mediator.SendAsync(new WithdrawalEntry(), recorder.Commands()));
+
+        Assert.Contains(nameof(WithdrawalEntry), thrown.Message, StringComparison.Ordinal);
+        Assert.Contains("2", thrown.Message, StringComparison.Ordinal);
+
+        // Counted before anything resolves: neither claimant runs.
+        Assert.Empty(recorder.Stages);
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -231,7 +231,7 @@ than change by accident.
    covered both. Both now raise `NoHandlerFoundException` — which derives from
    `InvalidOperationException`, so callers who were catching the second case keep catching
    it — and the two stay told apart by the message alone. Pinned by the group-filtering
-   scenarios and `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right`.
+   scenarios.
 
 3. ~~**Events invert the default for "no handler."**~~ *Fixed.* Publishing an
    *unregistered* event type used to throw `NoHandlerFoundException` whatever the caller
@@ -256,13 +256,31 @@ than change by accident.
    app. This area keeps its own `[ExcludeFromDiscovery]` types and registers nothing at
    marker level (rule 3 above), which is what makes `UnknownEvent` mean what it says here.
 
-4. **Covariance applies to interceptors but not to main handlers.** An interceptor
-   registered against a supertype joins a derived message's pipeline. A *handler*
-   registered against a supertype only serves a derived message that has no descriptor of
-   its own — register the derived type (which `RegisterGenerated` does for every discovered
-   message) and the base handler becomes an indirect handler that single-handler mediation
-   never considers, so the dispatch fails. Pinned by the two
-   `A_base_typed_handler_*` scenarios.
+4. ~~**Covariance applies to interceptors but not to main handlers.**~~ *Fixed.* An
+   interceptor registered against a supertype joins a derived message's pipeline; a
+   *handler* registered against a supertype used to serve a derived message only while that
+   message had no descriptor of its own. Registering the derived type — which
+   `RegisterGenerated` does for every discovered message — filed the base handler as an
+   indirect one, and single-handler mediation never looked there, so the dispatch failed.
+
+   Direct and indirect handlers are one candidate set now, so whether a message has a
+   descriptor of its own no longer decides who serves it. Two candidates are a contest and
+   fail the dispatch with `MultipleHandlerFoundException` — the same outcome two direct
+   handlers produce, counted before anything resolves so neither claimant runs. Pinned by
+   the two `A_base_typed_handler_*` scenarios and
+   `A_direct_and_a_base_typed_handler_claiming_one_message_fail_the_dispatch`.
+
+   Two consequences worth knowing:
+
+   - **A group filter that empties the direct set now falls through to a covariantly
+     matched handler** rather than failing with `NoHandlerFoundException`. The filter is
+     applied to both sets while the shape is built, so an indirect handler that survives it
+     is a candidate like any other. No scenario pins this corner yet.
+   - **The compiled plans give such a message up.** A message with any base-typed main
+     handler is disqualified from every staged and single-handler plan: a plan bakes one
+     handler in and cannot express "this is contested", and the model cannot prove the
+     supertype registration is the only one the runtime will see. Those dispatches take the
+     reflective path, and the lane map is what says so.
 
 5. ~~**Runtime registry mutation is half-supported.**~~ *Partly fixed — the diagnosis, not
    the constraint.* Registering an interceptor type after the container is built changes
@@ -282,6 +300,13 @@ than change by accident.
    builds the pipeline the broken one could not. Pinned by
    `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`
    and `A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not`.
+
+   The check covers indirect main handlers too, which was the one corner where it could
+   have broken a dispatch that always worked: single-handler mediation never read that slot,
+   so an unresolvable handler sitting in it was harmless. Entry 4 closed that gap from the
+   other side — the slot is a candidate set now, so anything in it genuinely has to be
+   resolvable, and checking it is no longer eager. Only the events fan-out ever read it
+   before, and it always resolved what it read.
 
 6. ~~**A void pipeline's "result" is a `ValueTask` sentinel, except on abort.**~~ *Fixed.*
    Post, final and exception interceptors of a void command used to be handed a non-null

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -2596,6 +2596,16 @@ stages: [handler, post, final]
 
 stages: [handler:base]
   1. handler:base
+     | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.A_base_typed_handler_serves_a_derived_message_registered_in_its_own_right
+       | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<A_base_typed_handler_serves_a_derived_message_registered_in_its_own_right>d__17.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+LedgerEntryHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler:base]
+  1. handler:base
      | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests.A_base_typed_handler_serves_a_derived_message_that_is_not_registered_itself
        | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+<A_base_typed_handler_serves_a_derived_message_that_is_not_registered_itself>d__16.MoveNext
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync


### PR DESCRIPTION
Closes #149
Closes #145

Faz 3'ün ikinci alt işi. **PR #154'ün (F6a) üzerine yığılmış** — hedef dal şimdilik
`fix/void-result-single-representation`; #154 merge olunca GitHub bu PR'ı otomatik olarak
`fix/modernization-phase-3`'e yeniden hedefler. Gerekçe: her iki iş de `baselines/lane-map.txt`'i
yeniden yakalıyor, ve F6a'sız bir ağaçtan yakalanmış baseline #154 merge olduğu anda bayat
olurdu. Feature dalından ayrı ayrı dallanmak epik'te (#130) uyarılan lane-map çakışmasını
garanti ederdi; yığmak onu tamamen ortadan kaldırıyor.

## Ne değişti

Kovaryans interceptor'lara ulaşıyordu ama ana handler'larda duruyordu. Supertype'a kayıtlı
bir handler, türetilmiş mesaja **yalnız o mesajın kendi descriptor'u yokken** hizmet
ediyordu. Türetilmiş tip kendi adına kaydolunca base handler `IndirectHandlers`'a
düşüyor, tekil-handler mediation yalnız direct listeyi okuduğu için dispatch
`NoHandlerFoundException` ile patlıyordu. `RegisterGenerated` keşfettiği her mesajı
kaydettiği için bu hata, assembly'ye türetilmiş tipi eklemekle geliyordu — ne handler ne
dispatch değişmeden.

Artık **direct ve indirect tek aday kümesi**. Üç tekil-handler stratejisi (void, result,
stream) iki listeyi de sayıyor; toplam 1'den büyükse `MultipleHandlerFoundException`,
0 ise `NoHandlerFoundException`, tek adayı hangi liste taşıyorsa oradan çözüyor. Sayım
hâlâ hiçbir şey resolve edilmeden yapılıyor — çekişmeli bir mesaj hiçbir adayı koşturmuyor,
iki direct handler'ın zaten davrandığı gibi (Faz 1'in `Handlers/MultipleMainHandlerTests`
alanı bunu pinliyor ve bu PR'da değişmedi).

`MessageDependencies.FastSingleHandler` de aynı aritmetiği öğrenmek zorundaydı: executor'ların
stratejiyi tamamen atladığı kısa devre, yalnız direct listeye bakıyordu. Bir direct + bir
kovaryant handler'ı olan mesaj kısa devreden geçip **sessizce direct handler'ı koşardı**,
çekişmeli olduğu söylenmek yerine.

## İki eksen ayrışmasın diye: generator kapısı

`TryGetSolePlannableHandler` ve staged-plan kapısı, assignable key'lerinden birine kayıtlı
ana handler'ı olan her mesajı **diskalifiye ediyor**. Plan tek bir handler'ı içine gömüyor
ve "bu çekişmeli" diyemiyor; model de supertype kaydının runtime'ın göreceği tek kayıt
olduğunu kanıtlayamıyor. Bu kapı olmasaydı iki eksen ayrışırdı: emit edilen plan gömülü
handler'ı koşarken strateji aynı mesaj için `MultipleHandlerFoundException` atardı.

Bedeli açık: böyle bir mesaj derleme-zamanı planını kaybediyor ve reflective yola düşüyor —
yani kovaryansın ana handler'lara hiç ulaşmadığı dönemdeki yerine. Sessiz değil: lane-map
bir `StagedPlanN` frame'inin strateji frame'ine dönüşmesi olarak gösterir.

## Sonradan keşfedilmesin diye söylenen iki şey

- **Grup filtresi direct kümeyi boşaltırsa artık kovaryant handler'a düşüyor**, eskiden
  `NoHandlerFoundException` ile patlarken. Filtre shape kurulurken iki listeye de
  uygulanıyor, dolayısıyla filtreden sağ çıkan bir indirect handler diğerleri gibi aday.
  Bu köşeyi pinleyen senaryo yok ve bu PR bir tane eklemiyor — README'de yazılı.
- **#145 bu işte eridi.** Geç-kayıt doğrulaması indirect ana handler'ları da denetliyordu;
  bu ancak biri onları okuyorsa savunulabilirdi, ve tekil-handler mediation hiç okumuyordu —
  yani o slota park etmiş çözülemez bir handler zararsızdı ve denetim **daima çalışan** bir
  dispatch'i kırabiliyordu. Slot artık aday kümesi, dolayısıyla içindekinin gerçekten
  çözülebilir olması gerekiyor. README bulgu 5'e bu paragraf eklendi.

## Değişen ve eklenen suite testleri

| Test | Değişiklik | Gerekçe |
|---|---|---|
| `Polymorphism` · `A_base_typed_handler_does_not_serve_a_derived_message_registered_in_its_own_right` | **ters döndü**, adı `A_base_typed_handler_serves_a_derived_message_registered_in_its_own_right` | Kararın adıyla andığı test. Artık dispatch'in `handler:base`'e ulaştığını ve base-tipli handler'ın türetilmiş runtime tipini gördüğünü assert ediyor — kardeş senaryonun kayıtsız tip için zaten assert ettiği şey. İkisi artık aynı sözleşme, mesele de bu |
| `Polymorphism` · `A_base_typed_handler_serves_a_derived_message_that_is_not_registered_itself` | değişmedi | Regresyon kapısı |
| `Polymorphism` · `A_direct_and_a_base_typed_handler_claiming_one_message_fail_the_dispatch` | **yeni** | Kararın diğer yarısı: kendi türetilmiş mesajı ve direct handler'ı var, zaten handler'lı bir base'in altında. İki kez talep edilmenin iki direct talep gibi patladığını, mesajı ve sayıyı adlandırdığını, hiçbir handler'ı koşturmadığını pinliyor. Sınıfın **sonuna** eklendi (`d__N`) |
| `Handlers/MultipleMainHandlerTests` dört senaryo | değişmedi | Çoklu-aday kuralının aynı istisnaya çıktığının kanıtı |
| `Groups/GroupFilteringTests` | değişmedi | Pinli senaryoların hiçbiri kovaryant handler'lı bir mesaja dokunmuyor |

README bulgu 4 *Fixed*; bulgu 2'nin ikinci pin referansı düştü (adlandırdığı senaryo artık
`NoHandlerFoundException` atmıyor); bulgu 5 eagerness sorusunu kapatan paragrafı aldı.

## Lane-map diff'i

**+10 satır, 0 silme, `StagedPlanN` numaraları değişmedi.** Tek yeni bölüm ters dönen
senaryo — eskiden işaretlenecek hiçbir şeye ulaşmadan patlıyordu. Frame'leri okumaya değer:
dispatch `VoidPipelineExecutor` üzerinden **araya strateji frame'i girmeden** base-tipli
handler'a gidiyor. Bu, `FastSingleHandler`'ın bu PR'da öğrendiği aritmetiğin kendisi —
assert edilmiş değil, görünür halde.

Polymorphism alanı keyed, dolayısıyla burada tehlikede olan bir plan yoktu ve generator'ın
yeni diskalifikasyonu bu dosyada hiçbir frame'i oynatmıyor.

## Kapılar

- Contract suite **166 → 167**, iki TFM × iki eksen yeşil (×2 koşum)
- Tam çözüm testleri yeşil (14 proje/TFM)
- **Sıfır uyarı**

## Açık bırakılan

- Grup filtresi × kovaryant handler köşesi pinsiz (yukarıda). Ayrı senaryo isterseniz
  `contract.groups` keyed alanına eklenebilir, plan lane'ini kıpırdatmaz.
- Kararda opsiyonel bırakılan "generator'dan bilgilendirici tanılama" **yapılmadı**:
  diskalifikasyon bir kullanıcı hatası değil, mesaj yine doğru dispatch ediliyor — yalnız
  reflective yoldan. Bir tanılama burada gürültü olurdu; kayıt lane-map'te zaten var.
