### PR TITLE
fix: the executor lane's abort arm rides the engine's frame

### DIFF
--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
@@ -55,28 +55,22 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
                 ? _directHandlerFactory is not null ? _directHandlerFactory() : _providerHandlerFactory!(serviceProvider)
                 : handlerReference.Resolve(serviceProvider);
 
-            // The strategy is skipped here, so its abort handling has to be too; see
-            // AbortShortCircuit.
-            try
+            // The strategy is skipped here, and with it its abort handling. That arm lives
+            // in the engine's dispatch frame — an exception-handling region here would keep
+            // Execute out of its caller on every dispatch; see MessageDispatchEngine.
+            if (handler is THandler planned)
             {
-                if (handler is THandler planned)
-                {
-                    return AbortShortCircuit.Guard(planned.HandleAsync((TMessage)message, context));
-                }
-
-                switch (handler)
-                {
-                    case IAsyncHandler<TMessage, TResult> asyncHandler:
-                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
-                    case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
-                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
-                    case IHandler<TMessage, TResult> syncHandler:
-                        return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
-                }
+                return planned.HandleAsync((TMessage)message, context);
             }
-            catch (ExecutionAbortedException)
+
+            switch (handler)
             {
-                return ValueTask.FromResult<TResult>(default!);
+                case IAsyncHandler<TMessage, TResult> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, TResult> syncHandler:
+                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
             }
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
@@ -74,29 +74,23 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
             // match. A runtime re-registration can put a differently-typed handler here;
             // the contract switch below then dispatches it exactly as the runtime
             // executor would.
-            // The strategy is skipped here, so its abort handling has to be too; see
-            // AbortShortCircuit.
-            try
+            // The strategy is skipped here, and with it its abort handling. That arm lives
+            // in the engine's dispatch frame — an exception-handling region here would keep
+            // Execute out of its caller on every dispatch; see MessageDispatchEngine.
+            if (handler is THandler planned)
             {
-                if (handler is THandler planned)
-                {
-                    return AbortShortCircuit.Guard(planned.HandleAsync((TMessage)message, context));
-                }
-
-                switch (handler)
-                {
-                    case IAsyncHandler<TMessage> asyncHandler:
-                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
-                    case IHandler<TMessage, ValueTask> valueTaskShaped:
-                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
-                    case IHandler<TMessage, object> syncHandler:
-                        syncHandler.Handle((TMessage)message, context);
-                        return ValueTask.CompletedTask;
-                }
+                return planned.HandleAsync((TMessage)message, context);
             }
-            catch (ExecutionAbortedException)
+
+            switch (handler)
             {
-                return ValueTask.CompletedTask;
+                case IAsyncHandler<TMessage> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, object> syncHandler:
+                    syncHandler.Handle((TMessage)message, context);
+                    return ValueTask.CompletedTask;
             }
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
@@ -49,24 +49,17 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
         {
             var handler = handlerReference.Resolve(serviceProvider);
 
-            // The strategy is skipped here, so its abort handling has to be too; see
-            // AbortShortCircuit. Nothing was produced when a zero-interceptor handler
-            // aborts, so the caller gets the result type's default.
-            try
+            // The strategy is skipped here, and with it its abort handling. That arm lives
+            // in the engine's dispatch frame — an exception-handling region here would keep
+            // Execute out of its caller on every dispatch; see MessageDispatchEngine.
+            switch (handler)
             {
-                switch (handler)
-                {
-                    case IAsyncHandler<TMessage, TResult> asyncHandler:
-                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
-                    case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
-                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
-                    case IHandler<TMessage, TResult> syncHandler:
-                        return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
-                }
-            }
-            catch (ExecutionAbortedException)
-            {
-                return ValueTask.FromResult<TResult>(default!);
+                case IAsyncHandler<TMessage, TResult> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask<TResult>> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, TResult> syncHandler:
+                    return ValueTask.FromResult(syncHandler.Handle((TMessage)message, context));
             }
 
             // Unsupported handler contract: fall through so the strategy raises its

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
@@ -38,25 +38,18 @@ internal sealed class VoidPipelineExecutor<TMessage>(
         {
             var handler = handlerReference.Resolve(serviceProvider);
 
-            // The strategy is skipped here, so its abort handling has to be too; see
-            // AbortShortCircuit. The try covers a handler that aborts synchronously, the
-            // guard the one that captured the abort into its task.
-            try
+            // The strategy is skipped here, and with it its abort handling. That arm lives
+            // in the engine's dispatch frame — an exception-handling region here would keep
+            // Execute out of its caller on every dispatch; see MessageDispatchEngine.
+            switch (handler)
             {
-                switch (handler)
-                {
-                    case IAsyncHandler<TMessage> asyncHandler:
-                        return AbortShortCircuit.Guard(asyncHandler.HandleAsync((TMessage)message, context));
-                    case IHandler<TMessage, ValueTask> valueTaskShaped:
-                        return AbortShortCircuit.Guard(valueTaskShaped.Handle((TMessage)message, context));
-                    case IHandler<TMessage, object> syncHandler:
-                        syncHandler.Handle((TMessage)message, context);
-                        return ValueTask.CompletedTask;
-                }
-            }
-            catch (ExecutionAbortedException)
-            {
-                return ValueTask.CompletedTask;
+                case IAsyncHandler<TMessage> asyncHandler:
+                    return asyncHandler.HandleAsync((TMessage)message, context);
+                case IHandler<TMessage, ValueTask> valueTaskShaped:
+                    return valueTaskShaped.Handle((TMessage)message, context);
+                case IHandler<TMessage, object> syncHandler:
+                    syncHandler.Handle((TMessage)message, context);
+                    return ValueTask.CompletedTask;
             }
         }
 

--- a/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
+++ b/src/Stella.Ergosfare.Core/MessageDispatchEngine.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Stella.Ergosfare.Core.Abstractions;
+using Stella.Ergosfare.Core.Abstractions.Exceptions;
 using Stella.Ergosfare.Core.Abstractions.Factories;
 using Stella.Ergosfare.Core.Internal.Contexts;
 using Stella.Ergosfare.Core.Internal.Mediator;
@@ -65,6 +66,16 @@ public sealed class MessageDispatchEngine
         {
             task = executor.Execute(message, context, serviceProvider);
         }
+        catch (ExecutionAbortedException)
+        {
+            // The executor lane's abort handling: the engine's frame already carries an
+            // exception-handling region for the pooled context, so the abort arm is free
+            // here — where the same arm inside Execute taxes every dispatch with a region
+            // that keeps Execute out of its caller. Nothing was produced when a
+            // zero-interceptor handler aborts, so the dispatch simply completes.
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
         catch
         {
             ErgosfareExecutionContextPool.Return(context);
@@ -88,6 +99,10 @@ public sealed class MessageDispatchEngine
             try
             {
                 await task;
+            }
+            catch (ExecutionAbortedException)
+            {
+                // An abort the handler captured into its task; see the synchronous arm.
             }
             finally
             {
@@ -136,6 +151,13 @@ public sealed class MessageDispatchEngine
         {
             task = executor.Execute(message, context, serviceProvider);
         }
+        catch (ExecutionAbortedException)
+        {
+            // See the untyped void overload: the abort arm rides the frame's existing
+            // exception-handling region.
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
         catch
         {
             ErgosfareExecutionContextPool.Return(context);
@@ -156,6 +178,10 @@ public sealed class MessageDispatchEngine
             try
             {
                 await task;
+            }
+            catch (ExecutionAbortedException)
+            {
+                // An abort the handler captured into its task; see the synchronous arm.
             }
             finally
             {
@@ -183,6 +209,13 @@ public sealed class MessageDispatchEngine
         {
             task = executor.Execute(message, context, serviceProvider);
         }
+        catch (ExecutionAbortedException)
+        {
+            // See the void overload: nothing was produced when a zero-interceptor handler
+            // aborts, so the caller gets the result type's default.
+            ErgosfareExecutionContextPool.Return(context);
+            return default;
+        }
         catch
         {
             ErgosfareExecutionContextPool.Return(context);
@@ -204,6 +237,11 @@ public sealed class MessageDispatchEngine
             try
             {
                 return await task;
+            }
+            catch (ExecutionAbortedException)
+            {
+                // An abort the handler captured into its task; see the synchronous arm.
+                return default!;
             }
             finally
             {
@@ -229,7 +267,17 @@ public sealed class MessageDispatchEngine
 
         var executor = _executorCache.GetVoidExecutor(message.GetType(), groups);
 
-        return executor.Execute(message, context, serviceProvider);
+        // Caller-owned context, so there is no pooled-return frame to ride: this overload
+        // carries the executor lane's abort arm itself. It serves nested and
+        // externally-contexted dispatches, not the pooled hot path.
+        try
+        {
+            return AbortShortCircuit.Guard(executor.Execute(message, context, serviceProvider));
+        }
+        catch (ExecutionAbortedException)
+        {
+            return default;
+        }
     }
 
     /// <summary>
@@ -245,6 +293,14 @@ public sealed class MessageDispatchEngine
 
         var executor = _executorCache.GetExecutor<TResult>(message.GetType(), groups);
 
-        return executor.Execute(message, context, serviceProvider);
+        // Caller-owned context; see the void overload above.
+        try
+        {
+            return AbortShortCircuit.Guard(executor.Execute(message, context, serviceProvider));
+        }
+        catch (ExecutionAbortedException)
+        {
+            return default;
+        }
     }
 }


### PR DESCRIPTION
Fixes the interceptor-less-path regression the phase-3 stack introduced: the abort short circuit's try/catch gave every executor's `Execute` an exception-handling region, and a method carrying one never inlines into its caller — the engine's dispatch frame. The region taxed every dispatch without ever being on a throwing path.

Stacked on #160 (`fix/typed-exception-interceptor-facades`); contains one commit.

## Attribution — four-point measurement, short-run, same machine

| Row | Faz2 close | pre-abort | HEAD | **this fix** |
|---|---|---|---|---|
| Command_Void_Generated | 20.22 | 19.84 | 25.40 | **20.76** |
| Query_Result_Generated | 23.91 | 23.82 | 29.02 | **24.51** |
| Command_Void | 29.92 | 30.63 | 33.84 | **28.84** |
| Query_Result | 35.78 | 35.56 | 40.84 | **37.62** |
| Command_Void_Grouped | 33.02 | 33.33 | 37.94 | **32.61** |
| Command_Void_Intercepted | 185.72 | 143.63 | 156.92 | **143.15** |

Covariance (F4) and the unit representation (F6a) cost nothing — the pre-abort point sits on the Faz2 close within noise; F6a is what took the intercepted row 185→143. The abort region was the whole regression, and it taxed the strategy-fallback rows too, since they enter `Execute` before falling through. Hoisting the region into helper methods was measured and rejected: the helper carries the region, cannot inline either, and adds a call (+1–5ns).

## The fix

The abort arm moves to the engine, whose pooled dispatch methods already carry an exception-handling region for the context-pool return — an `ExecutionAbortedException` arm there is free. Synchronous aborts land in the existing try; task-captured ones in `AwaitAndReturn`'s existing region. The two caller-owned-context overloads carry their own arm plus the guard: nested dispatches keep the cost, the hot path sheds it. The executors keep nothing — no region, no guard — and the semantics are unchanged on every path.

## Verification

- Contract suite **189/189 green on both TFMs**, including the executor-lane abort scenarios added with the short circuit — they pin the moved arm.
- **Lane map byte-identical** (hash-compared): the guard never left frames in the dumps, and the engine's arms ride existing frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
