### PR TITLE
chore: deprecate reflection-based assembly scanning (RegisterFromAssembly)

### DIFF
--- a/.github/templates/readme_template.md
+++ b/.github/templates/readme_template.md
@@ -75,7 +75,7 @@ public class CreateProductHandler : ICommandHandler<CreateProductCommand, Guid>
 var services = new ServiceCollection()
     .AddErgosfare(cfg =>
     {
-        cfg.AddCommandModule(b => b.RegisterFromAssembly(Assembly.GetExecutingAssembly()));
+        cfg.AddCommandModule(b => b.RegisterGenerated());
         cfg.AddInterceptors(); // enables interceptor pipeline
     })
     .BuildServiceProvider();

--- a/readme.md
+++ b/readme.md
@@ -68,8 +68,9 @@ var id = await mediator.SendAsync(new CreateProduct("Laptop"));
 
 `RegisterGenerated()` is emitted into your project by the source generator: every message,
 handler and interceptor in the compilation — and in referenced assemblies — registers with
-pre-computed descriptors, no reflection involved. `RegisterFromAssembly(...)` remains
-available as the runtime-scanning escape hatch (e.g. plugins loaded at runtime).
+pre-computed descriptors, no reflection involved. `RegisterFromAssembly(...)` is deprecated
+and will be removed in the next release; until then it remains as the runtime-scanning
+escape hatch.
 
 ## Compile-time discovery
 

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModuleBuilder.cs
@@ -84,6 +84,7 @@ public sealed class CommandModuleBuilder
     /// </summary>
     /// <param name="assembly">The assembly from which to register command types.</param>
     /// <returns>The current <see cref="CommandModuleBuilder" /> instance for method chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers command types via reflection; trimming may remove them. Register commands explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public CommandModuleBuilder RegisterFromAssembly(Assembly assembly)
         => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
@@ -96,6 +97,7 @@ public sealed class CommandModuleBuilder
     /// <param name="assembly">The assembly from which to register command types.</param>
     /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
     /// <returns>The current <see cref="CommandModuleBuilder" /> instance for method chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers command types via reflection; trimming may remove them. Register commands explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public CommandModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/CoreModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/CoreModuleBuilder.cs
@@ -47,6 +47,7 @@ public class CoreModuleBuilder(IMessageRegistry registry): IModuleBuilder
     /// </summary>
     /// <param name="assembly">The assembly whose types should be registered as messages.</param>
     /// <returns>The current <see cref="IModuleBuilder"/> instance for fluent chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers types via reflection; trimming may remove them. Register types explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public IModuleBuilder RegisterFromAssembly(Assembly assembly)
         => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
@@ -59,6 +60,7 @@ public class CoreModuleBuilder(IMessageRegistry registry): IModuleBuilder
     /// <param name="assembly">The assembly whose types should be registered as messages.</param>
     /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
     /// <returns>The current <see cref="IModuleBuilder"/> instance for fluent chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers types via reflection; trimming may remove them. Register types explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public IModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/IModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/IModuleBuilder.cs
@@ -43,6 +43,7 @@ public interface IModuleBuilder
     /// <returns>
     /// The current <see cref="IModuleBuilder"/> instance to allow for fluent chaining.
     /// </returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers types via reflection; trimming may remove them. Register types explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     IModuleBuilder RegisterFromAssembly(Assembly assembly);
 }

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ResultAdapterBuilder.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ResultAdapterBuilder.cs
@@ -59,6 +59,7 @@ public class ResultAdapterBuilder(IResultAdapterService resultAdapterService)
     /// This scans for non-abstract, concrete classes that implement <see cref="IResultAdapter"/>.
     /// Each matching type is instantiated and registered.
     /// </remarks>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Register adapters explicitly with Register<TAdapter>().")]
     [RequiresUnreferencedCode("Assembly scanning discovers adapter types via reflection; trimming may remove them. Register adapters explicitly in trimmed or AOT applications.")]
     public ResultAdapterBuilder RegisterFromAssembly(Assembly assembly)
     {

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModuleBuilder.cs
@@ -85,6 +85,7 @@ public class EventModuleBuilder(
     /// </summary>
     /// <param name="assembly">The assembly to scan for types implementing <see cref="IEvent"/>.</param>
     /// <returns>The current <see cref="EventModuleBuilder"/> instance for fluent chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers event types via reflection; trimming may remove them. Register events explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public EventModuleBuilder RegisterFromAssembly(Assembly assembly)
         => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
@@ -97,6 +98,7 @@ public class EventModuleBuilder(
     /// <param name="assembly">The assembly to scan for types implementing <see cref="IEvent"/>.</param>
     /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
     /// <returns>The current <see cref="EventModuleBuilder"/> instance for fluent chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers event types via reflection; trimming may remove them. Register events explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public EventModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModuleBuilder.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModuleBuilder.cs
@@ -76,6 +76,7 @@ public sealed class QueryModuleBuilder(IMessageRegistry messageRegistry)
     /// </summary>
     /// <param name="assembly">The <see cref="Assembly"/> to scan for query types.</param>
     /// <returns>The current <see cref="QueryModuleBuilder"/> instance for fluent chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers query types via reflection; trimming may remove them. Register queries explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public QueryModuleBuilder RegisterFromAssembly(Assembly assembly)
         => RegisterFromAssembly(assembly, DiscoveryKeyAttribute.DefaultKey);
@@ -88,6 +89,7 @@ public sealed class QueryModuleBuilder(IMessageRegistry messageRegistry)
     /// <param name="assembly">The <see cref="Assembly"/> to scan for query types.</param>
     /// <param name="discoveryKeyPattern">The discovery key pattern to select types by.</param>
     /// <returns>The current <see cref="QueryModuleBuilder"/> instance for fluent chaining.</returns>
+    [Obsolete("Reflection-based assembly scanning is deprecated and will be removed in the next release. Use source-generated RegisterGenerated() — or RegisterGenerated(pattern) for discovery keys — and Register<T>() for explicit registrations.")]
     [RequiresUnreferencedCode("Assembly scanning discovers query types via reflection; trimming may remove them. Register queries explicitly (or use source-generated registration) in trimmed or AOT applications.")]
     public QueryModuleBuilder RegisterFromAssembly(Assembly assembly, string discoveryKeyPattern)
     {

--- a/test/Stella.Ergosfare.Command.Test/CommandModuleBuilderDiscoveryTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandModuleBuilderDiscoveryTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using System.Reflection;
 using Stella.Ergosfare.Command.Test.__stubs__;
 using Stella.Ergosfare.Commands.Abstractions;

--- a/test/Stella.Ergosfare.Command.Test/CommandModuleTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/CommandModuleTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Reflection;
+﻿// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
+using System.Reflection;
 using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Core.Abstractions;

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/DependencyInjectionTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/DependencyInjectionTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Reflection;
+﻿// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
+using System.Reflection;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Strategies;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/IModuleBuilderTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/IModuleBuilderTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using System.Reflection;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ModuleConfigurationTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ModuleConfigurationTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using System.Reflection;
 using Stella.Ergosfare.Core.Abstractions;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ResultAdapterBuilderTests.cs
+++ b/test/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection.Test/ResultAdapterBuilderTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using Stella.Ergosfare.Core.Abstractions;
 using System.Reflection;
 

--- a/test/Stella.Ergosfare.Events.Test/AsyncBroadcastMediationStrategyTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/AsyncBroadcastMediationStrategyTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using System.Reflection;
 using Stella.Ergosfare.Core;
 using Stella.Ergosfare.Core.Abstractions.Strategies;

--- a/test/Stella.Ergosfare.Events.Test/EventMediatorTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EventMediatorTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using System.Reflection;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
 using Stella.Ergosfare.Events.Abstractions;

--- a/test/Stella.Ergosfare.Events.Test/EventModuleTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/EventModuleTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Reflection;
+﻿// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
+using System.Reflection;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;

--- a/test/Stella.Ergosfare.Queries.Test/QueryModuleTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/QueryModuleTests.cs
@@ -1,3 +1,7 @@
+// This file intentionally exercises the obsolete reflection-scanning surface until the
+// preview line removes it; the deprecation warning is expected and suppressed.
+#pragma warning disable CS0618
+
 using System.Reflection;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Handlers;


### PR DESCRIPTION
Marks the reflection-based `RegisterFromAssembly` surface `[Obsolete]` on main, one release ahead of its full removal on the preview line (board draft: "RegisterFromAssembly deprecation flag — preview + main ikiz PR"; this is the main half).

## What

- `[Obsolete]` on all ten members: the `IModuleBuilder` seam, both overloads on `CommandModuleBuilder` / `QueryModuleBuilder` / `EventModuleBuilder` / `CoreModuleBuilder`, and `ResultAdapterBuilder.RegisterFromAssembly`. The message names the migration target: `RegisterGenerated()` / `RegisterGenerated(pattern)` and `Register<T>()`; the adapter message points at `Register<TAdapter>()`, since adapters have no generated registration.
- The builders' tests keep exercising the obsolete surface until the preview removal; each affected test file suppresses CS0618 file-wide with a comment saying exactly that.
- Readme: the template sample registers through `RegisterGenerated()`; the prose records the deprecation instead of calling the API an escape hatch.
- No CHANGELOG entry — entries are stamped at release time; the removal note belongs to the next tag.

## Verification

- Solution build on `origin/main` + this change: **zero warnings**.
- Full test run: **every project green** (14 test assemblies, 0 failures; the single pre-existing skip in Stella.Ergosfare.Test is untouched).
- Examples are outside the solution and were left alone; the preview-line removal will sweep them.

## Follow-up

The preview twin removes the surface entirely along with its tests, as part of the registration-surface rework already converging on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
