### PR TITLE
fix: F1 — abort kısa devre, çağırana istisna değil üretilmiş sonuç

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/Context/Abstractions/IExecutionContext.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Context/Abstractions/IExecutionContext.cs
@@ -71,15 +71,22 @@ public interface IExecutionContext
     ExecutionContextScope CreateScope();
 
     /// <summary>
-    /// Aborts the execution of the current mediation operation.
+    /// Short-circuits the current mediation: nothing after the calling participant runs,
+    /// and the caller gets whatever the pipeline had produced by then.
     /// </summary>
-    /// <param name="messageResult">
-    /// The message result to set before aborting. Required if the message has a specific result type
-    /// and the execution is aborted in the pre-handler phase.
-    /// </param>
     /// <remarks>
-    /// When called, execution is immediately aborted and no further handlers are executed.
-    /// If a message result is required, it must be provided to satisfy the result type requirement.
+    /// <para>
+    /// Aborting is not a failure. The caller sees no exception, the exception-interceptor
+    /// stage does not run, and the remaining stages of the aborting participant's own stage
+    /// are skipped. Final interceptors still run — they always do — and are handed the same
+    /// result the caller receives, with no exception.
+    /// </para>
+    /// <para>
+    /// What the caller receives is what the pipeline had already produced. Abort after the
+    /// handler has run and its result is delivered; abort before it and there is nothing to
+    /// deliver, so the caller gets <c>null</c> or the result type's default. A resultless
+    /// dispatch simply completes.
+    /// </para>
     /// </remarks>
-    void Abort(object? messageResult = null);
+    void Abort();
 }

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage,TResult].cs
@@ -89,7 +89,18 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
             // dispatches (TMessage = ICommand<T> etc.) fall back to the bridge.
             var fastHandler = soleHandler.Resolve(serviceProvider);
 
-            var fastResult = await InvokeHandler(fastHandler, message, context);
+            TResult fastResult;
+
+            try
+            {
+                fastResult = await InvokeHandler(fastHandler, message, context);
+            }
+            catch (ExecutionAbortedException)
+            {
+                // The handler short-circuited before producing anything, so there is
+                // nothing to hand back but the result type's default.
+                return default!;
+            }
 
             var fastEx = resultAdapterService?.LookupException(fastResult);
             if (fastEx is not null) throw fastEx;
@@ -124,9 +135,11 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage, TResult>(IResu
         }
         catch (ExecutionAbortedException)
         {
-            throw;
+            // A short circuit, not a failure: the exception stage is skipped, the caller
+            // sees no exception, and `result` — whatever the pipeline had produced by the
+            // time the abort unwound — is what the final stage and the caller both get.
         }
-        catch (Exception e) when (e is not ExecutionAbortedException)
+        catch (Exception e)
         {
             exception = e;
 

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/MediationStrategies/SingleAsyncHandlerMediationStrategy[TMessage].cs
@@ -83,7 +83,16 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
             // for a ValueTask slot). Interface-erased dispatches fall back to the DIM bridge.
             var fastHandler = soleHandler.Resolve(serviceProvider);
 
-            await InvokeHandler(fastHandler, message, context);
+            try
+            {
+                await InvokeHandler(fastHandler, message, context);
+            }
+            catch (ExecutionAbortedException)
+            {
+                // The handler short-circuited its own dispatch. There is nothing to return
+                // and no stage left to tell, so the dispatch simply completes.
+                return;
+            }
 
             var fastEx = resultAdapterService?.LookupException(Unit.Value);
 
@@ -127,7 +136,13 @@ public sealed class SingleAsyncHandlerMediationStrategy<TMessage>(
                 result = invokedPostResult ?? result;
             }
         }
-        catch (Exception e) when (e is not ExecutionAbortedException)
+        catch (ExecutionAbortedException)
+        {
+            // A short circuit, not a failure: the exception stage is skipped, the caller
+            // sees no exception, and the final stage below still runs with whatever the
+            // pipeline had produced.
+        }
+        catch (Exception e)
         {
             exception = e;
 

--- a/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Contexts/ErgosfareExecutionContext.cs
@@ -169,11 +169,15 @@ internal sealed class ErgosfareExecutionContext(
     }
 
 
-    /// <summary>
-    /// Aborts the current mediation by throwing <see cref="ExecutionAbortedException"/>.
-    /// </summary>
-    /// <param name="messageResult">The result to abort with, when the pipeline requires one.</param>
-    public void Abort(object? messageResult = null)
+    /// <inheritdoc />
+    /// <remarks>
+    /// <see cref="ExecutionAbortedException"/> is how the short circuit travels: it unwinds
+    /// the participant and everything between it and the mediation strategy (or the baked
+    /// plan), which catches it, skips the exception stage and returns the result produced so
+    /// far. It is an implementation detail of the unwind and never reaches the caller — a
+    /// <c>catch</c> for it in participant code would defeat the abort, not observe it.
+    /// </remarks>
+    public void Abort()
     {
         throw new ExecutionAbortedException();
     }

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/AbortShortCircuit.cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/AbortShortCircuit.cs
@@ -1,0 +1,50 @@
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
+
+namespace Stella.Ergosfare.Core.Internal.Mediator;
+
+/// <summary>
+/// The executors' half of the abort contract. A pipeline with no interceptor stages is
+/// invoked handler-first, straight from the executor, with the mediation strategy — and its
+/// abort handling — skipped entirely. Only the handler itself can short-circuit such a
+/// dispatch, and nothing was produced when it does, so the caller gets the result type's
+/// default and no exception.
+/// </summary>
+/// <remarks>
+/// A synchronous throw never reaches here: the executors catch that around the invocation
+/// itself. This covers the other half, an abort captured into the returned task, and it
+/// pays only when the handler did not complete synchronously — the hot path returns without
+/// building a state machine.
+/// </remarks>
+internal static class AbortShortCircuit
+{
+    /// <summary>Completes normally if <paramref name="task"/> aborted.</summary>
+    public static ValueTask Guard(ValueTask task)
+        => task.IsCompletedSuccessfully ? default : Awaited(task);
+
+    /// <summary>Yields <c>default</c> if <paramref name="task"/> aborted.</summary>
+    public static ValueTask<TResult> Guard<TResult>(ValueTask<TResult> task)
+        => task.IsCompletedSuccessfully ? task : Awaited(task);
+
+    private static async ValueTask Awaited(ValueTask task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (ExecutionAbortedException)
+        {
+        }
+    }
+
+    private static async ValueTask<TResult> Awaited<TResult>(ValueTask<TResult> task)
+    {
+        try
+        {
+            return await task;
+        }
+        catch (ExecutionAbortedException)
+        {
+            return default!;
+        }
+    }
+}

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
@@ -1,4 +1,5 @@
-﻿using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -54,19 +55,28 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
                 ? _directHandlerFactory is not null ? _directHandlerFactory() : _providerHandlerFactory!(serviceProvider)
                 : handlerReference.Resolve(serviceProvider);
 
-            if (handler is THandler planned)
+            // The strategy is skipped here, so its abort handling has to be too; see
+            // AbortShortCircuit.
+            try
             {
-                return planned.HandleAsync((TMessage)message, context);
-            }
+                if (handler is THandler planned)
+                {
+                    return AbortShortCircuit.Guard(planned.HandleAsync((TMessage)message, context));
+                }
 
-            switch (handler)
+                switch (handler)
+                {
+                    case IAsyncHandler<TMessage, TResult> asyncHandler:
+                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
+                    case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
+                    case IHandler<TMessage, TResult> syncHandler:
+                        return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+                }
+            }
+            catch (ExecutionAbortedException)
             {
-                case IAsyncHandler<TMessage, TResult> asyncHandler:
-                    return asyncHandler.HandleAsync((TMessage)message, context);
-                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
-                    return valueTaskShaped.Handle((TMessage)message, context);
-                case IHandler<TMessage, TResult> syncHandler:
-                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+                return ValueTask.FromResult<TResult>(default!);
             }
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
@@ -1,4 +1,5 @@
-﻿using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -73,20 +74,29 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             // match. A runtime re-registration can put a differently-typed handler here;
             // the contract switch below then dispatches it exactly as the runtime
             // executor would.
-            if (handler is THandler planned)
+            // The strategy is skipped here, so its abort handling has to be too; see
+            // AbortShortCircuit.
+            try
             {
-                return planned.HandleAsync((TMessage)message, context);
-            }
+                if (handler is THandler planned)
+                {
+                    return AbortShortCircuit.Guard(planned.HandleAsync((TMessage)message, context));
+                }
 
-            switch (handler)
+                switch (handler)
+                {
+                    case IAsyncHandler<TMessage> asyncHandler:
+                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
+                    case IHandler<TMessage, ValueTask> valueTaskShaped:
+                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
+                    case IHandler<TMessage, object> syncHandler:
+                        syncHandler.Handle((TMessage)message, context);
+                        return ValueTask.CompletedTask;
+                }
+            }
+            catch (ExecutionAbortedException)
             {
-                case IAsyncHandler<TMessage> asyncHandler:
-                    return asyncHandler.HandleAsync((TMessage)message, context);
-                case IHandler<TMessage, ValueTask> valueTaskShaped:
-                    return valueTaskShaped.Handle((TMessage)message, context);
-                case IHandler<TMessage, object> syncHandler:
-                    syncHandler.Handle((TMessage)message, context);
-                    return ValueTask.CompletedTask;
+                return ValueTask.CompletedTask;
             }
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
@@ -1,4 +1,5 @@
-﻿using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -48,14 +49,24 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
         {
             var handler = handlerReference.Resolve(serviceProvider);
 
-            switch (handler)
+            // The strategy is skipped here, so its abort handling has to be too; see
+            // AbortShortCircuit. Nothing was produced when a zero-interceptor handler
+            // aborts, so the caller gets the result type's default.
+            try
             {
-                case IAsyncHandler<TMessage, TResult> asyncHandler:
-                    return asyncHandler.HandleAsync((TMessage)message, context);
-                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
-                    return valueTaskShaped.Handle((TMessage)message, context);
-                case IHandler<TMessage, TResult> syncHandler:
-                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+                switch (handler)
+                {
+                    case IAsyncHandler<TMessage, TResult> asyncHandler:
+                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
+                    case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
+                    case IHandler<TMessage, TResult> syncHandler:
+                        return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
+                }
+            }
+            catch (ExecutionAbortedException)
+            {
+                return ValueTask.FromResult<TResult>(default!);
             }
 
             // Unsupported handler contract: fall through so the strategy raises its

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
@@ -1,4 +1,5 @@
-﻿using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Abstractions.Registry.Descriptors;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
@@ -37,15 +38,25 @@ internal sealed class VoidPipelineExecutor<TMessage>(
         {
             var handler = handlerReference.Resolve(serviceProvider);
 
-            switch (handler)
+            // The strategy is skipped here, so its abort handling has to be too; see
+            // AbortShortCircuit. The try covers a handler that aborts synchronously, the
+            // guard the one that captured the abort into its task.
+            try
             {
-                case IAsyncHandler<TMessage> asyncHandler:
-                    return asyncHandler.HandleAsync((TMessage)message, context);
-                case IHandler<TMessage, ValueTask> valueTaskShaped:
-                    return valueTaskShaped.Handle((TMessage)message, context);
-                case IHandler<TMessage, object> syncHandler:
-                    syncHandler.Handle((TMessage)message, context);
-                    return ValueTask.CompletedTask;
+                switch (handler)
+                {
+                    case IAsyncHandler<TMessage> asyncHandler:
+                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
+                    case IHandler<TMessage, ValueTask> valueTaskShaped:
+                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
+                    case IHandler<TMessage, object> syncHandler:
+                        syncHandler.Handle((TMessage)message, context);
+                        return ValueTask.CompletedTask;
+                }
+            }
+            catch (ExecutionAbortedException)
+            {
+                return ValueTask.CompletedTask;
             }
         }
 

--- a/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
+++ b/src/Stella.Ergosfare.Events/AsyncBroadcastMediationStrategy.cs
@@ -101,6 +101,12 @@ public sealed class AsyncBroadcastMediationStrategy<TMessage>(
                     messageDependencies, null, serviceProvider, message, Unit.Value, context);
             }
         }
+        catch (ExecutionAbortedException)
+        {
+            // A short circuit, not a failure: a participant stopped the publish, the
+            // exception stage is skipped and the caller sees no exception. Final
+            // interceptors below still run.
+        }
         catch (Exception e)
         {
             exception = e;

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -661,11 +661,18 @@ internal static class RegistrationEmitter
         if (!needsGuards)
         {
             // Pre-only pipeline: with zero exception and final stages the strategy's
-            // try/catch/finally is a no-op shell — exceptions propagate unchanged.
-            EmitPreCalls(sb, plan, direct, "                ");
-            sb.Append("                await ");
+            // try/catch/finally collapses to the abort arm alone — exceptions propagate
+            // unchanged, an abort completes the dispatch with nothing to hand back.
+            sb.AppendLine("                try");
+            sb.AppendLine("                {");
+            EmitPreCalls(sb, plan, direct, "                    ");
+            sb.Append("                    await ");
             AppendParticipant(sb, plan.HandlerTypeExpression, direct ? plan.HandlerConstructionExpression : null);
             sb.AppendLine(".HandleAsync(message, context);");
+            sb.AppendLine("                }");
+            sb.Append("                catch (").Append(AbortedExceptionFullName).AppendLine(")");
+            sb.AppendLine("                {");
+            sb.AppendLine("                }");
             return;
         }
 
@@ -694,7 +701,13 @@ internal static class RegistrationEmitter
         }
 
         sb.AppendLine("                }");
-        sb.Append("                catch (global::System.Exception e) when (e is not ").Append(AbortedExceptionFullName).AppendLine(")");
+        // A short circuit, not a failure: the exception stage is skipped, the caller sees
+        // no exception, and the result produced so far survives into the final stage and
+        // the return — the strategy's own abort arm, emitted.
+        sb.Append("                catch (").Append(AbortedExceptionFullName).AppendLine(")");
+        sb.AppendLine("                {");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (global::System.Exception e)");
         sb.AppendLine("                {");
         sb.AppendLine("                    exception = e;");
 
@@ -729,10 +742,19 @@ internal static class RegistrationEmitter
 
         if (!needsGuards)
         {
-            EmitPreCalls(sb, plan, direct, "                ");
-            sb.Append("                return await ");
+            // Pre-only pipeline; see the void body. Nothing was produced when an abort
+            // unwinds through here, so the caller gets the result type's default.
+            sb.AppendLine("                try");
+            sb.AppendLine("                {");
+            EmitPreCalls(sb, plan, direct, "                    ");
+            sb.Append("                    return await ");
             AppendParticipant(sb, plan.HandlerTypeExpression, direct ? plan.HandlerConstructionExpression : null);
             sb.AppendLine(".HandleAsync(message, context);");
+            sb.AppendLine("                }");
+            sb.Append("                catch (").Append(AbortedExceptionFullName).AppendLine(")");
+            sb.AppendLine("                {");
+            sb.AppendLine("                    return default!;");
+            sb.AppendLine("                }");
             return;
         }
 
@@ -768,7 +790,13 @@ internal static class RegistrationEmitter
         }
 
         sb.AppendLine("                }");
-        sb.Append("                catch (global::System.Exception e) when (e is not ").Append(AbortedExceptionFullName).AppendLine(")");
+        // A short circuit, not a failure: the exception stage is skipped, the caller sees
+        // no exception, and the result produced so far survives into the final stage and
+        // the return — the strategy's own abort arm, emitted.
+        sb.Append("                catch (").Append(AbortedExceptionFullName).AppendLine(")");
+        sb.AppendLine("                {");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (global::System.Exception e)");
         sb.AppendLine("                {");
         sb.AppendLine("                    exception = e;");
 

--- a/test/Stella.Ergosfare.Contract.Test/Abort/PostAbortSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Abort/PostAbortSemanticsContract.cs
@@ -46,14 +46,13 @@ public abstract class PostAbortSemanticsContract
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller()
+    public async Task Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception()
     {
         await using var provider = CreateProvider();
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewCommand(), recorder.Commands()));
+        await mediator.SendAsync(NewCommand(), recorder.Commands());
 
         recorder.AssertStages("handler", "post:abort", "final");
     }
@@ -66,8 +65,7 @@ public abstract class PostAbortSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewCommand(), recorder.Commands()));
+        await mediator.SendAsync(NewCommand(), recorder.Commands());
 
         // A pre-interceptor abort leaves this null; by the post stage the handler has run,
         // so the pipeline's one result value is already in the slot and survives.
@@ -80,17 +78,20 @@ public abstract class PostAbortSemanticsContract
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller()
+    public async Task Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result()
     {
         await using var provider = CreateProvider();
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewResultCommand(), recorder.Commands()));
+        var result = await mediator.SendAsync(NewResultCommand(), recorder.Commands());
 
         recorder.AssertStages("handler", "post:abort", "final");
         Assert.Equal(AbortVocabulary.HandlerResult, recorder.DetailOf("post:abort"));
+
+        // The handler's result, not the value the aborting interceptor was about to
+        // return: the abort unwinds before the post stage writes its result back.
+        Assert.Equal(AbortVocabulary.HandlerResult, result);
     }
 
     [Fact]
@@ -101,11 +102,9 @@ public abstract class PostAbortSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewResultCommand(), recorder.Commands()));
+        await mediator.SendAsync(NewResultCommand(), recorder.Commands());
 
-        // The handler's result, not the value the aborting interceptor was about to return:
-        // the abort unwinds before the post stage writes its result back.
+        // The same value the caller gets, and no exception: an abort is not a failure.
         Assert.Equal($"{AbortVocabulary.HandlerResult}|none", recorder.DetailOf("final"));
     }
 
@@ -115,16 +114,19 @@ public abstract class PostAbortSemanticsContract
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException()
+    public async Task Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value()
     {
         await using var provider = CreateProvider();
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<IQueryMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.QueryAsync(NewValueQuery(), recorder.Queries()));
+        var result = await mediator.QueryAsync(NewValueQuery(), recorder.Queries());
 
         recorder.AssertStages("handler", "post:abort", "final");
+
+        // A value-typed result is produced just as much as a reference-typed one, so the
+        // caller gets the handler's number rather than the type's default.
+        Assert.Equal(AbortVocabulary.HandlerValue, result);
     }
 
     [Fact]
@@ -135,8 +137,7 @@ public abstract class PostAbortSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<IQueryMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.QueryAsync(NewValueQuery(), recorder.Queries()));
+        await mediator.QueryAsync(NewValueQuery(), recorder.Queries());
 
         Assert.Equal($"{AbortVocabulary.HandlerValue}|none", recorder.DetailOf("final"));
     }
@@ -153,8 +154,7 @@ public abstract class PostAbortSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewResultCommand(), recorder.Commands()));
+        await mediator.SendAsync(NewResultCommand(), recorder.Commands());
 
         // An abort is not a failure: the exception stage never sees it, and the lighter
         // post slot never runs.

--- a/test/Stella.Ergosfare.Contract.Test/Context/ExecutionContextDataFlowTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Context/ExecutionContextDataFlowTests.cs
@@ -148,4 +148,60 @@ public sealed class ExecutionContextDataFlowTests
         Assert.False(second.Items.ContainsKey("secret"));
         Assert.Equal("data", first.Items["secret"]);
     }
+
+    // --- a nested dispatch that aborts ------------------------------------------
+    //
+    // Appended rather than filed with the other types: a member inserted above renumbers
+    // the state machines below it and churns the lane map for no reason.
+
+    /// <summary>Dispatched from inside another handler, through a child scope.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class Inner : ICommand;
+
+    /// <summary>Aborts its own dispatch and nothing else.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class InnerHandler : ICommandHandler<Inner>
+    {
+        public ValueTask HandleAsync(Inner command, IExecutionContext context)
+        {
+            context.Abort();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>The outer dispatch, which nests the aborting one and carries on.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class Outer : ICommand
+    {
+        /// <summary>Whether the outer handler survived the nested abort.</summary>
+        public bool ReachedTheEnd;
+    }
+
+    /// <inheritdoc cref="Outer"/>
+    [DiscoveryKey(Key)]
+    public sealed class OuterHandler(ICommandMediator mediator) : ICommandHandler<Outer>
+    {
+        public async ValueTask HandleAsync(Outer command, IExecutionContext context)
+        {
+            using var scope = context.CreateScope();
+            await mediator.SendAsync(new Inner(), scope.Context);
+
+            command.ReachedTheEnd = true;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_nested_dispatchs_abort_stops_at_its_own_dispatch()
+    {
+        await using var provider = CreateProvider();
+        var command = new Outer();
+
+        // The abort's unwind is scoped to the dispatch that raised it. Nothing crosses the
+        // nested call back into the outer pipeline — the outer handler resumes on the next
+        // line and the outer dispatch completes normally.
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
+
+        Assert.True(command.ReachedTheEnd);
+    }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Events/EventPublishTests.cs
@@ -283,4 +283,61 @@ public sealed class EventPublishTests
         Assert.Equal(nameof(Unit), recorder.DetailOf("exception"));
         Assert.Equal(nameof(Unit), recorder.DetailOf("final"));
     }
+
+    // -----------------------------------------------------------------------
+    // aborting a publish
+    // -----------------------------------------------------------------------
+
+    /// <summary>An event whose post stage aborts after the handlers have run.</summary>
+    [DiscoveryKey(Key)]
+    public sealed class Recalled : IEvent;
+
+    [DiscoveryKey(Key)]
+    public sealed class RecalledHandler : IEventHandler<Recalled>
+    {
+        public ValueTask HandleAsync(Recalled @event, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="AnnouncedPost"/>
+    [DiscoveryKey(Key)]
+    public sealed class RecalledAbortingPost : IEvent, IAsyncPostInterceptor<Recalled>
+    {
+        public ValueTask<object> HandleAsync(Recalled @event, object result, IExecutionContext context)
+        {
+            context.Mark("post:abort");
+            context.Abort();
+            return ValueTask.FromResult(result);
+        }
+    }
+
+    /// <inheritdoc cref="AnnouncedPost"/>
+    [DiscoveryKey(Key)]
+    public sealed class RecalledFinal : IEvent, IAsyncFinalInterceptor<Recalled>
+    {
+        public ValueTask HandleAsync(
+            Recalled @event, object? result, Exception? exception, IExecutionContext context)
+        {
+            context.Mark("final", $"{Describe(result)}|{(exception is null ? "none" : exception.GetType().Name)}");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task Aborting_a_publish_completes_it_without_an_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = new PipelineRecorder();
+
+        // A publish short-circuits like any other dispatch: the exception stage never sees
+        // the abort, the final stage still runs, and the publisher gets no exception.
+        await provider.GetRequiredService<IEventMediator>().PublishAsync(new Recalled(), recorder.Events());
+
+        recorder.AssertStages("handler", "post:abort", "final");
+        Assert.Equal($"{nameof(Unit)}|none", recorder.DetailOf("final"));
+    }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineContracts.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineContracts.cs
@@ -95,7 +95,11 @@ public interface IPayloadValueQuery : IQuery<int>
 // void command pipeline
 // ---------------------------------------------------------------------------
 
-/// <summary>Marks its stage, then throws when the payload asks it to.</summary>
+/// <summary>
+/// Marks its stage, then throws or aborts when the payload asks it to. The abort branch is
+/// only reachable on the bare messages: where a pre-interceptor exists it aborts first, so
+/// the handler never sees that payload.
+/// </summary>
 [ExcludeFromDiscovery]
 public abstract class PayloadHandlerBase<TCommand> : ICommandHandler<TCommand>
     where TCommand : class, IPayloadCommand
@@ -108,6 +112,11 @@ public abstract class PayloadHandlerBase<TCommand> : ICommandHandler<TCommand>
         if (command.Payload.Contains(PipelineVocabulary.Throw, StringComparison.Ordinal))
         {
             throw new PipelineFailure("void handler failed");
+        }
+
+        if (command.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort();
         }
 
         return ValueTask.CompletedTask;
@@ -195,18 +204,20 @@ public abstract class PayloadResultHandlerBase<TCommand> : ICommandHandler<TComm
             throw new PipelineFailure("result handler failed");
         }
 
+        if (command.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
+        {
+            context.Abort();
+        }
+
         return ValueTask.FromResult(command.Payload);
     }
 }
 
-/// <summary>Aborts when asked — with a result value, to pin whether the value survives.</summary>
+/// <summary>Aborts when asked, before the handler has produced anything.</summary>
 [ExcludeFromDiscovery]
 public abstract class PayloadResultPreBase<TCommand> : ICommandPreInterceptor<TCommand>
     where TCommand : class, IPayloadResultCommand, new()
 {
-    /// <summary>The value handed to <see cref="IExecutionContext.Abort"/> on the abort path.</summary>
-    public const string AbortValue = "aborted-with-value";
-
     /// <inheritdoc />
     public ValueTask<TCommand> HandleAsync(TCommand command, IExecutionContext context)
     {
@@ -214,7 +225,7 @@ public abstract class PayloadResultPreBase<TCommand> : ICommandPreInterceptor<TC
 
         if (command.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
         {
-            context.Abort(AbortValue);
+            context.Abort();
         }
 
         return ValueTask.FromResult(new TCommand { Payload = command.Payload + PipelineVocabulary.Rewritten });
@@ -292,9 +303,6 @@ public abstract class PayloadValueHandlerBase<TQuery> : IQueryHandler<TQuery, in
 public abstract class PayloadValuePreBase<TQuery> : IQueryPreInterceptor<TQuery>
     where TQuery : class, IPayloadValueQuery, new()
 {
-    /// <summary>The value handed to <see cref="IExecutionContext.Abort"/> on the abort path.</summary>
-    public const int AbortValue = 41;
-
     /// <inheritdoc />
     public ValueTask<TQuery> HandleAsync(TQuery query, IExecutionContext context)
     {
@@ -302,7 +310,7 @@ public abstract class PayloadValuePreBase<TQuery> : IQueryPreInterceptor<TQuery>
 
         if (query.Payload.Contains(PipelineVocabulary.Abort, StringComparison.Ordinal))
         {
-            context.Abort(AbortValue);
+            context.Abort();
         }
 
         return ValueTask.FromResult(new TQuery { Payload = query.Payload + PipelineVocabulary.Rewritten });

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineSemanticsContract.cs
@@ -248,9 +248,10 @@ public abstract class PipelineSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewCommand("abort"), recorder.Commands()));
+        await mediator.SendAsync(NewCommand("abort"), recorder.Commands());
 
+        // Aborted before the handler ran, so there is nothing in the slot — and an abort is
+        // not a failure, so there is no exception either.
         Assert.Equal("abort|null|none", recorder.DetailOf("final"));
     }
 
@@ -260,30 +261,31 @@ public abstract class PipelineSemanticsContract
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException()
+    public async Task Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch()
     {
         await using var provider = CreateProvider();
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewCommand("abort"), recorder.Commands()));
+        await mediator.SendAsync(NewCommand("abort"), recorder.Commands());
 
+        // The handler and the post stage are skipped; the final stage always runs.
         recorder.AssertStages("pre", "final");
     }
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value()
+    public async Task Aborting_before_the_handler_delivers_no_result_to_the_caller()
     {
         await using var provider = CreateProvider();
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        // The pre-interceptor calls Abort(AbortValue); the caller never sees that value.
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewResultCommand("abort"), recorder.Commands()));
+        // Nothing had been produced when the pre-interceptor aborted, so there is nothing
+        // to hand back — the caller gets the result type's default, not an exception.
+        var result = await mediator.SendAsync(NewResultCommand("abort"), recorder.Commands());
 
+        Assert.Null(result);
         recorder.AssertStages("pre", "final");
         Assert.Equal("abort|null|none", recorder.DetailOf("final"));
     }
@@ -338,15 +340,15 @@ public abstract class PipelineSemanticsContract
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default()
+    public async Task A_value_typed_query_abort_delivers_the_result_types_default()
     {
         await using var provider = CreateProvider();
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<IQueryMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.QueryAsync(NewValueQuery("abort"), recorder.Queries()));
+        var result = await mediator.QueryAsync(NewValueQuery("abort"), recorder.Queries());
 
+        Assert.Equal(0, result);
         recorder.AssertStages("pre", "final");
         Assert.Equal("abort|0|none", recorder.DetailOf("final"));
     }
@@ -401,5 +403,42 @@ public abstract class PipelineSemanticsContract
         // failed inside the handler reaches its exception stage with an empty slot. Being a
         // reference type is what lets that slot stay empty instead of unboxing into a crash.
         Assert.Equal($"throw+rewritten|null|{nameof(PipelineFailure)}", recorder.DetailOf("exception"));
+    }
+
+    // -----------------------------------------------------------------------
+    // aborting a pipeline that has no interceptor stages
+    //
+    // Appended for the same reason as the block above.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        // With nothing to intercept, the executor invokes the handler and never enters the
+        // mediation strategy, so the strategy's abort handling is not the one that runs
+        // here. The contract is the same one either way: the caller sees no exception.
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewBareCommand("abort"), recorder.Commands());
+
+        recorder.AssertStages("handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_result_handler_aborting_a_pipeline_with_no_interceptors_delivers_the_default()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        var result = await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewBareResultCommand("abort"), recorder.Commands());
+
+        // The handler abandoned its own result, so there is nothing to deliver.
+        Assert.Null(result);
+        recorder.AssertStages("handler");
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -218,11 +218,30 @@ not comparable to this file.
 Pinned as-is. Each is a candidate for the modernization to decide on deliberately rather
 than change by accident.
 
-1. **`IExecutionContext.Abort(object? messageResult)` ignores its argument.** The
-   implementation throws `ExecutionAbortedException` unconditionally; the documented
-   "result to abort with" never reaches the caller, and the final interceptor is handed
-   `null` (or the result type's default). Pinned by
-   `Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value`.
+1. ~~**`IExecutionContext.Abort(object? messageResult)` ignores its argument.**~~ *Fixed.*
+   The implementation threw `ExecutionAbortedException` unconditionally and never read the
+   argument, so the documented "result to abort with" reached nobody — and the exception
+   itself surfaced to the caller, which the XML doc did not mention either.
+
+   Aborting is a short circuit now. The parameter is gone from the signature (it never
+   worked, and no shim pretends otherwise), and the caller receives **what the pipeline had
+   already produced**: the handler's result when the abort came after it, the result type's
+   default when it came before. No exception reaches the caller on any path, the
+   exception-interceptor stage never sees the abort, and final interceptors run as they
+   always do — handed the same value the caller gets, with no exception.
+
+   `ExecutionAbortedException` still exists and is still what travels: it unwinds the
+   participant up to the mediation strategy or the baked plan, which catches it. It is an
+   implementation detail of the unwind, not a signal to catch — a `catch` for it in
+   participant code defeats the abort rather than observing it.
+
+   Pinned across the areas that reach each arm: `Abort/` for "already produced" on all three
+   result shapes, the `Aborting_*` and `A_*_abort_*` scenarios in `Pipeline/` and `Sync/`
+   for "nothing produced yet",
+   `A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch` and its
+   result twin for the interceptor-free lane the executors serve without ever entering a
+   strategy, `Aborting_a_publish_completes_it_without_an_exception` for the fan-out, and
+   `A_nested_dispatchs_abort_stops_at_its_own_dispatch` for the scoped-child case.
 
 2. ~~**Two different exceptions mean "nothing will handle this."**~~ *Fixed.* A message
    type absent from the registry used to produce `NoHandlerFoundException` while a

--- a/test/Stella.Ergosfare.Contract.Test/Sync/SyncSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Sync/SyncSemanticsContract.cs
@@ -110,10 +110,9 @@ public abstract class SyncSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        // Same empty slot, reached through the abort path — the final stage sees it as
-        // null and ExecutionAbortedException reaches the caller unreplaced.
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewCommand("abort"), recorder.Commands()));
+        // Same empty slot, reached through the abort path: the final stage sees it as null,
+        // and the abort short-circuits without reaching the caller.
+        await mediator.SendAsync(NewCommand("abort"), recorder.Commands());
 
         recorder.AssertStages("pre", "final");
         Assert.Equal("abort|null|none", recorder.DetailOf("final"));
@@ -191,9 +190,9 @@ public abstract class SyncSemanticsContract
         var recorder = NewRecorder();
         var mediator = provider.GetRequiredService<ICommandMediator>();
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(
-            async () => await mediator.SendAsync(NewResultCommand("abort"), recorder.Commands()));
+        var result = await mediator.SendAsync(NewResultCommand("abort"), recorder.Commands());
 
+        Assert.Null(result);
         recorder.AssertStages("pre", "final");
         Assert.Equal("abort|null|none", recorder.DetailOf("final"));
     }

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -53,6 +53,26 @@ GeneratedRegistrationPipelineExclusionTests — stages: [pre:direct, handler]
                        | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationPipelineTests — stages: [handler]
+  1. handler  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch>d__32.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.GeneratedVoidPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [handler]
+  1. handler  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_aborting_a_pipeline_with_no_interceptors_delivers_the_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_aborting_a_pipeline_with_no_interceptors_delivers_the_default>d__33.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.GeneratedResultPipelineExecutor`3.Execute
+               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [handler]
   1. handler  <- throw
      | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered
        | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>d__16.MoveNext
@@ -66,87 +86,75 @@ GeneratedRegistrationPipelineTests — stages: [handler]
 
 GeneratedRegistrationPipelineTests — stages: [pre, final]
   1. pre  <- abort
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
-                         | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_delivers_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_delivers_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                     | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|0|none
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_delivers_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_delivers_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationPipelineTests — stages: [pre, final]
   1. pre  <- abort
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. final  <- abort|null|none
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_before_the_handler_delivers_no_result_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_before_the_handler_delivers_no_result_to_the_caller>d__24.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_before_the_handler_delivers_no_result_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_before_the_handler_delivers_no_result_to_the_caller>d__24.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationPipelineTests — stages: [pre, final]
   1. pre  <- abort
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. final  <- abort|null|none
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
   1. pre  <- throw
@@ -502,121 +510,103 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
 
 GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortVoidHandlerBase`1.HandleAsync
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortVoidHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. post:abort  <- Unit
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortingVoidPostBase`1.HandleAsync
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortingVoidPostBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. final  <- Unit|none
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortVoidFinalBase`1.HandleAsync
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan2+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortVoidFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortResultHandlerBase`1.HandleAsync
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result>d__7.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. post:abort  <- produced
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
-                         | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Abort.AbortingResultPostBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  3. final  <- produced|none
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortResultFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result>d__7.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortingResultPostBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- produced|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result>d__7.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan0+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationPostAbortTests — stages: [handler, post:abort, final]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortQueryHandlerBase`1.HandleAsync
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value>d__9.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortQueryHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. post:abort  <- 7
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
-                         | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Abort.AbortingQueryPostBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  3. final  <- 7|none
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value>d__9.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
+                     | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortingQueryPostBase`1.HandleAsync
                          | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- 7|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value>d__9.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan1+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationSyncEventHandlerTests — stages: [async, sync:object, sync:valuetask]
   1. async
@@ -847,53 +837,45 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
   1. pre  <- abort
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationSyncTests — stages: [pre, final]
   1. pre  <- abort
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0.<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0+<<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0.<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0+<<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                     | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
-                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
-                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
   1. pre  <- throw
@@ -1226,6 +1208,26 @@ RuntimeRegistrationPipelineExclusionTests — stages: [pre:direct, handler]
                        | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineTests — stages: [handler]
+  1. handler  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch>d__32.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [handler]
+  1. handler  <- abort
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_result_handler_aborting_a_pipeline_with_no_interceptors_delivers_the_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_result_handler_aborting_a_pipeline_with_no_interceptors_delivers_the_default>d__33.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [handler]
   1. handler  <- throw
      | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered
        | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_handler_exception_propagates_unwrapped_when_no_exception_interceptor_is_registered>d__16.MoveNext
@@ -1239,99 +1241,87 @@ RuntimeRegistrationPipelineTests — stages: [handler]
 
 RuntimeRegistrationPipelineTests — stages: [pre, final]
   1. pre  <- abort
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
-                             | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
-                               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
-                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_delivers_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_delivers_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|0|none
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>d__28.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0.<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass28_0+<<A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_value_typed_query_abort_delivers_the_result_types_default
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_value_typed_query_abort_delivers_the_result_types_default>d__28.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineTests — stages: [pre, final]
   1. pre  <- abort
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                             | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
-                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. final  <- abort|null|none
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>d__23.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0.<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass23_0+<<Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_before_the_handler_delivers_no_result_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_before_the_handler_delivers_no_result_to_the_caller>d__24.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
                              | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_before_the_handler_delivers_no_result_to_the_caller
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_before_the_handler_delivers_no_result_to_the_caller>d__24.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineTests — stages: [pre, final]
   1. pre  <- abort
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                             | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                               | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
-                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. final  <- abort|null|none
-     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value
-       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>d__24.MoveNext
-         | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0.<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0
-           | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<>c__DisplayClass24_0+<<Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
                              | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- abort|null|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<Aborting_from_a_pre_interceptor_skips_the_handler_and_completes_the_dispatch>d__23.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineTests — stages: [pre, handler, exception, final]
   1. pre  <- throw
@@ -1742,136 +1732,118 @@ RuntimeRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:tie-
 
 RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
-                         | Stella.Ergosfare.Contract.Test.Abort.AbortVoidHandlerBase`1.HandleAsync
-                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Abort.AbortVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. post:abort  <- Unit
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Abort.AbortingVoidPostBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortingVoidPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. final  <- Unit|none
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>d__5.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0.<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass5_0+<<Aborting_from_a_post_interceptor_surfaces_ExecutionAbortedException_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Abort.AbortVoidFinalBase`1.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_post_interceptor_completes_the_dispatch_without_an_exception>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortVoidFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
-                         | Stella.Ergosfare.Contract.Test.Abort.AbortResultHandlerBase`1.HandleAsync
-                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result>d__7.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Abort.AbortResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. post:abort  <- produced
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
-                             | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
-                               | Stella.Ergosfare.Contract.Test.Abort.AbortingResultPostBase`1.HandleAsync
-                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  3. final  <- produced|none
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>d__7.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0.<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass7_0+<<Aborting_from_a_result_pipelines_post_interceptor_delivers_no_value_to_the_caller>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Abort.AbortResultFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result>d__7.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortingResultPostBase`1.HandleAsync
                              | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- produced|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_result_pipelines_post_interceptor_delivers_the_produced_result>d__7.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPostAbortTests — stages: [handler, post:abort, final]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
-                         | Stella.Ergosfare.Contract.Test.Abort.AbortQueryHandlerBase`1.HandleAsync
-                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value>d__9.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Abort.AbortQueryHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. post:abort  <- 7
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
-                             | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
-                               | Stella.Ergosfare.Contract.Test.Abort.AbortingQueryPostBase`1.HandleAsync
-                                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  3. final  <- 7|none
-     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException
-       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0.<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0
-           | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<>c__DisplayClass9_0+<<Aborting_from_a_value_typed_querys_post_interceptor_surfaces_ExecutionAbortedException>b__0>d.MoveNext
-             | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value>d__9.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
+                         | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Abort.AbortingQueryPostBase`1.HandleAsync
                              | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- 7|none
+     | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract.Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value
+       | Stella.Ergosfare.Contract.Test.Abort.PostAbortSemanticsContract+<Aborting_from_a_value_typed_querys_post_interceptor_delivers_the_produced_value>d__9.MoveNext
+         | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Abort.AbortQueryFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationSyncEventHandlerTests — stages: [async, sync:object, sync:valuetask]
   1. async
@@ -2102,61 +2074,53 @@ RuntimeRegistrationSyncTests — stages: [pre, final]
   1. pre  <- abort
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__14.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0.<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass14_0+<<A_result_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationSyncTests — stages: [pre, final]
   1. pre  <- abort
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0.<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0+<<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
      | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract.A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result
        | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>d__9.MoveNext
-         | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0.<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0
-           | Stella.Ergosfare.Contract.Test.Sync.SyncSemanticsContract+<>c__DisplayClass9_0+<<A_void_pipelines_synchronous_final_interceptor_runs_on_abort_with_no_result>b__0>d.MoveNext
-             | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-               | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-                 | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
-                         | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationSyncTests — stages: [pre, handler, exception, final]
   1. pre  <- throw
@@ -2592,6 +2556,41 @@ stages: [handler, post, final]
                  | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
                    | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
                      | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+AnnouncedFinal.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler, post:abort, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.Aborting_a_publish_completes_it_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<Aborting_a_publish_completes_it_without_an_exception>d__31.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.PublishSequentially
+                   | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<PublishSequentially>d__4.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+RecalledHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post:abort
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.Aborting_a_publish_completes_it_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<Aborting_a_publish_completes_it_without_an_exception>d__31.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+RecalledAbortingPost.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- Unit|none
+     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.Aborting_a_publish_completes_it_without_an_exception
+       | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+<Aborting_a_publish_completes_it_without_an_exception>d__31.MoveNext
+         | Stella.Ergosfare.Events.EventMediator.PublishAsync
+           | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Publish
+             | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1.Mediate
+               | Stella.Ergosfare.Events.AsyncBroadcastMediationStrategy`1+<Mediate>d__2.MoveNext
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                     | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+RecalledFinal.HandleAsync
                        | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 stages: [handler:base]

--- a/test/Stella.Ergosfare.Core.Test/ExecutionContextTests.cs
+++ b/test/Stella.Ergosfare.Core.Test/ExecutionContextTests.cs
@@ -29,8 +29,9 @@ public class ExecutionContextTests
         // modify dictionary after construction (should still reference the same instance)
         items.Add("foo", "bar");
 
-        // act & assert: aborting should throw and set the MessageResult
-        Assert.Throws<ExecutionAbortedException>(() => ctx.Abort("baz"));
+        // act & assert: aborting raises the internal unwind signal, which the mediation
+        // strategy — not the caller — catches; nothing here stands between the two.
+        Assert.Throws<ExecutionAbortedException>(() => ctx.Abort());
         Assert.Equal(token, ctx.CancellationToken);
         Assert.Equal(items, ctx.Items);
         

--- a/test/Stella.Ergosfare.Queries.Test/QueryInterceptorDefaultImplementationTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/QueryInterceptorDefaultImplementationTests.cs
@@ -116,6 +116,6 @@ public class QueryInterceptorDefaultImplementationTests
             item = default!;
             return false;
         }
-        public void Abort(object? messageResult = null) => throw new NotSupportedException();
+        public void Abort() => throw new NotSupportedException();
     }
 }

--- a/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
+++ b/test/Stella.Ergosfare.SourceGenerator.Test/StagedPlanExecutionParityTests.cs
@@ -346,11 +346,12 @@ public class StagedPlanExecutionParityTests
 
         var command = (ICommand<string>)Activator.CreateInstance(commandType)!;
 
-        await Assert.ThrowsAsync<ExecutionAbortedException>(async () =>
-            await provider.GetRequiredService<ICommandMediator>().SendAsync(command));
+        var result = await provider.GetRequiredService<ICommandMediator>().SendAsync(command);
 
         // The abort never reaches the handler, is invisible to the exception stage, and
-        // the final stage still runs — the strategy's exact contract.
+        // the final stage still runs — the strategy's exact contract. Nothing had been
+        // produced, so the caller gets the result type's default and no exception.
+        Assert.Null(result);
         Assert.Equal(["pre", "final"], Entries);
     }
 


### PR DESCRIPTION
Closes #150

Faz 3'ün üçüncü ve son alt işi, fazın en riskli değişikliği. **PR #155'in (F4) üzerine
yığılmış** — hedef dal şimdilik `fix/covariant-handler-resolution`; üstteki PR'lar merge
oldukça GitHub bunu otomatik olarak yeniden hedefler. Gerekçe #155'inkiyle aynı: her iş
`baselines/lane-map.txt`'i yeniden yakalıyor, ve F1 zaten F6a ile F4'ün dokunduğu abort
testlerinin üzerine yazıyor.

## Ne değişti

`IExecutionContext.Abort` bir `messageResult` alıyor, onu **hiç okumuyor** ve koşulsuz
`ExecutionAbortedException` atıyordu. Belgelenen "abort ederken verilecek sonuç" kimseye
ulaşmıyordu — ve istisnanın kendisi **çağırana kadar gidiyordu**, ki XML doc bundan hiç söz
etmiyordu. Sözleşme iki yönden de yanlıştı.

Artık abort bir **kısa devre**:

- `messageResult` parametresi imzadan **kalktı**. Hiç çalışmadı; uyumluluk shim'i yok.
- Çağıran, pipeline'ın **o ana dek gerçekten ürettiğini** alıyor: abort handler'dan sonra
  geldiyse handler'ın sonucunu, öncesinde geldiyse sonuç tipinin default'unu.
- **Hiçbir yolda çağırana istisna ulaşmıyor.**
- Exception aşaması abort'u görmüyor (abort bir hata değil); final aşaması her zamanki gibi
  koşuyor ve **çağıranla aynı değeri**, istisnasız alıyor.
- `ExecutionAbortedException` yaşıyor ama yalnız **unwind mekanizması** olarak; XML doc'u
  bunu söylüyor: katılımcı kodunda onu `catch`'lemek abort'u gözlemlemek değil, iptal etmek
  olur.

## "Pipeline'ı koşturan" dört yer var, dördü de öğrenmek zorundaydı

| Yer | Ne yapıldı |
|---|---|
| İki tekil-handler stratejisi | Mevcut try/finally kabuğuna kendi abort kolu — üretilmiş sonuç orada duruyor |
| Stream stratejisi | **Değişmedi** — abort'u zaten `yield break` ile kısa devre yapıyordu |
| Broadcast stratejisi | Abort'u diğer istisnalarla birlikte yakalayıp exception interceptor'lara yolluyor ya da rethrow ediyordu; artık kendi kolu var |
| Emit edilen planlar | Aynı kol; **pre-only kabuklar dahil** — exception ve final aşaması yokken strateji kabuğu hiçe iniyordu ve abort doğrudan dışarı çıkıyordu |

### Dördüncüsü: executor'lar

Interceptor aşaması olmayan bir pipeline handler-first koşuyor — **strateji tamamen
atlanıyor**, dolayısıyla stratejinin abort işleyişi de. Böyle bir dispatch'i yalnız
handler'ın kendisi abort edebilir ve o anda üretilmiş bir şey yoktur, yani çağıran sonuç
tipinin default'unu alır.

Yeni `AbortShortCircuit` bunu taşıyor: executor'lar senkron abort'u çağrının etrafında
yakalıyor, dönen task'i ise handler senkron tamamlanmadıysa **ancak o zaman** ödeme yapan
bir guard'a veriyor. Inline tamamlanan handler — benchmark'lanan yol — tek bir
`IsCompletedSuccessfully` kontrolü ekliyor ve **state machine kurmuyor**.

## Değişen ve eklenen suite testleri

### "Hiçbir şey üretilmemişti" kolu

| Test | Değişiklik | Gerekçe |
|---|---|---|
| `Pipeline` · `Aborting_from_a_pre_interceptor_skips_the_handler_and_surfaces_ExecutionAbortedException` | adı `..._and_completes_the_dispatch`, `ThrowsAsync` düştü | Adının ikinci yarısı artık yanlış |
| `Pipeline` · `A_final_interceptor_runs_on_abort_with_no_result_and_no_exception` | `ThrowsAsync` düştü, beklenti aynı | Final'in gördüğü değişmedi; çağıranın gördüğü değişti |
| `Pipeline` · `Aborting_with_a_result_value_still_throws_and_does_not_deliver_the_value` | **yeniden yazıldı** → `Aborting_before_the_handler_delivers_no_result_to_the_caller` | Katılımcısı `Abort(AbortValue)` çağırıyordu, **derlenmiyor**. İki `AbortValue` sabiti de silindi |
| `Pipeline` · `A_value_typed_query_abort_throws_and_leaves_final_with_the_result_types_default` | adı `..._delivers_the_result_types_default`, artık **çağıranın** 0'ını da assert ediyor | Değer tipinde de aynı kural |
| `Sync` · iki abort senaryosu | `ThrowsAsync` düştü; result'lı olan çağıranın `null`'ını assert ediyor | Aynı kol, senkron sözleşmelerden |

### "Bir şey üretilmişti" kolu — Faz 1'in `Abort/` alanı

Bu alan tam olarak bu değişiklik için yazılmıştı. **Yedi senaryonun hepsi `ThrowsAsync`'i
düşürdü.** Üçü daha ileri gidip çağıranın ne aldığını assert ediyor (handler'ın string'i,
handler'ın sayısı, void'de sadece tamamlanma); ikisi adından "surfaces
ExecutionAbortedException" ibaresini attı.
`A_post_abort_skips_the_remaining_post_interceptors_and_the_exception_stage` **hiç
değişmedi** — kısa devrenin neyi durdurduğunun regresyon kapısı.

### Yeni senaryolar (hepsi sınıf sonuna eklendi)

| Test | Neden şart |
|---|---|
| `Pipeline` · `A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch` + result ikizi | **Executor lane'ini hiçbir senaryo koşmuyordu.** Oradaki abort işleyişi bu PR'ın yeni kodu; pinlenmeseydi kapsamsız inerdi. İki payload handler base'i bunu sürmek için abort kolu aldı — interceptor'lu mesajlarda erişilemez, orada pre önce abort ediyor |
| `Events` · `Aborting_a_publish_completes_it_without_an_exception` | Broadcast kolu |
| `Context` · `A_nested_dispatchs_abort_stops_at_its_own_dispatch` | İç içe dispatch: dış handler abort eden bir dispatch'i nest ediyor ve **bir sonraki satırdan devam ediyor** |

### Suite dışı

- `StagedPlanExecutionParityTests.Abort_SkipsTheExceptionStageAndStillRunsFinals` — istisna
  yerine çağıranın `null`'ını assert ediyor
- `ExecutionContextTests` — parametresiz `Abort()`
- `QueryInterceptorDefaultImplementationTests.FakeExecutionContext` — yeni imza

README bulgu 1 *Fixed* olarak yeniden yazıldı; unwind-mekanizması notu ve hangi alanın
hangi kolu pinlediğinin haritası eklendi.

## Lane-map diff'i — büyük ama neredeyse tamamı girinti

**+456 / −457**, ve bunun neredeyse hiçbiri lane değişimi değil.

Her abort senaryosu `Assert.ThrowsAsync(async () => await ...)` içinde koşuyordu. Abort
artık fırlatmadığı için o lambda gitti — ve trace başına **iki stack frame** ile birlikte.
Altındaki frame'ler birebir aynı, dört sütun solda. Diff'in gövdesi bu.

Gerçekten değişen: **beş yeni bölüm, silinen yok.** Dördü iki eksendeki interceptor'suz
abort senaryoları — trace'leri okumaya değer, dispatch `VoidPipelineExecutor` /
`GeneratedVoidPipelineExecutor` / `ResultPipelineExecutor` üzerinden **hiçbir strateji
frame'i olmadan** handler'a gidiyor, ki `AbortShortCircuit` tam olarak o lane için var.
Beşincisi abort edilen publish.

Lane sayıları hiçbir şeyin düşmediğini doğruluyor:

| | baseline | yeni |
|---|---|---|
| `StagedPlanN.Execute` | 76 | 76 |
| `StagedVoidPipelineExecutor` | 40 | 40 |
| `StagedResultPipelineExecutor` | 36 | 36 |
| `VoidPipelineExecutor` | 76 | 77 |
| `ResultPipelineExecutor` | 48 | 49 |
| `GeneratedVoidPipelineExecutor` | 1 | 2 |
| `…MediationStrategy.Mediate` | 122 | 125 |

Artışların hepsi yeni senaryolar.

## Kapılar

- Contract suite **167 → 173**, iki TFM × iki eksen yeşil (×2 koşum)
- Tam çözüm testleri yeşil (14 proje/TFM)
- **Sıfır uyarı**

## `docs/` bu PR'da güncellenmedi — gerekçe

Issue #150 bunu karara bağlamamı istiyordu. Karar: **hayır.** Üç sebep:

1. `docs` bir **submodule** — ayrı repo, ayrı PR ve release hattı; bu dalın commit'i oraya
   giremez.
2. **Parity disiplini**: abort'u anlatan sayfalar hem `docs/` hem `preview/` altında ikizli
   duruyor (`core-concepts/execution-context.mdoc`, `core-concepts/nested-dispatch.mdoc`,
   dört `cross-cutting-concerns/*-interceptors.mdoc`), ve ikisi 4 yapısal fark dışında
   birebir aynı kalmak zorunda.
3. Faz henüz `preview-dev`'e inmedi. Review'da hâlâ değişebilecek bir sözleşmeyi
   belgelemek erken olur.

Faz kapanışında tek bir docs PR'ı olarak, F6a + F4 + F1'in üçünü birden anlatacak şekilde
yapılması için ayrı issue açıldı.
