### PR TITLE
[v2] Faz 4 - typed exception interceptor facades (For<TException>)

### DIFF
--- a/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptorFor[TCommand,TException].cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptorFor[TCommand,TException].cs
@@ -1,0 +1,48 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Commands.Abstractions;
+
+
+/// <summary>
+/// A result-agnostic exception interceptor for a specific command type that runs only for
+/// exceptions of type <typeparamref name="TException"/>. The exception arrives already
+/// typed — no <c>is</c> check in the interceptor body.
+/// </summary>
+/// <typeparam name="TCommand">The type of command being intercepted. Must implement <see cref="ICommand"/>.</typeparam>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// The result-agnostic base is deliberate, for the same reason it is on
+/// <see cref="ICommandExceptionInterceptor{TCommand}"/>: a result-typed base is invisible to
+/// the pipeline's pattern match whenever the pipeline result is a value type. For a
+/// strongly-typed result use
+/// <see cref="ICommandExceptionInterceptorFor{TCommand, TResult, TException}"/>.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface ICommandExceptionInterceptorFor<in TCommand, TException> :
+    ICommand, IAsyncExceptionInterceptor<TCommand>, IExceptionInterceptorFilter<TException>
+    where TCommand : ICommand
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object> IAsyncExceptionInterceptor<TCommand>.HandleAsync(
+        TCommand command, object? messageResult, Exception exception, IExecutionContext context)
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        => await HandleAsync(command, messageResult, (TException)exception, context);
+
+    /// <summary>
+    /// Handles the exception asynchronously, potentially replacing the pipeline result.
+    /// </summary>
+    /// <param name="command">The command being processed when the exception occurred.</param>
+    /// <param name="messageResult">The result produced before the exception occurred, if any.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{Object}"/> producing the result that continues through the pipeline.
+    /// </returns>
+    ValueTask<object> HandleAsync(TCommand command, object? messageResult, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptorFor[TCommand,TResult,TException].cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptorFor[TCommand,TResult,TException].cs
@@ -1,0 +1,56 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Commands.Abstractions;
+
+
+/// <summary>
+/// A type-safe exception interceptor for commands with a strongly-typed result that runs
+/// only for exceptions of type <typeparamref name="TException"/>. The exception arrives
+/// already typed — no <c>is</c> check in the interceptor body.
+/// </summary>
+/// <typeparam name="TCommand">
+/// The command type being intercepted. Must implement <see cref="ICommand{TResult}"/>.
+/// </typeparam>
+/// <typeparam name="TResult">
+/// The result type of the command. Also the type returned by the interceptor — an
+/// interceptor that declines to replace the result returns <c>null</c>.
+/// </typeparam>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// Filtering does not reorder anything: matching interceptors run in the pipeline's
+/// existing order (weight descending, then type name), and the result threads through them
+/// exactly as it does through the unfiltered
+/// <see cref="ICommandExceptionInterceptor{TCommand, TResult}"/>. When no interceptor
+/// accepts the thrown exception, it leaves the pipeline unwrapped with its original stack.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface ICommandExceptionInterceptorFor<in TCommand, TResult, TException> :
+    ICommand, IAsyncExceptionInterceptor<TCommand, TResult>, IExceptionInterceptorFilter<TException>
+    where TCommand : ICommand<TResult>
+    where TResult : notnull
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object?> IAsyncExceptionInterceptor<TCommand, TResult>.HandleAsync(
+        TCommand command, TResult? result, Exception exception, IExecutionContext context)
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        => await HandleAsync(command, result, (TException)exception, context);
+
+    /// <summary>
+    /// Handles the exception asynchronously, potentially modifying the command result.
+    /// </summary>
+    /// <param name="command">The command being processed when the exception occurred.</param>
+    /// <param name="result">The result produced before the exception occurred, if any.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> producing the (possibly modified) result that
+    /// continues through the pipeline.
+    /// </returns>
+    ValueTask<TResult?> HandleAsync(TCommand command, TResult? result, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptorFor[TException].cs
+++ b/src/Stella.Ergosfare.Commands.Abstractions/ExceptionInterceptors/ICommandExceptionInterceptorFor[TException].cs
@@ -1,0 +1,44 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Commands.Abstractions;
+
+
+/// <summary>
+/// A module-wide exception interceptor that runs for every command but only for exceptions
+/// of type <typeparamref name="TException"/> — the filtered form of
+/// <see cref="ICommandExceptionInterceptor"/>, and the shape a global error policy takes.
+/// </summary>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// Being message- and result-agnostic, this interceptor joins the exception stage of every
+/// command pipeline in the module; the filter is what keeps it from swallowing exceptions
+/// it was not written for.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface ICommandExceptionInterceptorFor<TException> :
+    ICommand, IAsyncExceptionInterceptor<ICommand>, IExceptionInterceptorFilter<TException>
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object> IAsyncExceptionInterceptor<ICommand>.HandleAsync(
+        ICommand command, object? messageResult, Exception exception, IExecutionContext context)
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        => await HandleAsync(command, messageResult, (TException)exception, context);
+
+    /// <summary>
+    /// Handles the exception asynchronously, potentially replacing the pipeline result.
+    /// </summary>
+    /// <param name="command">The command being processed when the exception occurred.</param>
+    /// <param name="messageResult">The result produced before the exception occurred, if any.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{Object}"/> producing the result that continues through the pipeline.
+    /// </returns>
+    ValueTask<object> HandleAsync(ICommand command, object? messageResult, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionInterceptorFilter.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionInterceptorFilter.cs
@@ -1,0 +1,29 @@
+
+namespace Stella.Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// The erased probe an exception interceptor carries when it accepts only some exceptions.
+/// The exception stage asks every interceptor that implements it whether the thrown
+/// exception is one it accepts, runs only those that answer yes, and rethrows the original
+/// exception unwrapped when none does.
+/// </summary>
+/// <remarks>
+/// An interceptor that does not implement this contract accepts every exception — the
+/// untyped facades keep their unfiltered behavior with no opt-in.
+/// <para>
+/// The probe is deliberately separate from the dispatch contracts
+/// (<see cref="IExceptionInterceptor{TMessage, TResult}"/> and the asynchronous pair):
+/// filtering is orthogonal to which typed member the stage invokes, so a filtered
+/// interceptor is dispatched through exactly the same arm as an unfiltered one.
+/// </para>
+/// </remarks>
+public interface IExceptionInterceptorFilter
+{
+    /// <summary>
+    /// Determines whether this interceptor accepts the thrown exception.
+    /// </summary>
+    /// <param name="exception">The exception the pipeline threw.</param>
+    /// <returns><c>true</c> when the interceptor should run for this exception; otherwise <c>false</c>.</returns>
+    bool Matches(Exception exception);
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionInterceptorFilter[TException].cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Handlers/ExceptionInterceptors/IExceptionInterceptorFilter[TException].cs
@@ -1,0 +1,21 @@
+
+namespace Stella.Ergosfare.Core.Abstractions.Handlers;
+
+
+/// <summary>
+/// Declares the exception type an interceptor accepts. Matching follows <c>catch</c>
+/// semantics: <typeparamref name="TException"/> and every type derived from it.
+/// </summary>
+/// <typeparam name="TException">The exception type this interceptor accepts.</typeparam>
+/// <remarks>
+/// This contract carries the exception type into the generated pipelines: the source
+/// generator reads <typeparamref name="TException"/> off it and bakes the same test into
+/// the emitted plan as a compile-time <c>is</c> check, so both registration axes filter
+/// identically.
+/// </remarks>
+public interface IExceptionInterceptorFilter<TException> : IExceptionInterceptorFilter
+    where TException : Exception
+{
+    /// <inheritdoc />
+    bool IExceptionInterceptorFilter.Matches(Exception exception) => exception is TException;
+}

--- a/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/ExceptionInterceptorInvocationStrategy.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Strategies/InvocationStrategies/ExceptionInterceptorInvocationStrategy.cs
@@ -11,13 +11,17 @@ namespace Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies;
 /// result-agnostic ones via <see cref="IAsyncExceptionInterceptor{TMessage}"/>, synchronous
 /// ones via <see cref="IExceptionInterceptor{TMessage, TResult}"/>. There is no object-typed
 /// bridge and no boxed awaitable; `in` variance admits interceptors registered for base
-/// message or result types. With no interceptors registered, the captured exception is
-/// rethrown with its original stack.
+/// message or result types.
+/// <para>
+/// An interceptor carrying an <see cref="IExceptionInterceptorFilter"/> runs only for the
+/// exceptions it accepts. When no interceptor <em>matches</em> — none registered, or every
+/// registered one filtered the exception out — the captured exception is rethrown with its
+/// original stack.
+/// </para>
 /// </summary>
 /// <typeparam name="TMessage">The dispatch message type (the runtime type on executor paths).</typeparam>
 /// <typeparam name="TResult">
-/// The pipeline's result type — <see cref="ValueTask"/> for void pipelines, where the
-/// completed-task box stands in as the (meaningless) result object.
+/// The pipeline's result type — <see cref="Unit"/> for pipelines that produce no result.
 /// </typeparam>
 /// <remarks>
 /// Static: the pipeline state travels as arguments, so a dispatch allocates no invoker object.
@@ -32,9 +36,9 @@ internal static class ExceptionInterceptorInvocationStrategy<TMessage, TResult>
     /// <param name="serviceProvider">The provider of the scope this dispatch runs in; interceptors resolve from it.</param>
     /// <param name="message">The message whose processing threw.</param>
     /// <param name="result">The result produced by the pipeline so far, if any.</param>
-    /// <param name="exceptionDispatchInfo">The captured exception; rethrown when no interceptor is registered.</param>
+    /// <param name="exceptionDispatchInfo">The captured exception; rethrown when no interceptor matches it.</param>
     /// <param name="executionContext">The execution context for the current pipeline invocation.</param>
-    /// <returns>The (possibly replaced) result after all exception interceptors have executed.</returns>
+    /// <returns>The (possibly replaced) result after all matching exception interceptors have executed.</returns>
     public static async ValueTask<object?> Invoke(
         IMessageDependencies messageDependencies,
         IServiceProvider serviceProvider,
@@ -44,17 +48,23 @@ internal static class ExceptionInterceptorInvocationStrategy<TMessage, TResult>
         IExecutionContext executionContext)
     {
         var interceptors = messageDependencies.ExceptionInterceptors;
-
-        if (interceptors.Count == 0)
-        {
-            exceptionDispatchInfo.Throw();
-        }
-
         var exception = exceptionDispatchInfo.SourceException;
+        var matched = false;
 
         for (var i = 0; i < interceptors.Count; i++)
         {
             var interceptor = interceptors[i].Resolve(serviceProvider);
+
+            // A filtered interceptor that rejects this exception is not a participant at
+            // all: it neither runs nor counts towards "something handled it". Resolution
+            // still happens first — the filter lives on the instance, and resolving every
+            // registered interceptor is the behavior the unfiltered stage already had.
+            if (interceptor is IExceptionInterceptorFilter filter && !filter.Matches(exception))
+            {
+                continue;
+            }
+
+            matched = true;
 
             result = interceptor switch
             {
@@ -68,6 +78,15 @@ internal static class ExceptionInterceptorInvocationStrategy<TMessage, TResult>
                     $"'{interceptor.GetType()}' does not implement a supported exception-interceptor contract for message '{typeof(TMessage)}' and result '{typeof(TResult)}'. " +
                     "Interface-erased dispatch is not supported; dispatch with the concrete message type."),
             };
+        }
+
+        // Nobody accepted the exception, so nobody handled it. Rethrowing the captured
+        // exception hands the caller the original stack — the same outcome an empty stage
+        // produces, and the reason a filtered interceptor may never be counted by presence
+        // alone: that would swallow every exception it declined.
+        if (!matched)
+        {
+            exceptionDispatchInfo.Throw();
         }
 
         return result;

--- a/src/Stella.Ergosfare.Events.Abstractions/ExceptionInterceptors/IEventExceptionInterceptorFor[TEvent,TException].cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/ExceptionInterceptors/IEventExceptionInterceptorFor[TEvent,TException].cs
@@ -1,0 +1,48 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Events.Abstractions;
+
+
+/// <summary>
+/// An exception interceptor for a specific event type that runs only for exceptions of type
+/// <typeparamref name="TException"/>. The exception arrives already typed — no <c>is</c>
+/// check in the interceptor body.
+/// </summary>
+/// <typeparam name="TEvent">The type of event being intercepted. Must implement <see cref="IEvent"/>.</typeparam>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// A publish produces no result, so — unlike
+/// <see cref="IEventExceptionInterceptor{TEvent}"/>, which still carries a vestigial
+/// <see cref="ValueTask"/> parameter — the handled member takes only the event, the
+/// exception and the context. When no interceptor accepts the thrown exception, it leaves
+/// the pipeline unwrapped with its original stack.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface IEventExceptionInterceptorFor<in TEvent, TException> :
+    IEvent, IAsyncExceptionInterceptor<TEvent, Unit>, IExceptionInterceptorFilter<TException>
+    where TEvent : notnull
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object?> IAsyncExceptionInterceptor<TEvent, Unit>.HandleAsync(
+        TEvent @event, Unit? result, Exception exception, IExecutionContext context)
+    {
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        await HandleAsync(@event, (TException)exception, context);
+        return Unit.Value;
+    }
+
+    /// <summary>
+    /// Handles an exception thrown while the event was being published.
+    /// </summary>
+    /// <param name="event">The event being processed when the exception occurred.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The execution context for the current mediation pipeline.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous exception handling operation.</returns>
+    ValueTask HandleAsync(TEvent @event, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Events.Abstractions/ExceptionInterceptors/IEventExceptionInterceptorFor[TException].cs
+++ b/src/Stella.Ergosfare.Events.Abstractions/ExceptionInterceptors/IEventExceptionInterceptorFor[TException].cs
@@ -1,0 +1,44 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Events.Abstractions;
+
+
+/// <summary>
+/// A module-wide exception interceptor that runs for every event but only for exceptions of
+/// type <typeparamref name="TException"/> — the filtered form of
+/// <see cref="IEventExceptionInterceptor"/>, and the shape a global error policy takes.
+/// </summary>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// Being message-agnostic, this interceptor joins the exception stage of every event
+/// pipeline in the module; the filter is what keeps it from swallowing exceptions it was
+/// not written for.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface IEventExceptionInterceptorFor<TException> :
+    IEvent, IAsyncExceptionInterceptor<IEvent, Unit>, IExceptionInterceptorFilter<TException>
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object?> IAsyncExceptionInterceptor<IEvent, Unit>.HandleAsync(
+        IEvent @event, Unit? result, Exception exception, IExecutionContext context)
+    {
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        await HandleAsync(@event, (TException)exception, context);
+        return Unit.Value;
+    }
+
+    /// <summary>
+    /// Handles an exception thrown while an event was being published.
+    /// </summary>
+    /// <param name="event">The event being processed when the exception occurred.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The execution context for the current mediation pipeline.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous exception handling operation.</returns>
+    ValueTask HandleAsync(IEvent @event, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptorFor[TException].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptorFor[TException].cs
@@ -1,0 +1,44 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Queries.Abstractions;
+
+
+/// <summary>
+/// A module-wide exception interceptor that runs for every query but only for exceptions of
+/// type <typeparamref name="TException"/> — the filtered form of
+/// <see cref="IQueryExceptionInterceptor"/>, and the shape a global error policy takes.
+/// </summary>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// Being message- and result-agnostic, this interceptor joins the exception stage of every
+/// query pipeline in the module; the filter is what keeps it from swallowing exceptions it
+/// was not written for.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface IQueryExceptionInterceptorFor<TException> :
+    IQuery, IAsyncExceptionInterceptor<IQuery>, IExceptionInterceptorFilter<TException>
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object> IAsyncExceptionInterceptor<IQuery>.HandleAsync(
+        IQuery query, object? messageResult, Exception exception, IExecutionContext context)
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        => await HandleAsync(query, messageResult, (TException)exception, context);
+
+    /// <summary>
+    /// Handles the exception asynchronously, potentially replacing the pipeline result.
+    /// </summary>
+    /// <param name="query">The query being processed when the exception occurred.</param>
+    /// <param name="messageResult">The result produced before the exception occurred, if any.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{Object}"/> producing the result that continues through the pipeline.
+    /// </returns>
+    ValueTask<object> HandleAsync(IQuery query, object? messageResult, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptorFor[TQuery,TException].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptorFor[TQuery,TException].cs
@@ -1,0 +1,46 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Queries.Abstractions;
+
+
+/// <summary>
+/// A result-agnostic exception interceptor for a specific query type that runs only for
+/// exceptions of type <typeparamref name="TException"/>. The exception arrives already
+/// typed — no <c>is</c> check in the interceptor body.
+/// </summary>
+/// <typeparam name="TQuery">The type of query being intercepted. Must implement <see cref="IQuery"/>.</typeparam>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// The result-agnostic base keeps the interceptor visible to the pipeline's pattern match
+/// whatever the query's result type is, including value-typed results. For a strongly-typed
+/// result use <see cref="IQueryExceptionInterceptorFor{TQuery, TResult, TException}"/>.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface IQueryExceptionInterceptorFor<in TQuery, TException> :
+    IQuery, IAsyncExceptionInterceptor<TQuery>, IExceptionInterceptorFilter<TException>
+    where TQuery : IQuery
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object> IAsyncExceptionInterceptor<TQuery>.HandleAsync(
+        TQuery query, object? messageResult, Exception exception, IExecutionContext context)
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        => await HandleAsync(query, messageResult, (TException)exception, context);
+
+    /// <summary>
+    /// Handles the exception asynchronously, potentially replacing the pipeline result.
+    /// </summary>
+    /// <param name="query">The query being processed when the exception occurred.</param>
+    /// <param name="messageResult">The result produced before the exception occurred, if any.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{Object}"/> producing the result that continues through the pipeline.
+    /// </returns>
+    ValueTask<object> HandleAsync(TQuery query, object? messageResult, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptorFor[TQuery,TResult,TException].cs
+++ b/src/Stella.Ergosfare.Queries.Abstractions/ExceptionInterceptors/IQueryExceptionInterceptorFor[TQuery,TResult,TException].cs
@@ -1,0 +1,54 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+
+namespace Stella.Ergosfare.Queries.Abstractions;
+
+
+/// <summary>
+/// A type-safe exception interceptor for queries with a strongly-typed result that runs
+/// only for exceptions of type <typeparamref name="TException"/>. The exception arrives
+/// already typed — no <c>is</c> check in the interceptor body.
+/// </summary>
+/// <typeparam name="TQuery">The query type being intercepted. Must implement <see cref="IQuery{TResult}"/>.</typeparam>
+/// <typeparam name="TResult">
+/// The result type of the query. Also the type returned by the interceptor — an interceptor
+/// that declines to replace the result returns <c>null</c>.
+/// </typeparam>
+/// <typeparam name="TException">
+/// The exception type this interceptor accepts, matched with <c>catch</c> semantics:
+/// derived exception types match too.
+/// </typeparam>
+/// <remarks>
+/// Filtering does not reorder anything: matching interceptors run in the pipeline's
+/// existing order (weight descending, then type name), and the result threads through them
+/// exactly as it does through the unfiltered
+/// <see cref="IQueryExceptionInterceptor{TQuery, TResult}"/>. When no interceptor accepts
+/// the thrown exception, it leaves the pipeline unwrapped with its original stack.
+/// </remarks>
+// ReSharper disable once UnusedType.Global
+public interface IQueryExceptionInterceptorFor<in TQuery, TResult, TException> :
+    IQuery, IAsyncExceptionInterceptor<TQuery, TResult>, IExceptionInterceptorFilter<TException>
+    where TQuery : IQuery<TResult>
+    where TResult : notnull
+    where TException : Exception
+{
+    /// <inheritdoc />
+    async ValueTask<object?> IAsyncExceptionInterceptor<TQuery, TResult>.HandleAsync(
+        TQuery query, TResult? result, Exception exception, IExecutionContext context)
+        // The cast cannot fail: the exception stage runs this interceptor only after its
+        // filter accepted the exception.
+        => await HandleAsync(query, result, (TException)exception, context);
+
+    /// <summary>
+    /// Handles the exception asynchronously, potentially modifying the query result.
+    /// </summary>
+    /// <param name="query">The query being processed when the exception occurred.</param>
+    /// <param name="result">The result produced before the exception occurred, if any.</param>
+    /// <param name="exception">The exception thrown during pipeline execution.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> producing the (possibly modified) result that
+    /// continues through the pipeline.
+    /// </returns>
+    ValueTask<TResult?> HandleAsync(TQuery query, TResult? result, TException exception, IExecutionContext context);
+}

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -52,6 +52,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     private const string EventMarkerNamespace = "Stella.Ergosfare.Events.Abstractions";
 
     private const string HandlerContractNamespace = "Stella.Ergosfare.Core.Abstractions.Handlers";
+    private const string ExceptionFilterContractName = "IExceptionInterceptorFilter";
     private const string AttributeNamespace = "Stella.Ergosfare.Core.Abstractions.Attributes";
 
     private const string MessageRegistryMetadataName = "Stella.Ergosfare.Core.Abstractions.Registry.IMessageRegistry";
@@ -757,6 +758,8 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
 
         ImmutableArray<ContractShapeModel>.Builder? shapes = null;
 
+        ReadExceptionFilter(symbol, out var exceptionFilterExpression, out var undecidableExceptionFilter);
+
         foreach (var iface in symbol.AllInterfaces)
         {
             if (iface.Arity is not (1 or 2) || !IsInNamespace(iface, HandlerContractNamespace))
@@ -785,13 +788,16 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                     NormalizedTypeExpression(arguments[0]), null),
                 "IExceptionInterceptor" when iface.Arity == 2 => new ContractShapeModel(
                     DescriptorKind.ExceptionInterceptor, IsAsync: false, IsResultTyped: true,
-                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1]),
+                    exceptionFilterExpression, undecidableExceptionFilter),
                 "IAsyncExceptionInterceptor" when iface.Arity == 2 => new ContractShapeModel(
                     DescriptorKind.ExceptionInterceptor, IsAsync: true, IsResultTyped: true,
-                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
+                    NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1]),
+                    exceptionFilterExpression, undecidableExceptionFilter),
                 "IAsyncExceptionInterceptor" when iface.Arity == 1 => new ContractShapeModel(
                     DescriptorKind.ExceptionInterceptor, IsAsync: true, IsResultTyped: false,
-                    NormalizedTypeExpression(arguments[0]), null),
+                    NormalizedTypeExpression(arguments[0]), null,
+                    exceptionFilterExpression, undecidableExceptionFilter),
                 "IFinalInterceptor" when iface.Arity == 2 => new ContractShapeModel(
                     DescriptorKind.FinalInterceptor, IsAsync: false, IsResultTyped: true,
                     NormalizedTypeExpression(arguments[0]), VerbatimTypeExpression(arguments[1])),
@@ -811,6 +817,59 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         }
 
         return shapes?.ToImmutable() ?? ImmutableArray<ContractShapeModel>.Empty;
+    }
+
+    /// <summary>
+    ///     Reads the exception type an interceptor accepts off its
+    ///     <c>IExceptionInterceptorFilter&lt;TException&gt;</c>, so the staged plan can
+    ///     bake the runtime stage's filter probe in as an <c>is</c> test.
+    /// </summary>
+    /// <remarks>
+    ///     Only the single-generic-filter shape is decidable. A type carrying the
+    ///     non-generic filter without exactly one generic one has written its own
+    ///     <c>Matches</c> (or has several to disambiguate by hand), and no compile-time test
+    ///     reproduces it — the plan is disqualified instead of guessing, and the dispatch
+    ///     asks the instance through the runtime stage.
+    /// </remarks>
+    private static void ReadExceptionFilter(INamedTypeSymbol symbol, out string? filterExpression, out bool undecidable)
+    {
+        filterExpression = null;
+        undecidable = false;
+
+        var carriesFilter = false;
+        var genericFilterCount = 0;
+
+        foreach (var iface in symbol.AllInterfaces)
+        {
+            if (iface.Name != ExceptionFilterContractName || !IsInNamespace(iface, HandlerContractNamespace))
+            {
+                continue;
+            }
+
+            if (iface.Arity == 0)
+            {
+                carriesFilter = true;
+                continue;
+            }
+
+            if (iface.Arity == 1)
+            {
+                genericFilterCount++;
+                filterExpression = VerbatimTypeExpression(iface.TypeArguments[0]);
+            }
+        }
+
+        if (!carriesFilter)
+        {
+            filterExpression = null;
+            return;
+        }
+
+        if (genericFilterCount != 1)
+        {
+            filterExpression = null;
+            undecidable = true;
+        }
     }
 
     private static bool HasExcludeFromDiscovery(ImmutableArray<AttributeData> attributes)
@@ -1351,7 +1410,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         var pipelineResultExpression = resultTypeExpression ?? UnitExpression;
         var pipelineResultIsValueType = resultTypeExpression is not null && resultIsValueType;
 
-        var stages = new List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct)>?[4];
+        var stages = new List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct, string? ExceptionFilter)>?[4];
 
         foreach (var candidate in types)
         {
@@ -1421,12 +1480,12 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
                 }
 
                 if (!TrySelectArm(candidate, kind, message, pipelineResultExpression, pipelineResultIsValueType,
-                        out var arm))
+                        out var arm, out var exceptionFilter))
                 {
                     return false;
                 }
 
-                (stages[kindIndex] ??= []).Add((candidate, arm, matchedDirect));
+                (stages[kindIndex] ??= []).Add((candidate, arm, matchedDirect, exceptionFilter));
                 _ = matchedMessageKey;
             }
         }
@@ -1451,9 +1510,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
         RegistrableTypeModel message,
         string pipelineResultExpression,
         bool pipelineResultIsValueType,
-        out StagedCallArm arm)
+        out StagedCallArm arm,
+        out string? exceptionFilter)
     {
         arm = default;
+        exceptionFilter = null;
 
         var hasAsyncTyped = false;
         var hasAsyncAgnostic = false;
@@ -1465,6 +1526,16 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
             {
                 continue;
             }
+
+            // A filter the string model cannot reproduce takes the whole plan down: an
+            // emitted call with no guard runs an interceptor that declined the exception,
+            // and — worse — makes the stage count it as having handled one.
+            if (shape.HasUndecidableExceptionFilter)
+            {
+                return false;
+            }
+
+            exceptionFilter = shape.ExceptionFilterExpression;
 
             // Message-side variance: exact match always works; a base/interface
             // registration matches only for reference-typed messages.
@@ -1557,7 +1628,7 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
     ///     non-generic, so the display name equals the runtime <c>Type.FullName</c>).
     /// </summary>
     private static ImmutableArray<StagedCallModel> OrderStage(
-        List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct)>? entries,
+        List<(RegistrableTypeModel Type, StagedCallArm Arm, bool Direct, string? ExceptionFilter)>? entries,
         bool hasKeyedServiceExtensions)
     {
         if (entries is null)
@@ -1583,10 +1654,11 @@ public sealed class ErgosfareRegistrationGenerator : IIncrementalGenerator
 
         var calls = ImmutableArray.CreateBuilder<StagedCallModel>(entries.Count);
 
-        foreach (var (type, arm, _) in entries)
+        foreach (var (type, arm, _, exceptionFilter) in entries)
         {
             calls.Add(new StagedCallModel(
-                type.TypeofExpression, arm, GatedConstructionExpression(type, hasKeyedServiceExtensions)));
+                type.TypeofExpression, arm, GatedConstructionExpression(type, hasKeyedServiceExtensions),
+                exceptionFilter));
         }
 
         return calls.MoveToImmutable();

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ContractShapeModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ContractShapeModel.cs
@@ -11,9 +11,23 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// <param name="IsResultTyped">Whether the contract carries a typed result parameter (arity-2 for post/exception/final).</param>
 /// <param name="MessageTypeExpression">The contract's registered message type, normalized like descriptor message types.</param>
 /// <param name="ResultTypeExpression">The declared result type for result-typed contracts, <c>null</c> otherwise.</param>
+/// <param name="ExceptionFilterExpression">
+///     The exception type the declaring interceptor accepts, read off its
+///     <c>IExceptionInterceptorFilter&lt;TException&gt;</c>; <c>null</c> when it accepts
+///     every exception. Only ever set on <see cref="DescriptorKind.ExceptionInterceptor"/>
+///     shapes.
+/// </param>
+/// <param name="HasUndecidableExceptionFilter">
+///     Whether the declaring interceptor filters in a way the generator cannot reproduce —
+///     a hand-written non-generic filter, or several generic ones, where the exception type
+///     is not a single compile-time constant. Such a plan is disqualified so the dispatch
+///     falls back to the runtime stage, which asks the instance itself.
+/// </param>
 internal readonly record struct ContractShapeModel(
     DescriptorKind Kind,
     bool IsAsync,
     bool IsResultTyped,
     string MessageTypeExpression,
-    string? ResultTypeExpression);
+    string? ResultTypeExpression,
+    string? ExceptionFilterExpression = null,
+    bool HasUndecidableExceptionFilter = false);

--- a/src/Stella.Ergosfare.SourceGenerator/Models/StagedCallModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/StagedCallModel.cs
@@ -5,4 +5,16 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 /// through, and — when the participant qualifies — the bare <c>new T(...)</c> expression
 /// the direct-construction variant substitutes for the container resolution.
 /// </summary>
-internal readonly record struct StagedCallModel(string TypeExpression, StagedCallArm Arm, string? ConstructionExpression);
+/// <param name="TypeExpression">The participant's <c>typeof</c>-qualified type expression.</param>
+/// <param name="Arm">The pattern-match arm the runtime strategy would invoke it through.</param>
+/// <param name="ConstructionExpression">The direct-construction expression, or <c>null</c>.</param>
+/// <param name="ExceptionFilterExpression">
+///     For an exception-stage call whose participant accepts only one exception type, that
+///     type — emitted as an <c>is</c> guard around the call, standing in for the runtime
+///     stage's filter probe. <c>null</c> means the call is unguarded.
+/// </param>
+internal readonly record struct StagedCallModel(
+    string TypeExpression,
+    StagedCallArm Arm,
+    string? ConstructionExpression,
+    string? ExceptionFilterExpression = null);

--- a/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/RegistrationEmitter.cs
@@ -653,6 +653,66 @@ internal static class RegistrationEmitter
         }
     }
 
+    /// <summary>
+    ///     Emits the exception stage's chain calls, guarding every filtered participant
+    ///     with the compile-time <c>is</c> test its runtime filter probe would apply.
+    /// </summary>
+    /// <remarks>
+    ///     When every participant is filtered, none of them may turn out to accept the
+    ///     exception — and a stage that ran nobody has handled nothing, so the plan
+    ///     rethrows exactly as the runtime stage does. A single unfiltered participant
+    ///     makes that impossible, and the flag is not emitted at all.
+    /// </remarks>
+    private static void EmitExceptionCalls(
+        StringBuilder sb, StagedPlanModel plan, bool direct, string chainVariable, string indent)
+    {
+        var alwaysMatches = false;
+
+        foreach (var call in plan.ExceptionCalls)
+        {
+            if (call.ExceptionFilterExpression is null)
+            {
+                alwaysMatches = true;
+                break;
+            }
+        }
+
+        if (!alwaysMatches)
+        {
+            sb.Append(indent).AppendLine("var matchedExceptionInterceptor = false;");
+        }
+
+        foreach (var call in plan.ExceptionCalls)
+        {
+            if (call.ExceptionFilterExpression is null)
+            {
+                EmitChainCall(sb, plan, call, direct, "ExceptionInterceptor", chainVariable, "e", indent);
+                continue;
+            }
+
+            sb.Append(indent).Append("if (e is ").Append(call.ExceptionFilterExpression).AppendLine(")");
+            sb.Append(indent).AppendLine("{");
+
+            if (!alwaysMatches)
+            {
+                sb.Append(indent).AppendLine("    matchedExceptionInterceptor = true;");
+            }
+
+            EmitChainCall(sb, plan, call, direct, "ExceptionInterceptor", chainVariable, "e", indent + "    ");
+            sb.Append(indent).AppendLine("}");
+        }
+
+        if (alwaysMatches)
+        {
+            return;
+        }
+
+        sb.Append(indent).AppendLine("if (!matchedExceptionInterceptor)");
+        sb.Append(indent).AppendLine("{");
+        sb.Append(indent).AppendLine("    throw;");
+        sb.Append(indent).AppendLine("}");
+    }
+
     private static void EmitVoidExecuteBody(StringBuilder sb, StagedPlanModel plan, bool direct)
     {
         var needsResult = !plan.PostCalls.IsEmpty || !plan.ExceptionCalls.IsEmpty || !plan.FinalCalls.IsEmpty;
@@ -719,10 +779,7 @@ internal static class RegistrationEmitter
         {
             sb.AppendLine("                    var resultBeforeExceptions = result;");
 
-            foreach (var call in plan.ExceptionCalls)
-            {
-                EmitChainCall(sb, plan, call, direct, "ExceptionInterceptor", "result", "e", "                    ");
-            }
+            EmitExceptionCalls(sb, plan, direct, "result", "                    ");
 
             sb.Append("                    var invokedExceptionResult = (").Append(UnitFullName).AppendLine("?) result;");
             sb.AppendLine("                    result = invokedExceptionResult == null ? resultBeforeExceptions : result;");
@@ -808,10 +865,7 @@ internal static class RegistrationEmitter
         {
             sb.AppendLine("                    object? exceptionChain = result;");
 
-            foreach (var call in plan.ExceptionCalls)
-            {
-                EmitChainCall(sb, plan, call, direct, "ExceptionInterceptor", "exceptionChain", "e", "                    ");
-            }
+            EmitExceptionCalls(sb, plan, direct, "exceptionChain", "                    ");
 
             if (plan.ResultIsValueType)
             {

--- a/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/ExceptionFilterContracts.cs
+++ b/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/ExceptionFilterContracts.cs
@@ -1,0 +1,206 @@
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Contract.Test.ExceptionFilters;
+
+/// <summary>
+/// The shared vocabulary of the typed exception-interceptor scenarios: a pipeline that
+/// throws a chosen exception type, and an exception stage whose participants each declare
+/// which exceptions they accept.
+/// </summary>
+/// <remarks>
+/// Everything here is excluded from discovery: these are shapes, not registrable
+/// constructs. Exclusion is not inherited, so the closing types stay discoverable.
+/// </remarks>
+public static class ExceptionFilterVocabulary
+{
+    /// <summary>The result the string-result handler would have produced had it not thrown.</summary>
+    public const string NeverProduced = "never";
+
+    /// <summary>The result the interceptor accepting the tagged fault substitutes.</summary>
+    public const string TaggedRecovery = "recovered:tagged";
+
+    /// <summary>The suffix the unfiltered interceptor appends to whatever it is handed.</summary>
+    public const string UntypedSuffix = "+untyped";
+
+    /// <summary>Renders a stage's exception argument for the recorder.</summary>
+    public static string Describe(Exception? exception)
+        => exception is null ? "none" : exception.GetType().Name;
+}
+
+/// <summary>Which exception a scenario's handler throws.</summary>
+public enum FaultKind
+{
+    /// <summary>The type the filtered interceptors are written for.</summary>
+    Tagged,
+
+    /// <summary>A subtype of it — accepted too, under <c>catch</c> semantics.</summary>
+    DerivedTagged,
+
+    /// <summary>A type only the second filtered interceptor accepts.</summary>
+    Unrelated,
+
+    /// <summary>A type no filtered interceptor accepts.</summary>
+    Stray,
+}
+
+/// <summary>The fault the filtered interceptors of this area are written for.</summary>
+/// <remarks>Deliberately not sealed: the subtype below is what pins <c>catch</c> matching.</remarks>
+public class TaggedFaultException(string message = "tagged") : Exception(message);
+
+/// <summary>A subtype of the tagged fault, used to pin <c>catch</c> matching semantics.</summary>
+public sealed class DerivedTaggedFaultException() : TaggedFaultException("derived");
+
+/// <summary>A fault only the second filtered interceptor of this area accepts.</summary>
+public sealed class UnrelatedFaultException() : Exception("unrelated");
+
+/// <summary>A fault no filtered interceptor of this area accepts.</summary>
+public sealed class StrayFaultException() : Exception("stray");
+
+/// <summary>Throws the fault the message selected.</summary>
+public static class Faults
+{
+    /// <summary>Creates the exception a scenario asked its handler to throw.</summary>
+    public static Exception Create(FaultKind kind) => kind switch
+    {
+        FaultKind.Tagged => new TaggedFaultException(),
+        FaultKind.DerivedTagged => new DerivedTaggedFaultException(),
+        FaultKind.Unrelated => new UnrelatedFaultException(),
+        _ => new StrayFaultException(),
+    };
+}
+
+/// <summary>The void command whose handler throws the fault it carries.</summary>
+[ExcludeFromDiscovery]
+public interface IFilteredVoidCommand : ICommand
+{
+    /// <summary>The fault the handler throws.</summary>
+    FaultKind Fault { get; }
+}
+
+/// <summary>The string-result command whose handler throws the fault it carries.</summary>
+[ExcludeFromDiscovery]
+public interface IFilteredResultCommand : ICommand<string>
+{
+    /// <summary>The fault the handler throws.</summary>
+    FaultKind Fault { get; }
+}
+
+// ---------------------------------------------------------------------------
+// void pipeline — every exception-stage participant is filtered
+// ---------------------------------------------------------------------------
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public abstract class FilteredVoidHandlerBase<TCommand> : ICommandHandler<TCommand>
+    where TCommand : class, IFilteredVoidCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler");
+        throw Faults.Create(command.Fault);
+    }
+}
+
+/// <summary>Accepts the tagged fault and every type derived from it.</summary>
+[ExcludeFromDiscovery]
+public abstract class FilteredVoidTaggedBase<TCommand> : ICommandExceptionInterceptorFor<TCommand, TaggedFaultException>
+    where TCommand : class, IFilteredVoidCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(
+        TCommand command, object? messageResult, TaggedFaultException exception, IExecutionContext context)
+    {
+        context.Mark("exception:tagged", ExceptionFilterVocabulary.Describe(exception));
+        return ValueTask.FromResult<object>(Unit.Value);
+    }
+}
+
+/// <summary>Accepts only the unrelated fault.</summary>
+[ExcludeFromDiscovery]
+public abstract class FilteredVoidUnrelatedBase<TCommand> : ICommandExceptionInterceptorFor<TCommand, UnrelatedFaultException>
+    where TCommand : class, IFilteredVoidCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(
+        TCommand command, object? messageResult, UnrelatedFaultException exception, IExecutionContext context)
+    {
+        context.Mark("exception:unrelated", ExceptionFilterVocabulary.Describe(exception));
+        return ValueTask.FromResult<object>(Unit.Value);
+    }
+}
+
+/// <summary>Records the result and exception the final stage is handed.</summary>
+[ExcludeFromDiscovery]
+public abstract class FilteredVoidFinalBase<TCommand> : ICommandFinalInterceptor<TCommand>
+    where TCommand : class, IFilteredVoidCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, object? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final", ExceptionFilterVocabulary.Describe(exception));
+        return ValueTask.CompletedTask;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// string-result pipeline — a filtered participant beside an unfiltered one
+// ---------------------------------------------------------------------------
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public abstract class FilteredResultHandlerBase<TCommand> : ICommandHandler<TCommand, string>
+    where TCommand : class, IFilteredResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string> HandleAsync(TCommand command, IExecutionContext context)
+    {
+        context.Mark("handler");
+        throw Faults.Create(command.Fault);
+    }
+}
+
+/// <summary>The heavier slot: accepts the tagged fault and substitutes a recovery result.</summary>
+[ExcludeFromDiscovery]
+public abstract class FilteredResultTaggedBase<TCommand>
+    : ICommandExceptionInterceptorFor<TCommand, string, TaggedFaultException>
+    where TCommand : class, IFilteredResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string?> HandleAsync(
+        TCommand command, string? result, TaggedFaultException exception, IExecutionContext context)
+    {
+        context.Mark("exception:tagged", ExceptionFilterVocabulary.Describe(exception));
+        return ValueTask.FromResult<string?>(ExceptionFilterVocabulary.TaggedRecovery);
+    }
+}
+
+/// <summary>The lighter slot: unfiltered, so it accepts whatever reaches the stage.</summary>
+[ExcludeFromDiscovery]
+public abstract class FilteredResultUntypedBase<TCommand> : ICommandExceptionInterceptor<TCommand, string>
+    where TCommand : class, IFilteredResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask<string?> HandleAsync(
+        TCommand command, string? result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception:untyped", ExceptionFilterVocabulary.Describe(exception));
+        return ValueTask.FromResult<string?>((result ?? string.Empty) + ExceptionFilterVocabulary.UntypedSuffix);
+    }
+}
+
+/// <inheritdoc cref="FilteredVoidFinalBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class FilteredResultFinalBase<TCommand> : ICommandFinalInterceptor<TCommand, string>
+    where TCommand : class, IFilteredResultCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand command, string? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final", ExceptionFilterVocabulary.Describe(exception));
+        return ValueTask.CompletedTask;
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/ExceptionFilterSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/ExceptionFilterSemanticsContract.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Abstractions;
+using Stella.Ergosfare.Contract.Test.Harness;
+
+namespace Stella.Ergosfare.Contract.Test.ExceptionFilters;
+
+/// <summary>
+/// What declaring an exception type on an exception interceptor does: the interceptor runs
+/// only for exceptions it accepts, receives them already typed, and — when nothing in the
+/// stage accepts the thrown exception — the exception leaves the pipeline unwrapped
+/// instead of being swallowed by participants that declined it.
+/// </summary>
+/// <remarks>
+/// Both registration axes inherit these scenarios verbatim: the generated axis filters
+/// through a compile-time <c>is</c> guard baked into the emitted staged-plan body, the
+/// runtime axis through the filter probe the invocation strategy asks each resolved
+/// instance. Those are two separate implementations of one rule, and a divergence shows up
+/// as one subclass failing.
+/// </remarks>
+public abstract class ExceptionFilterSemanticsContract
+{
+    /// <summary>A container with this axis' typed exception-interceptor types registered its own way.</summary>
+    protected abstract ServiceProvider CreateProvider();
+
+    /// <summary>The void command whose handler throws the given fault.</summary>
+    protected abstract IFilteredVoidCommand NewVoidCommand(FaultKind fault);
+
+    /// <summary>The string-result command whose handler throws the given fault.</summary>
+    protected abstract IFilteredResultCommand NewResultCommand(FaultKind fault);
+
+    /// <summary>
+    /// A recorder stamped with the running axis, so a diagnostic dump of these shared
+    /// scenarios says which registration path produced each trace.
+    /// </summary>
+    private PipelineRecorder NewRecorder() => new() { Label = GetType().Name };
+
+    // -----------------------------------------------------------------------
+    // matching
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_exception_interceptor_runs_for_the_exception_type_it_declares()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await mediator.SendAsync(NewVoidCommand(FaultKind.Tagged), recorder.Commands());
+
+        recorder.AssertStages("handler", "exception:tagged", "final");
+        Assert.Equal(nameof(TaggedFaultException), recorder.DetailOf("exception:tagged"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await mediator.SendAsync(NewVoidCommand(FaultKind.Unrelated), recorder.Commands());
+
+        // Both interceptors are in the stage; only the one that accepts this fault runs.
+        recorder.AssertStages("handler", "exception:unrelated", "final");
+        Assert.DoesNotContain("exception:tagged", recorder.Stages);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_declared_exception_type_matches_its_subtypes_the_way_catch_does()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await mediator.SendAsync(NewVoidCommand(FaultKind.DerivedTagged), recorder.Commands());
+
+        // Assignability, not type identity: the interceptor declared the base fault.
+        recorder.AssertStages("handler", "exception:tagged", "final");
+        Assert.Equal(nameof(DerivedTaggedFaultException), recorder.DetailOf("exception:tagged"));
+    }
+
+    // -----------------------------------------------------------------------
+    // nothing matches
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        // Two interceptors are registered, so presence alone would have swallowed this.
+        // Only a *matching* interceptor counts as having handled the exception.
+        var thrown = await Assert.ThrowsAsync<StrayFaultException>(
+            () => mediator.SendAsync(NewVoidCommand(FaultKind.Stray), recorder.Commands()).AsTask());
+
+        // Not wrapped in anything: the caller catches the type the handler threw.
+        Assert.Equal("stray", thrown.Message);
+        recorder.AssertStages("handler", "final");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_final_stage_still_runs_when_no_interceptor_accepted_the_exception()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await Assert.ThrowsAsync<StrayFaultException>(
+            () => mediator.SendAsync(NewVoidCommand(FaultKind.Stray), recorder.Commands()).AsTask());
+
+        // The rethrow leaves through the same shell an empty exception stage does, so the
+        // final stage observes the failure on its way out — and neither filtered
+        // interceptor ran.
+        recorder.AssertStages("handler", "final");
+        Assert.Equal(nameof(StrayFaultException), recorder.DetailOf("final"));
+    }
+
+    // -----------------------------------------------------------------------
+    // filtered beside unfiltered
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var result = await mediator.SendAsync(NewResultCommand(FaultKind.Tagged), recorder.Commands());
+
+        // Filtering does not reorder the stage: the heavier slot still runs first, and the
+        // result threads from the filtered interceptor into the unfiltered one.
+        recorder.AssertStages("handler", "exception:tagged", "exception:untyped", "final");
+        Assert.Equal(
+            ExceptionFilterVocabulary.TaggedRecovery + ExceptionFilterVocabulary.UntypedSuffix,
+            result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        var result = await mediator.SendAsync(NewResultCommand(FaultKind.Stray), recorder.Commands());
+
+        // One unfiltered participant is enough for the stage to have handled the
+        // exception — the caller sees no exception at all.
+        recorder.AssertStages("handler", "exception:untyped", "final");
+        Assert.Equal(ExceptionFilterVocabulary.UntypedSuffix, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+        var mediator = provider.GetRequiredService<ICommandMediator>();
+
+        await mediator.SendAsync(NewResultCommand(FaultKind.DerivedTagged), recorder.Commands());
+
+        // The interceptor's parameter is TaggedFaultException; what it recorded is the
+        // runtime type it was handed through that parameter.
+        recorder.AssertStages("handler", "exception:tagged", "exception:untyped", "final");
+        Assert.Equal(nameof(DerivedTaggedFaultException), recorder.DetailOf("exception:tagged"));
+    }
+}

--- a/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/FallbackExceptionFilterTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/FallbackExceptionFilterTypes.cs
@@ -1,0 +1,64 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Contract.Test.ExceptionFilters.Fallback;
+
+// The same scenarios for the explicit runtime-registration axis. Excluded from discovery
+// so the generator models nothing for them: no descriptor, no dispatch root, no staged
+// plan — the exception stage is the reflective invocation strategy, which asks each
+// resolved instance its filter probe instead of running a baked-in `is` test.
+
+// --- void command: every exception-stage participant is filtered ------------
+
+/// <inheritdoc cref="Generated.FilteredVoidCommand"/>
+[ExcludeFromDiscovery]
+public sealed class FilteredVoidCommand : IFilteredVoidCommand
+{
+    /// <inheritdoc />
+    public required FaultKind Fault { get; init; }
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class FilteredVoidCommandHandler : FilteredVoidHandlerBase<FilteredVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class FilteredVoidCommandTagged : FilteredVoidTaggedBase<FilteredVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(1)]
+public sealed class FilteredVoidCommandUnrelated : FilteredVoidUnrelatedBase<FilteredVoidCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class FilteredVoidCommandFinal : FilteredVoidFinalBase<FilteredVoidCommand>;
+
+// --- string-result command: filtered beside unfiltered ----------------------
+
+/// <inheritdoc cref="Generated.FilteredResultCommand"/>
+[ExcludeFromDiscovery]
+public sealed class FilteredResultCommand : IFilteredResultCommand
+{
+    /// <inheritdoc />
+    public required FaultKind Fault { get; init; }
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class FilteredResultCommandHandler : FilteredResultHandlerBase<FilteredResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(9)]
+public sealed class FilteredResultCommandTagged : FilteredResultTaggedBase<FilteredResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+[Weight(1)]
+public sealed class FilteredResultCommandUntyped : FilteredResultUntypedBase<FilteredResultCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class FilteredResultCommandFinal : FilteredResultFinalBase<FilteredResultCommand>;

--- a/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/GeneratedExceptionFilterTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/GeneratedExceptionFilterTypes.cs
@@ -1,0 +1,59 @@
+using Stella.Ergosfare.Core.Abstractions.Attributes;
+
+namespace Stella.Ergosfare.Contract.Test.ExceptionFilters.Generated;
+
+// The typed exception-interceptor types for the source-generated registration axis.
+// Top-level, unkeyed and ungrouped on purpose: the filter has to be baked into the emitted
+// staged-plan body as a compile-time `is` guard, and only default-discovery participants
+// reach one. A [DiscoveryKey] here would register, pass, and silently prove nothing the
+// fallback axis does not already cover.
+//
+// Every message type is local to this area and no interceptor is registered against a
+// module marker, so joining the assembly's unkeyed pool cannot reach another area's
+// pipelines — and no other area's exception can reach these filters.
+
+// --- void command: every exception-stage participant is filtered ------------
+
+/// <summary>Void command whose handler throws the fault it carries.</summary>
+public sealed class FilteredVoidCommand : IFilteredVoidCommand
+{
+    /// <inheritdoc />
+    public required FaultKind Fault { get; init; }
+}
+
+/// <inheritdoc />
+public sealed class FilteredVoidCommandHandler : FilteredVoidHandlerBase<FilteredVoidCommand>;
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class FilteredVoidCommandTagged : FilteredVoidTaggedBase<FilteredVoidCommand>;
+
+/// <inheritdoc />
+[Weight(1)]
+public sealed class FilteredVoidCommandUnrelated : FilteredVoidUnrelatedBase<FilteredVoidCommand>;
+
+/// <inheritdoc />
+public sealed class FilteredVoidCommandFinal : FilteredVoidFinalBase<FilteredVoidCommand>;
+
+// --- string-result command: filtered beside unfiltered ----------------------
+
+/// <summary>String-result command whose handler throws the fault it carries.</summary>
+public sealed class FilteredResultCommand : IFilteredResultCommand
+{
+    /// <inheritdoc />
+    public required FaultKind Fault { get; init; }
+}
+
+/// <inheritdoc />
+public sealed class FilteredResultCommandHandler : FilteredResultHandlerBase<FilteredResultCommand>;
+
+/// <inheritdoc />
+[Weight(9)]
+public sealed class FilteredResultCommandTagged : FilteredResultTaggedBase<FilteredResultCommand>;
+
+/// <inheritdoc />
+[Weight(1)]
+public sealed class FilteredResultCommandUntyped : FilteredResultUntypedBase<FilteredResultCommand>;
+
+/// <inheritdoc />
+public sealed class FilteredResultCommandFinal : FilteredResultFinalBase<FilteredResultCommand>;

--- a/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/GeneratedRegistrationExceptionFilterTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/GeneratedRegistrationExceptionFilterTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.ExceptionFilters.Generated;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Generated;
+
+namespace Stella.Ergosfare.Contract.Test.ExceptionFilters;
+
+/// <summary>
+/// The typed exception-interceptor contract under source-generated registration — the
+/// primary axis. The generator reads each interceptor's declared exception type at compile
+/// time and bakes it into the emitted plan as an <c>is</c> guard, so this axis never asks
+/// an instance anything.
+/// </summary>
+/// <remarks>
+/// The pattern-less overload is deliberate and is reserved for this axis: plan eligibility
+/// requires default-discovery types, so a keyed selection would quietly fall back to the
+/// reflective executors and stop testing the emitted guard.
+/// </remarks>
+public sealed class GeneratedRegistrationExceptionFilterTests : ExceptionFilterSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.RegisterGenerated()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IFilteredVoidCommand NewVoidCommand(FaultKind fault)
+        => new FilteredVoidCommand { Fault = fault };
+
+    /// <inheritdoc />
+    protected override IFilteredResultCommand NewResultCommand(FaultKind fault)
+        => new FilteredResultCommand { Fault = fault };
+}

--- a/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/RuntimeRegistrationExceptionFilterTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/ExceptionFilters/RuntimeRegistrationExceptionFilterTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+using Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection;
+using Stella.Ergosfare.Contract.Test.ExceptionFilters.Fallback;
+using Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection;
+
+namespace Stella.Ergosfare.Contract.Test.ExceptionFilters;
+
+/// <summary>
+/// The same typed exception-interceptor contract under explicit runtime registration — the
+/// fallback the generated axis degrades to. These types are excluded from discovery, so no
+/// compile-time plan exists for them and the exception stage is the reflective invocation
+/// strategy, which asks every resolved instance whether it accepts the thrown exception.
+/// </summary>
+/// <remarks>
+/// The unfiltered interceptor is registered before the filtered one on purpose: if
+/// registration order decided the stage, the inherited ordering expectation would fail here
+/// and pass on the generated axis.
+/// </remarks>
+public sealed class RuntimeRegistrationExceptionFilterTests : ExceptionFilterSemanticsContract
+{
+    /// <inheritdoc />
+    protected override ServiceProvider CreateProvider()
+        => new ServiceCollection()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands
+                    .Register<FilteredVoidCommandHandler>()
+                    .Register<FilteredVoidCommandUnrelated>()
+                    .Register<FilteredVoidCommandTagged>()
+                    .Register<FilteredVoidCommandFinal>()
+                    .Register<FilteredResultCommandHandler>()
+                    .Register<FilteredResultCommandUntyped>()
+                    .Register<FilteredResultCommandTagged>()
+                    .Register<FilteredResultCommandFinal>()))
+            .BuildServiceProvider();
+
+    /// <inheritdoc />
+    protected override IFilteredVoidCommand NewVoidCommand(FaultKind fault)
+        => new FilteredVoidCommand { Fault = fault };
+
+    /// <inheritdoc />
+    protected override IFilteredResultCommand NewResultCommand(FaultKind fault)
+        => new FilteredResultCommand { Fault = fault };
+}

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -37,6 +37,7 @@ contract class and closing it over a per-axis type set:
 | Pipeline semantics | `Pipeline/PipelineSemanticsContract.cs` | `Pipeline/GeneratedPipelineTypes.cs` | `Pipeline/FallbackPipelineTypes.cs` |
 | Synchronous interceptors | `Sync/SyncSemanticsContract.cs` | `Sync/GeneratedSyncTypes.cs` | `Sync/FallbackSyncTypes.cs` |
 | Post-interceptor abort | `Abort/PostAbortSemanticsContract.cs` | `Abort/GeneratedPostAbortTypes.cs` | `Abort/FallbackPostAbortTypes.cs` |
+| Typed exception filters | `ExceptionFilters/ExceptionFilterSemanticsContract.cs` | `ExceptionFilters/GeneratedExceptionFilterTypes.cs` | `ExceptionFilters/FallbackExceptionFilterTypes.cs` |
 
 | Axis | Types | Registration | Executors actually reached |
 | --- | --- | --- | --- |
@@ -51,7 +52,7 @@ Both halves of that table are load-bearing, and both are easy to break by accide
   additionally must not be nested). Adding a `[DiscoveryKey]` here still registers through
   generated descriptors — and silently dispatches on the reflective executors, testing
   nothing the fallback axis does not already cover. The pattern-less `RegisterGenerated()`
-  is therefore **reserved for the three areas above**, and every type they declare is local
+  is therefore **reserved for the four areas above**, and every type they declare is local
   to its own area: a message type shared with another area, or an interceptor registered
   against something outside the area, would cross-contaminate the shared unkeyed pool.
 - **The fallback axis must stay `[ExcludeFromDiscovery]`.** The generator's descriptor
@@ -87,6 +88,14 @@ reach the reflective path by construction and the key costs nothing:
 - **`contract.exclude`** (`Exclusion/PipelineExclusionTests.cs`) — the generator skips
   messages carrying `[ExcludeFromPipeline]` rather than modeling the exclusion.
 
+One gate is deliberately left unpinned, because no assertion can see it: an exception
+interceptor that implements the non-generic `IExceptionInterceptorFilter` by hand — rather
+than declaring one `IExceptionInterceptorFilter<TException>` — has no compile-time exception
+type, so the generator disqualifies the whole plan and the dispatch falls back to the
+reflective stage, which asks the instance. Both paths then produce the same observable
+behavior; only the lane map would show the difference. Do not write such an interceptor in
+the unkeyed pool: it would take an area's plans down without failing a single test.
+
 ## Rules for anyone adding tests here
 
 **The `MessageRegistry` is process-wide.** It is a singleton shared by every container in
@@ -97,7 +106,7 @@ the test process, and it never forgets. Everything below follows from that.
    else.
 2. **Give your area its own discovery key, and never call the pattern-less
    `RegisterGenerated()`.** That overload registers every default-discovery construct in
-   the assembly, and it belongs to the three both-axis areas alone (see
+   the assembly, and it belongs to the four both-axis areas alone (see
    [Registration axes](#registration-axes)). An unkeyed message anywhere else joins those
    containers and can break their plan expectations. Reach for it only when the scenario
    genuinely needs to run inside an emitted plan — and then keep every type the scenario
@@ -120,6 +129,11 @@ the test process, and it never forgets. Everything below follows from that.
 7. **No sleeps.** Use `TaskCompletionSource` if async coordination is ever needed. Every
    scenario here completes synchronously today.
 8. **Hand-written stubs, no Moq.** The repository is phasing mocks out.
+9. **Give your area its own exception types.** Since typed exception interceptors match on
+   assignability, an exception type is now a selector as much as a message type is: an
+   interceptor declaring a widely-used base type accepts faults thrown by scenarios that
+   have never heard of it. Declare the faults your area throws inside the area, and never
+   filter on a framework exception type.
 
 ## How a scenario observes a dispatch
 

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -1,3 +1,279 @@
+GeneratedRegistrationExceptionFilterTests — stages: [handler, exception:tagged, exception:untyped, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultTaggedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception:untyped  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultUntypedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, exception:tagged, exception:untyped, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultTaggedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception:untyped  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultUntypedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, exception:tagged, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_declared_exception_type_matches_its_subtypes_the_way_catch_does
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_declared_exception_type_matches_its_subtypes_the_way_catch_does>d__6.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_declared_exception_type_matches_its_subtypes_the_way_catch_does
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_declared_exception_type_matches_its_subtypes_the_way_catch_does>d__6.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidTaggedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_declared_exception_type_matches_its_subtypes_the_way_catch_does
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_declared_exception_type_matches_its_subtypes_the_way_catch_does>d__6.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, exception:tagged, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_runs_for_the_exception_type_it_declares
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_runs_for_the_exception_type_it_declares>d__4.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_runs_for_the_exception_type_it_declares
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_runs_for_the_exception_type_it_declares>d__4.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidTaggedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_runs_for_the_exception_type_it_declares
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_runs_for_the_exception_type_it_declares>d__4.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, exception:unrelated, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:unrelated  <- UnrelatedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidUnrelatedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- UnrelatedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, exception:untyped, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:untyped  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                     | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultUntypedBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass7_0.<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass7_0.<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationExceptionFilterTests — stages: [handler, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_final_stage_still_runs_when_no_interceptor_accepted_the_exception
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass8_0.<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_final_stage_still_runs_when_no_interceptor_accepted_the_exception
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass8_0.<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
+                   | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
 GeneratedRegistrationPipelineExclusionTests — stages: [pre:covariant, handler]
   1. pre:covariant
      | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract.The_same_covariant_interceptor_still_joins_a_sibling_without_the_attribute
@@ -91,8 +367,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -103,8 +379,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -115,8 +391,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -127,8 +403,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -139,8 +415,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -151,8 +427,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -163,8 +439,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -175,8 +451,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|null|PipelineFailure
@@ -185,8 +461,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultExceptionBase`1.HandleAsync
@@ -197,8 +473,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -209,8 +485,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -221,8 +497,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|0|PipelineFailure
@@ -231,8 +507,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TQuery,TResult>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueExceptionBase`1.HandleAsync
@@ -243,8 +519,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -255,8 +531,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -267,8 +543,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|null|PipelineFailure
@@ -277,8 +553,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadExceptionBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+rewritten|Unit|PipelineFailure
@@ -287,8 +563,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -299,8 +575,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -311,8 +587,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|ok+rewritten
@@ -321,8 +597,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPostBase`1.HandleAsync
@@ -333,8 +609,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -345,8 +621,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -357,8 +633,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|Unit
@@ -367,8 +643,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+rewritten|Unit|none
@@ -377,8 +653,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan4+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -389,8 +665,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -401,8 +677,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|7
@@ -411,8 +687,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePostBase`1.HandleAsync
@@ -423,8 +699,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -435,8 +711,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -447,8 +723,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -459,8 +735,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -471,8 +747,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -483,8 +759,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   6. post:high
@@ -493,8 +769,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   7. post:low
@@ -503,8 +779,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan3+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -840,8 +1116,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
@@ -850,8 +1126,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -862,8 +1138,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
@@ -872,8 +1148,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -884,8 +1160,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- throw+sync-pre
@@ -894,8 +1170,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+sync-pre|null|SyncFailure
@@ -904,8 +1180,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultExceptionBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+sync-pre|sync-fallback|SyncFailure
@@ -914,8 +1190,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -926,8 +1202,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- throw+sync-pre
@@ -936,8 +1212,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+sync-pre|null|SyncFailure
@@ -946,8 +1222,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidExceptionBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+sync-pre|null|SyncFailure
@@ -956,8 +1232,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -968,8 +1244,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- ok+sync-pre
@@ -978,8 +1254,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+sync-pre|ok+sync-pre
@@ -988,8 +1264,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+sync-pre|ok+sync-pre+sync-post|none
@@ -998,8 +1274,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1010,8 +1286,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- ok+sync-pre
@@ -1020,8 +1296,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+sync-pre|Unit
@@ -1030,8 +1306,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+sync-pre|Unit|none
@@ -1040,8 +1316,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1052,8 +1328,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- ok+sync-pre
@@ -1062,8 +1338,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+sync-pre|Unit
@@ -1072,8 +1348,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+sync-pre|Unit|none
@@ -1082,8 +1358,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1094,8 +1370,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
@@ -1106,8 +1382,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. pre:async-low
@@ -1116,8 +1392,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
@@ -1128,8 +1404,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   5. post:sync-high
@@ -1138,8 +1414,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   6. post:async-low
@@ -1148,10 +1424,326 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, exception:tagged, exception:untyped, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultTaggedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception:untyped  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultUntypedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_filtered_and_an_unfiltered_interceptor_both_run_in_the_pipelines_existing_order>d__9.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, exception:tagged, exception:untyped, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`3+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultTaggedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. exception:untyped  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultUntypedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  4. final  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_typed_exception_reaches_the_interceptor_without_a_cast_in_its_body>d__11.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, exception:tagged, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_declared_exception_type_matches_its_subtypes_the_way_catch_does
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_declared_exception_type_matches_its_subtypes_the_way_catch_does>d__6.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_declared_exception_type_matches_its_subtypes_the_way_catch_does
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_declared_exception_type_matches_its_subtypes_the_way_catch_does>d__6.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidTaggedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- DerivedTaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.A_declared_exception_type_matches_its_subtypes_the_way_catch_does
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<A_declared_exception_type_matches_its_subtypes_the_way_catch_does>d__6.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, exception:tagged, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_runs_for_the_exception_type_it_declares
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_runs_for_the_exception_type_it_declares>d__4.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:tagged  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_runs_for_the_exception_type_it_declares
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_runs_for_the_exception_type_it_declares>d__4.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidTaggedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- TaggedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_runs_for_the_exception_type_it_declares
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_runs_for_the_exception_type_it_declares>d__4.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, exception:unrelated, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:unrelated  <- UnrelatedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptorFor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidUnrelatedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- UnrelatedFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_interceptor_does_not_run_for_an_exception_type_it_did_not_declare>d__5.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, exception:untyped, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception:untyped  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultUntypedBase`1.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_unfiltered_interceptor_still_accepts_what_the_filtered_one_declined>d__10.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.ResultPipelineExecutor`2.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`2+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredResultFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass7_0.<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>d__7.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass7_0.<An_exception_no_interceptor_declared_leaves_the_pipeline_unwrapped>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                         | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationExceptionFilterTests — stages: [handler, final]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_final_stage_still_runs_when_no_interceptor_accepted_the_exception
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass8_0.<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                       | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidHandlerBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. final  <- StrayFaultException
+     | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract.The_final_stage_still_runs_when_no_interceptor_accepted_the_exception
+       | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>d__8.MoveNext
+         | Stella.Ergosfare.Contract.Test.ExceptionFilters.ExceptionFilterSemanticsContract+<>c__DisplayClass8_0.<The_final_stage_still_runs_when_no_interceptor_accepted_the_exception>b__0
+           | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+             | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+               | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                       | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                         | Stella.Ergosfare.Contract.Test.ExceptionFilters.FilteredVoidFinalBase`1.HandleAsync
+                           | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineExclusionTests — stages: [pre:covariant, handler]
   1. pre:covariant

--- a/test/Stella.Ergosfare.Events.Test/FilteredEventExceptionInterceptorTests.cs
+++ b/test/Stella.Ergosfare.Events.Test/FilteredEventExceptionInterceptorTests.cs
@@ -1,0 +1,90 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+using Stella.Ergosfare.Core.Internal.Contexts;
+using Stella.Ergosfare.Events.Abstractions;
+
+namespace Stella.Ergosfare.Events.Test;
+
+/// <summary>
+/// Verifies the filtered event exception-interceptor facades: their filter probe answers
+/// with <c>catch</c> semantics, and their default interface implementations forward the
+/// pipeline's untyped call to the typed member with the exception already narrowed.
+/// </summary>
+/// <remarks>
+/// A publish produces no result, so these facades return the pipeline's one result value
+/// rather than anything of the interceptor's own — the assertion below is what keeps the
+/// broadcast stage's result slot well-formed.
+/// </remarks>
+public class FilteredEventExceptionInterceptorTests
+{
+    private sealed record TestEvent : IEvent;
+
+    private sealed class TestFault() : Exception("fault");
+
+    private sealed class DerivedTestFault() : Exception("derived");
+
+    private sealed class TypedEventInterceptor : IEventExceptionInterceptorFor<TestEvent, TestFault>
+    {
+        public TestFault? Received;
+
+        public ValueTask HandleAsync(TestEvent @event, TestFault exception, IExecutionContext context)
+        {
+            Received = exception;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ModuleWideEventInterceptor : IEventExceptionInterceptorFor<TestFault>
+    {
+        public TestFault? Received;
+
+        public ValueTask HandleAsync(IEvent @event, TestFault exception, IExecutionContext context)
+        {
+            Received = exception;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static ErgosfareExecutionContext CreateContext() => new(null, default);
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FilterAcceptsTheDeclaredExceptionTypeAndRejectsOthers()
+    {
+        IExceptionInterceptorFilter filter = new TypedEventInterceptor();
+
+        Assert.True(filter.Matches(new TestFault()));
+        Assert.False(filter.Matches(new DerivedTestFault()));
+        Assert.False(filter.Matches(new InvalidOperationException()));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TypedFacadeDefaultImplementationForwardsTheNarrowedException()
+    {
+        var interceptor = new TypedEventInterceptor();
+        var fault = new TestFault();
+
+        var result = await ((IAsyncExceptionInterceptor<TestEvent, Unit>) interceptor)
+            .HandleAsync(new TestEvent(), Unit.Value, fault, CreateContext());
+
+        Assert.Same(fault, interceptor.Received);
+
+        // The publish has no result of its own; the slot keeps the pipeline's one value.
+        Assert.Same(Unit.Value, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ModuleWideFacadeDefaultImplementationForwardsTheNarrowedException()
+    {
+        var interceptor = new ModuleWideEventInterceptor();
+        var fault = new TestFault();
+
+        var result = await ((IAsyncExceptionInterceptor<IEvent, Unit>) interceptor)
+            .HandleAsync(new TestEvent(), Unit.Value, fault, CreateContext());
+
+        Assert.Same(fault, interceptor.Received);
+        Assert.Same(Unit.Value, result);
+    }
+}

--- a/test/Stella.Ergosfare.Queries.Test/FilteredQueryExceptionInterceptorTests.cs
+++ b/test/Stella.Ergosfare.Queries.Test/FilteredQueryExceptionInterceptorTests.cs
@@ -1,0 +1,90 @@
+using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
+using Stella.Ergosfare.Queries.Abstractions;
+
+namespace Stella.Ergosfare.Queries.Test;
+
+/// <summary>
+/// Verifies the filtered query exception-interceptor facades: their filter probe answers
+/// with <c>catch</c> semantics, and their default interface implementations forward the
+/// pipeline's untyped call to the typed member with the exception already narrowed.
+/// </summary>
+public class FilteredQueryExceptionInterceptorTests
+{
+    private sealed record TestQuery : IQuery<string>;
+
+    private class TestFault() : Exception("fault");
+
+    private sealed class DerivedTestFault : TestFault;
+
+    private sealed class ResultTypedQueryInterceptor : IQueryExceptionInterceptorFor<TestQuery, string, TestFault>
+    {
+        public const string Recovery = "recovered";
+
+        public TestFault? Received;
+
+        public ValueTask<string?> HandleAsync(
+            TestQuery query, string? result, TestFault exception, IExecutionContext context)
+        {
+            Received = exception;
+            return ValueTask.FromResult<string?>(Recovery);
+        }
+    }
+
+    private sealed class ResultAgnosticQueryInterceptor : IQueryExceptionInterceptorFor<TestQuery, TestFault>
+    {
+        public TestFault? Received;
+
+        public ValueTask<object> HandleAsync(
+            TestQuery query, object? messageResult, TestFault exception, IExecutionContext context)
+        {
+            Received = exception;
+            return ValueTask.FromResult<object>(messageResult ?? Unit.Value);
+        }
+    }
+
+    // These facades hand the context straight through to the typed member without reading
+    // it, and the concrete context is internal to the core assembly.
+    private static IExecutionContext CreateContext() => null!;
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void FilterMatchesTheDeclaredExceptionTypeAndItsSubtypes()
+    {
+        IExceptionInterceptorFilter filter = new ResultTypedQueryInterceptor();
+
+        Assert.True(filter.Matches(new TestFault()));
+
+        // catch semantics: a subtype of the declared fault matches too.
+        Assert.True(filter.Matches(new DerivedTestFault()));
+        Assert.False(filter.Matches(new InvalidOperationException()));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResultTypedFacadeDefaultImplementationForwardsTheNarrowedException()
+    {
+        var interceptor = new ResultTypedQueryInterceptor();
+        var fault = new DerivedTestFault();
+
+        var result = await ((IAsyncExceptionInterceptor<TestQuery, string>) interceptor)
+            .HandleAsync(new TestQuery(), "original", fault, CreateContext());
+
+        Assert.Same(fault, interceptor.Received);
+        Assert.Equal(ResultTypedQueryInterceptor.Recovery, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ResultAgnosticFacadeDefaultImplementationForwardsTheNarrowedException()
+    {
+        var interceptor = new ResultAgnosticQueryInterceptor();
+        var fault = new TestFault();
+
+        var result = await ((IAsyncExceptionInterceptor<TestQuery>) interceptor)
+            .HandleAsync(new TestQuery(), "original", fault, CreateContext());
+
+        Assert.Same(fault, interceptor.Received);
+        Assert.Equal("original", result);
+    }
+}


### PR DESCRIPTION
Faz 4: typed exception interceptor facades — `...ExceptionInterceptorFor<TMessage, TResult, TException>`, `<TMessage, TException>` and `<TException>` shapes for commands and queries. The interceptor's `if (ex is X)` probe moves into the contract: the parameter arrives typed, and the core counts matches so a non-matching set rethrows instead of swallowing (the DIM-shortcut bug the issue warned about — DIM is used for the type test only, the "did anyone match" count lives in the strategy).

Closes #131.

## Contents

- `feat: exception interceptors that declare the exception type they accept` — the facade family, the `IExceptionInterceptorFilter` seam on the instance (deliberately descriptor-free, so the matching logic ports to the single-plan-type surgery unchanged), generator modeling for both axes, and the contract scenarios.
- `test: re-capture the lane map after the typed exception filters` — baseline refresh, counter-verified.

## Open decision riding this review: #151

The event facade aliases (`IEventFinalInterceptor<T>` / non-generic twins) broke consumers at compile time when F6a moved their base to `<TEvent, Unit>`; #151 asks whether to add own `ValueTask result` members + DIM shims to remove the break entirely. Recommendation on the table: accept the loud one-word break (CS0535) rather than add cosmetic members whose `result` parameter would carry a constant `CompletedTask` — but this PR's review is where that call lands, since it touches the same facade family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
