### PR TITLE
perf: dependencies freeze after the first dispatch

### DIFF
--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
@@ -14,7 +14,6 @@ namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 /// </remarks>
 /// <param name="messageType">The message type whose pipeline could not be built.</param>
 /// <param name="participantType">The participant the container cannot resolve.</param>
-[Serializable]
 public class UnresolvableParticipantException(Type messageType, Type participantType)
     : InvalidOperationException(
         $"The pipeline for '{messageType.Name}' includes '{participantType.FullName ?? participantType.Name}', " +

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedResultPipelineExecutor[TMessage,TResult,THandler].cs
@@ -13,8 +13,9 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 /// <see cref="GeneratedVoidPipelineExecutor{TMessage, THandler}"/>: closed over the
 /// message, its result and its compile-time-known sole async handler, so the handler call
 /// devirtualizes instead of walking the contract pattern match. The same advisory-plan
-/// contract applies — the registry-version-guarded dependency cache re-validates the
-/// pipeline and any mismatch falls back to the runtime dispatch shape.
+/// contract applies — the dependency cache validates the pipeline on the first dispatch
+/// and any mismatch falls back to the runtime dispatch shape; the validated shape is
+/// frozen thereafter.
 /// </summary>
 #pragma warning disable CS8714 // TResult is used as a pattern type argument; handler contracts declare notnull results
 internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandler>(
@@ -40,11 +41,21 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
 
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
-    private int _cachedVersion = int.MinValue;
     private bool _useDirectConstruction;
+
+    // True once the first dispatch has validated the entire fast lane — planned handler
+    // type, direct construction, no adapters. From then on the planned handler is
+    // constructed and invoked without touching dependencies at all.
+    private bool _fastDirect;
 
     public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
+        if (_fastDirect)
+        {
+            var direct = _directHandlerFactory is not null ? _directHandlerFactory() : _providerHandlerFactory!(serviceProvider);
+            return direct.HandleAsync((TMessage)message, context);
+        }
+
         var dependencies = GetDependencies();
 
         if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
@@ -81,12 +92,11 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
-            // Read before the build: a registration completing mid-build must land as a
-            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
-            var registryVersion = typedFactory.CurrentRegistryVersion;
+            // Frozen registry: dependencies resolve once per executor and are never
+            // re-validated — a registration after the first dispatch is not observed.
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == registryVersion)
+            if (cached is not null)
             {
                 return cached;
             }
@@ -99,7 +109,9 @@ internal sealed class GeneratedResultPipelineExecutor<TMessage, TResult, THandle
                 && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
                 && plannedType == typeof(THandler)
                 && typedFactory.IsPlainTransientRegistration(typeof(THandler));
-            _cachedVersion = registryVersion;
+            _fastDirect = _useDirectConstruction
+                && !_foreignAdapters
+                && (_concreteAdapters is null || _concreteAdapters.IsEmpty);
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/GeneratedVoidPipelineExecutor[TMessage,THandler].cs
@@ -14,10 +14,10 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 /// reference exactly like <see cref="VoidPipelineExecutor{TMessage}"/> but invokes it
 /// through the closed <typeparamref name="THandler"/> type, so the call devirtualizes
 /// (and inlines for sealed handlers) instead of walking the contract pattern match. The
-/// plan is advisory: the same registry-version-guarded dependency cache re-validates the
-/// pipeline, and any mismatch — interceptors registered at runtime, a differently-typed
-/// handler instance, configured adapters — falls back to the runtime dispatch shape,
-/// preserving semantics exactly.
+/// plan is advisory: the dependency cache validates the pipeline on the first dispatch,
+/// and any mismatch — a differently-typed handler instance, configured adapters — falls
+/// back to the runtime dispatch shape, preserving semantics exactly. The validated shape
+/// is frozen; a registration after the first dispatch is not observed.
 /// </summary>
 internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     IMessageDescriptor descriptor,
@@ -47,7 +47,6 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
 
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
-    private int _cachedVersion = int.MinValue;
 
     // Re-validated with the dependency cache: true only while the registry's sole handler
     // is the planned type, instances are not memoized, and the handler's effective DI
@@ -55,8 +54,19 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     // which GetRequiredService is observably nothing but a constructor call.
     private bool _useDirectConstruction;
 
+    // True once the first dispatch has validated the entire fast lane — planned handler
+    // type, direct construction, no adapters. From then on the planned handler is
+    // constructed and invoked without touching dependencies at all.
+    private bool _fastDirect;
+
     public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
+        if (_fastDirect)
+        {
+            var direct = _directHandlerFactory is not null ? _directHandlerFactory() : _providerHandlerFactory!(serviceProvider);
+            return direct.HandleAsync((TMessage)message, context);
+        }
+
         var dependencies = GetDependencies();
 
         if (_cachedFastDependencies?.FastSingleHandler is { } handlerReference
@@ -101,12 +111,11 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
-            // Read before the build: a registration completing mid-build must land as a
-            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
-            var registryVersion = typedFactory.CurrentRegistryVersion;
+            // Frozen registry: dependencies resolve once per executor and are never
+            // re-validated — a registration after the first dispatch is not observed.
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == registryVersion)
+            if (cached is not null)
             {
                 return cached;
             }
@@ -119,7 +128,9 @@ internal sealed class GeneratedVoidPipelineExecutor<TMessage, THandler>(
                 && fastDependencies is { MemoizedInstances: false, FastSingleHandler.HandlerType: var plannedType }
                 && plannedType == typeof(THandler)
                 && typedFactory.IsPlainTransientRegistration(typeof(THandler));
-            _cachedVersion = registryVersion;
+            _fastDirect = _useDirectConstruction
+                && !_foreignAdapters
+                && (_concreteAdapters is null || _concreteAdapters.IsEmpty);
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/ResultPipelineExecutor[TMessage,TResult].cs
@@ -30,11 +30,10 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
     // Dependencies cached per executor (executors are already per message type + groups),
-    // re-validated against the registry version — turns the per-dispatch factory call and
-    // cache lookup into a single field read + version compare.
+    // resolved once and frozen — turns the per-dispatch factory call and cache lookup
+    // into a single field read.
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
-    private int _cachedVersion = int.MinValue;
 
     public ValueTask<TResult> Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -73,22 +72,18 @@ internal sealed class ResultPipelineExecutor<TMessage, TResult>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
-            // Read before the build: a registration completing mid-build must land as a
-            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
-            var registryVersion = typedFactory.CurrentRegistryVersion;
+            // Frozen registry: dependencies resolve once per executor and are never
+            // re-validated — a registration after the first dispatch is not observed.
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == registryVersion)
+            if (cached is not null)
             {
                 return cached;
             }
 
-            // Create runs the registry-version invalidation and rebuilds; races are benign —
-            // both writers publish equivalent, idempotent state.
             var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
             _cachedFastDependencies = dependencies as MessageDependencies;
             _cachedDependencies = dependencies;
-            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedResultPipelineExecutor[TMessage,TResult].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedResultPipelineExecutor[TMessage,TResult].cs
@@ -25,7 +25,6 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
     private IMessageDependencies? _cachedDependencies;
-    private int _cachedVersion = int.MinValue;
     private bool _useStagedPlan;
     private bool _useDirectConstruction;
 
@@ -47,12 +46,11 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
-            // Read before the build: a registration completing mid-build must land as a
-            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
-            var registryVersion = typedFactory.CurrentRegistryVersion;
+            // Frozen registry: dependencies resolve once per executor and are never
+            // re-validated — a registration after the first dispatch is not observed.
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == registryVersion)
+            if (cached is not null)
             {
                 return cached;
             }
@@ -66,7 +64,6 @@ internal sealed class StagedResultPipelineExecutor<TMessage, TResult>(
             _useDirectConstruction = _useStagedPlan
                 && plan.SupportsDirectConstruction
                 && StagedPlanGate.AllPlainTransient(typedFactory, plan.Composition);
-            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/StagedVoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/StagedVoidPipelineExecutor[TMessage].cs
@@ -9,14 +9,14 @@ namespace Stella.Ergosfare.Core.Internal.Mediator;
 
 /// <summary>
 /// Void pipeline hosting a staged plan: bespoke straight-line code for the message's whole
-/// interceptor-bearing pipeline. The plan is advisory — the registry-version-guarded
-/// dependency cache re-validates the plan's composition against the live pipeline
+/// interceptor-bearing pipeline. The plan is advisory — the dependency cache validates the
+/// plan's composition against the live pipeline on the first dispatch
 /// (<see cref="StagedPlanGate"/>) plus the memoization and adapter gates, and any mismatch
 /// falls back to the runtime strategy, preserving semantics exactly. The plan resolves its
 /// participants from the dispatching scope's provider — outside memoized mode that is
 /// literally what the runtime handler references do, so container semantics are preserved.
-/// Like every version-guarded executor, a dispatch racing a registration may run the
-/// previous shape once; it never runs a shape the registry has not published.
+/// The validated composition is frozen; a registration after the first dispatch is not
+/// observed.
 /// </summary>
 internal sealed class StagedVoidPipelineExecutor<TMessage>(
     IMessageDescriptor descriptor,
@@ -32,7 +32,6 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
     private readonly bool _foreignAdapters = resultAdapterService is not null and not ResultAdapterService;
 
     private IMessageDependencies? _cachedDependencies;
-    private int _cachedVersion = int.MinValue;
     private bool _useStagedPlan;
     private bool _useDirectConstruction;
 
@@ -54,12 +53,11 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
-            // Read before the build: a registration completing mid-build must land as a
-            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
-            var registryVersion = typedFactory.CurrentRegistryVersion;
+            // Frozen registry: dependencies resolve once per executor and are never
+            // re-validated — a registration after the first dispatch is not observed.
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == registryVersion)
+            if (cached is not null)
             {
                 return cached;
             }
@@ -73,7 +71,6 @@ internal sealed class StagedVoidPipelineExecutor<TMessage>(
             _useDirectConstruction = _useStagedPlan
                 && plan.SupportsDirectConstruction
                 && StagedPlanGate.AllPlainTransient(typedFactory, plan.Composition);
-            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
+++ b/src/Stella.Ergosfare.Core/Internal/Mediator/VoidPipelineExecutor[TMessage].cs
@@ -26,7 +26,6 @@ internal sealed class VoidPipelineExecutor<TMessage>(
 
     private IMessageDependencies? _cachedDependencies;
     private MessageDependencies? _cachedFastDependencies;
-    private int _cachedVersion = int.MinValue;
 
     public ValueTask Execute(object message, IExecutionContext context, IServiceProvider serviceProvider)
     {
@@ -60,12 +59,11 @@ internal sealed class VoidPipelineExecutor<TMessage>(
     {
         if (dependenciesFactory is MessageDependenciesFactory typedFactory)
         {
-            // Read before the build: a registration completing mid-build must land as a
-            // version mismatch on the next dispatch, never as a fresh stamp on stale deps.
-            var registryVersion = typedFactory.CurrentRegistryVersion;
+            // Frozen registry: dependencies resolve once per executor and are never
+            // re-validated — a registration after the first dispatch is not observed.
             var cached = _cachedDependencies;
 
-            if (cached is not null && _cachedVersion == registryVersion)
+            if (cached is not null)
             {
                 return cached;
             }
@@ -73,7 +71,6 @@ internal sealed class VoidPipelineExecutor<TMessage>(
             var dependencies = typedFactory.Create(typeof(TMessage), descriptor, groups);
             _cachedFastDependencies = dependencies as MessageDependencies;
             _cachedDependencies = dependencies;
-            _cachedVersion = registryVersion;
             return dependencies;
         }
 

--- a/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/DispatchItemsAndInvalidationTests.cs
@@ -98,7 +98,7 @@ public class DispatchItemsAndInvalidationTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task Send_ShouldPickUpRuntimeRegistrations_AfterWarmingTheExecutorCache()
+    public async Task Send_ShouldNotObserveRegistrations_AfterWarmingTheExecutorCache()
     {
         var provider = new ServiceCollection()
             .AddTransient<LateRegisteredInterceptor>()
@@ -115,14 +115,14 @@ public class DispatchItemsAndInvalidationTests
         await mediator.SendAsync(new LateInterceptedCommand(), warm);
         Assert.False(warm.Items.ContainsKey("lateInterceptorRan"));
 
-        // A runtime registration bumps the registry version; the cached plan must rebuild
-        // and the dispatch must leave the fast path for the full pipeline.
+        // A registration after the first dispatch is not observed: the executor's frozen
+        // pipeline keeps the zero-interceptor fast path.
         registry.Register(typeof(LateRegisteredInterceptor));
 
         var probe = new CommandMediationSettings();
         await mediator.SendAsync(new LateInterceptedCommand(), probe);
 
-        Assert.Equal(true, probe.Items["lateInterceptorRan"]);
+        Assert.False(probe.Items.ContainsKey("lateInterceptorRan"));
     }
 
     public sealed class ResultCommand : ICommand<int> { }

--- a/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/GeneratedVoidPlanExecutionTests.cs
@@ -78,7 +78,7 @@ public class GeneratedVoidPlanExecutionTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task PlannedDispatch_StillPicksUpRuntimeRegistrations()
+    public async Task PlannedDispatch_DoesNotObserveRegistrationsAfterTheFirstDispatch()
     {
         GeneratedDispatchRoots.AddVoidPlan<LatePlannedCommand, LatePlannedCommandHandler>();
 
@@ -97,14 +97,14 @@ public class GeneratedVoidPlanExecutionTests
         await mediator.SendAsync(new LatePlannedCommand(), warm);
         Assert.False(warm.Items.ContainsKey("lateInterceptorRan"));
 
-        // A runtime registration bumps the registry version; the plan's cached pipeline
-        // must rebuild and leave the fast path for the full interceptor pipeline.
+        // A registration after the first dispatch is not observed: the plan's pipeline
+        // froze on the devirtualized fast path and stays there.
         registry.Register(typeof(LatePlannedInterceptor));
 
         var probe = new CommandMediationSettings();
         await mediator.SendAsync(new LatePlannedCommand(), probe);
 
-        Assert.Equal(true, probe.Items["lateInterceptorRan"]);
+        Assert.False(probe.Items.ContainsKey("lateInterceptorRan"));
     }
 
     [ExcludeFromDiscovery]

--- a/test/Stella.Ergosfare.Command.Test/StagedPlanExecutionTests.cs
+++ b/test/Stella.Ergosfare.Command.Test/StagedPlanExecutionTests.cs
@@ -159,7 +159,7 @@ public class StagedPlanExecutionTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Category", "Coverage")]
-    public async Task RuntimeRegistration_FallsBackToTheStrategy()
+    public async Task RuntimeRegistration_DoesNotDislodgeTheFrozenPlan()
     {
         GeneratedDispatchRoots.AddStagedPlan(new FallbackCommandPlan());
 
@@ -182,18 +182,15 @@ public class StagedPlanExecutionTests
         await mediator.SendAsync(beforeRegistration);
         Assert.Equal(["staged", "pre", "handler"], beforeRegistration.Order);
 
-        // A runtime registration bumps the registry version; the next rebuild sees a
-        // second pre-interceptor the plan was not baked for — the advisory contract
-        // demands the strategy path, which runs both interceptors.
+        // A registration after the first dispatch is not observed: the staged plan froze
+        // with the composition it validated, and the extra interceptor never joins.
         provider.GetRequiredService<IMessageRegistry>().Register(typeof(ExtraFallbackCommandPreInterceptor));
 
         var afterRegistration = new FallbackCommand();
         await mediator.SendAsync(afterRegistration);
 
-        Assert.DoesNotContain("staged", afterRegistration.Order);
-        Assert.Contains("pre", afterRegistration.Order);
-        Assert.Contains("extra-pre", afterRegistration.Order);
-        Assert.Equal("handler", afterRegistration.Order[^1]);
+        Assert.Equal(["staged", "pre", "handler"], afterRegistration.Order);
+        Assert.DoesNotContain("extra-pre", afterRegistration.Order);
     }
 
     [ExcludeFromDiscovery]

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/FallbackPipelineTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/FallbackPipelineTypes.cs
@@ -180,3 +180,29 @@ public sealed class OrderedHighPost() : OrderedPostBase<OrderedCommand>("post:hi
 [ExcludeFromDiscovery]
 [Weight(3)]
 public sealed class OrderedLowPost() : OrderedPostBase<OrderedCommand>("post:low");
+
+// --- void command, async typed interceptors ---------------------------------
+
+/// <inheritdoc cref="Generated.AsyncTypedPipelineCommand"/>
+[ExcludeFromDiscovery]
+public sealed class AsyncTypedPipelineCommand : IPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AsyncTypedPipelineCommandHandler : PayloadHandlerBase<AsyncTypedPipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AsyncTypedPipelineCommandPost : AsyncTypedPostBase<AsyncTypedPipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AsyncTypedPipelineCommandException : AsyncTypedExceptionBase<AsyncTypedPipelineCommand>;
+
+/// <inheritdoc />
+[ExcludeFromDiscovery]
+public sealed class AsyncTypedPipelineCommandFinal : AsyncTypedFinalBase<AsyncTypedPipelineCommand>;

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedPipelineTypes.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedPipelineTypes.cs
@@ -153,3 +153,24 @@ public sealed class OrderedHighPost() : OrderedPostBase<OrderedCommand>("post:hi
 /// <inheritdoc />
 [Weight(3)]
 public sealed class OrderedLowPost() : OrderedPostBase<OrderedCommand>("post:low");
+
+// --- void command, async typed interceptors ---------------------------------
+
+/// <summary>Void command whose post, exception and final stages bind async typed over <c>Unit</c>.</summary>
+public sealed class AsyncTypedPipelineCommand : IPayloadCommand
+{
+    /// <inheritdoc />
+    public string Payload { get; set; } = string.Empty;
+}
+
+/// <inheritdoc />
+public sealed class AsyncTypedPipelineCommandHandler : PayloadHandlerBase<AsyncTypedPipelineCommand>;
+
+/// <inheritdoc />
+public sealed class AsyncTypedPipelineCommandPost : AsyncTypedPostBase<AsyncTypedPipelineCommand>;
+
+/// <inheritdoc />
+public sealed class AsyncTypedPipelineCommandException : AsyncTypedExceptionBase<AsyncTypedPipelineCommand>;
+
+/// <inheritdoc />
+public sealed class AsyncTypedPipelineCommandFinal : AsyncTypedFinalBase<AsyncTypedPipelineCommand>;

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedRegistrationPipelineTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/GeneratedRegistrationPipelineTests.cs
@@ -53,4 +53,8 @@ public sealed class GeneratedRegistrationPipelineTests : PipelineSemanticsContra
 
     /// <inheritdoc />
     protected override ICommand NewOrderedCommand() => new OrderedCommand();
+
+    /// <inheritdoc />
+    protected override IPayloadCommand NewAsyncTypedCommand(string payload)
+        => new AsyncTypedPipelineCommand { Payload = payload };
 }

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineContracts.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineContracts.cs
@@ -2,6 +2,7 @@ using Stella.Ergosfare.Commands.Abstractions;
 using Stella.Ergosfare.Contract.Test.Harness;
 using Stella.Ergosfare.Core.Abstractions;
 using Stella.Ergosfare.Core.Abstractions.Attributes;
+using Stella.Ergosfare.Core.Abstractions.Handlers;
 using Stella.Ergosfare.Queries.Abstractions;
 
 namespace Stella.Ergosfare.Contract.Test.Pipeline;
@@ -398,5 +399,58 @@ public abstract class OrderedPostBase<TCommand>(string slot) : ICommandPostInter
     {
         context.Mark(slot);
         return ValueTask.FromResult(result);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// async typed interceptors over the Unit slot
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// The async typed post contract closed over <see cref="Unit"/> — the one call arm no
+/// other void scenario reaches: the result-agnostic and sync typed shapes are pinned
+/// elsewhere, this family pins <c>IAsyncXInterceptor&lt;TMessage, Unit&gt;</c>. The
+/// <see cref="ICommand"/> marker is the same seam the flavored facades use to make an
+/// interceptor a command construct.
+/// </summary>
+[ExcludeFromDiscovery]
+public abstract class AsyncTypedPostBase<TCommand> : ICommand, IAsyncPostInterceptor<TCommand, Unit>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object> HandleAsync(TCommand message, Unit messageResult, IExecutionContext context)
+    {
+        context.Mark("post", $"{message.Payload}|{PipelineVocabulary.Describe(messageResult)}");
+        return ValueTask.FromResult<object>(messageResult);
+    }
+}
+
+/// <inheritdoc cref="AsyncTypedPostBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AsyncTypedExceptionBase<TCommand> : ICommand, IAsyncExceptionInterceptor<TCommand, Unit>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask<object?> HandleAsync(TCommand message, Unit? result, Exception exception, IExecutionContext context)
+    {
+        context.Mark("exception",
+            $"{message.Payload}|{PipelineVocabulary.Describe(result)}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.FromResult<object?>(Unit.Value);
+    }
+}
+
+/// <inheritdoc cref="AsyncTypedPostBase{TCommand}"/>
+[ExcludeFromDiscovery]
+public abstract class AsyncTypedFinalBase<TCommand> : ICommand, IAsyncFinalInterceptor<TCommand, Unit>
+    where TCommand : class, IPayloadCommand
+{
+    /// <inheritdoc />
+    public ValueTask HandleAsync(TCommand message, Unit? result, Exception? exception, IExecutionContext context)
+    {
+        context.Mark("final",
+            $"{message.Payload}|{PipelineVocabulary.Describe(result)}|{PipelineVocabulary.Describe(exception)}");
+
+        return ValueTask.CompletedTask;
     }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineSemanticsContract.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/PipelineSemanticsContract.cs
@@ -441,4 +441,50 @@ public abstract class PipelineSemanticsContract
         Assert.Null(result);
         recorder.AssertStages("handler");
     }
+
+    // -----------------------------------------------------------------------
+    // async typed interceptors over the Unit slot
+    //
+    // Appended for the same reason as the blocks above — the factory included: an
+    // abstract member inserted among the ones at the top would renumber every state
+    // machine below it.
+    // -----------------------------------------------------------------------
+
+    /// <summary>The void command whose post, exception and final stages bind async typed over Unit.</summary>
+    protected abstract IPayloadCommand NewAsyncTypedCommand(string payload);
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewAsyncTypedCommand("ok"), recorder.Commands());
+
+        // The third contract shape a resultless stage can take: result-agnostic and sync
+        // typed are pinned elsewhere, this is IAsyncXInterceptor<TMessage, Unit>. Same
+        // slot, same shared instance, compared by reference in the renderer.
+        recorder.AssertStages("handler", "post", "final");
+        Assert.Equal($"ok|{nameof(Unit)}", recorder.DetailOf("post"));
+        Assert.Equal($"ok|{nameof(Unit)}|none", recorder.DetailOf("final"));
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot()
+    {
+        await using var provider = CreateProvider();
+        var recorder = NewRecorder();
+
+        await provider.GetRequiredService<ICommandMediator>()
+            .SendAsync(NewAsyncTypedCommand("throw"), recorder.Commands());
+
+        // The handler failed before producing, so the async typed exception arm is handed
+        // an empty slot; the Unit.Value it returns is what the final stage then sees.
+        recorder.AssertStages("handler", "exception", "final");
+        Assert.Equal($"throw|null|{nameof(PipelineFailure)}", recorder.DetailOf("exception"));
+        Assert.Equal($"throw|{nameof(Unit)}|{nameof(PipelineFailure)}", recorder.DetailOf("final"));
+    }
 }

--- a/test/Stella.Ergosfare.Contract.Test/Pipeline/RuntimeRegistrationPipelineTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Pipeline/RuntimeRegistrationPipelineTests.cs
@@ -31,6 +31,10 @@ public sealed class RuntimeRegistrationPipelineTests : PipelineSemanticsContract
                     .Register<PipelineCommandException>()
                     .Register<PipelineCommandFinal>()
                     .Register<BarePipelineCommandHandler>()
+                    .Register<AsyncTypedPipelineCommandHandler>()
+                    .Register<AsyncTypedPipelineCommandPost>()
+                    .Register<AsyncTypedPipelineCommandException>()
+                    .Register<AsyncTypedPipelineCommandFinal>()
                     .Register<PipelineResultCommandHandler>()
                     .Register<PipelineResultCommandPre>()
                     .Register<PipelineResultCommandPost>()
@@ -77,4 +81,8 @@ public sealed class RuntimeRegistrationPipelineTests : PipelineSemanticsContract
 
     /// <inheritdoc />
     protected override ICommand NewOrderedCommand() => new OrderedCommand();
+
+    /// <inheritdoc />
+    protected override IPayloadCommand NewAsyncTypedCommand(string payload)
+        => new AsyncTypedPipelineCommand { Payload = payload };
 }

--- a/test/Stella.Ergosfare.Contract.Test/README.md
+++ b/test/Stella.Ergosfare.Contract.Test/README.md
@@ -121,8 +121,9 @@ the test process, and it never forgets. Everything below follows from that.
    `PolymorphicDispatchTests` does. If a scenario ever genuinely needs a marker-wide
    registration, it belongs in its own collection with `DisableParallelization = true`.
 5. **Mutating the registry after a container is live goes in
-   `RegistryMutationCollection`** (`DisableParallelization = true`). The version bump
-   invalidates every container's cached pipeline.
+   `RegistryMutationCollection`** (`DisableParallelization = true`). The types it
+   registers land in the process-wide registry for good, and the freeze-order semantics
+   it pins would blur beside parallel neighbors.
 6. **Do not pin internals.** Instance identity is contract only where lifetime says so
    (transient = new per dispatch, memoized = reused). No assertions on pooling, caching,
    plan or strategy selection, or timing.
@@ -316,7 +317,8 @@ than change by accident.
      reflective path, and the lane map is what says so.
 
 5. ~~**Runtime registry mutation is half-supported.**~~ *Partly fixed — the diagnosis, not
-   the constraint.* Registering an interceptor type after the container is built changes
+   the constraint; since the dependency freeze, resolved by contract — see the closing
+   paragraph.* Registering an interceptor type after the container is built changes
    the next dispatch only if that type is also in DI. It used to fail with an opaque
    `InvalidOperationException: No service for type ...`, raised part-way through the
    dispatch by whichever stage first asked for the participant. Pipeline construction now
@@ -328,11 +330,21 @@ than change by accident.
    process-wide, has no removal, and a container is per-application, so a participant
    resolvable in one container may be absent from another. That is also why the check
    cannot live in `Register` — only a pipeline being built in a container's context can
-   answer the question. What the fix does guarantee is that the failure is not sticky:
-   nothing is cached for a failed build, so a container that does register the participant
-   builds the pipeline the broken one could not. Pinned by
-   `A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch`
-   and `A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not`.
+   answer the question. The check runs when the pipeline first materializes: a participant
+   the container cannot resolve fails the message's first dispatch, named and explained,
+   before any stage runs. Pinned by
+   `A_participant_the_container_cannot_resolve_fails_the_first_dispatch`.
+
+   **The observability half of this entry is retired.** Since the dependency freeze, a
+   registration made after a message's first dispatch is not observed at all: the version
+   guard that made "the next dispatch picks it up" true was the fast path's one recurring
+   cost, and the contract it bought — registration-after-use — was exercised by nothing
+   but these scenarios. Registration up to the first dispatch keeps its full meaning,
+   pinned by `A_registration_before_the_first_dispatch_joins_the_pipeline`. The two
+   `..._picks_up_an_interceptor_registered_after_it_ran` scenarios invert into
+   `..._first_dispatch_is_not_observed` successors on both axes, and the cross-container
+   recovery pin is deferred to the per-container snapshot rework, where that contract gets
+   a non-shared executor to stand on.
 
    The check covers indirect main handlers too, which was the one corner where it could
    have broken a dispatch that always worked: single-handler mediation never read that slot,
@@ -425,8 +437,9 @@ than change by accident.
     `VoidPipelineExecutor` and the mediation strategies both have a working arm for these
     handlers, and the keyed axis exercises it.
 
-11. **A memoized handler instance survives only until the next registration anywhere in the
-    process.** `ForceMemoizedHandlers` caches the instance inside the handler reference held
+11. ~~**A memoized handler instance survives only until the next registration anywhere in the
+    process.**~~ *Closed by the dependency freeze — see the closing paragraph.*
+    `ForceMemoizedHandlers` caches the instance inside the handler reference held
     by a `MessageDependencies` object, and that object is cached against the registry
     version (`MessageDependenciesFactory.Create` →
     `MessageDescriptorCache.InvalidateIfRegistryChanged`). Registering a *new* type — in any
@@ -439,9 +452,12 @@ than change by accident.
     fail roughly one run in ten. It is not a test defect and not a race in the registry: a
     registration between two dispatches genuinely resets memoization. The scenario is now in
     `RegistryMutationCollection` so nothing registers beside it — the only change this phase
-    made to an existing test file, and the reason is this entry. Whether memoized instances
-    should survive a refresh is a live question for the plan lifecycle
-    (freeze → refresh → re-freeze), not something to paper over here.
+    made to an existing test file, and the reason is this entry.
+    <br />The dependency freeze closed this entry from the other side: executors stop
+    consulting the registry version after their first dispatch, so a later registration no
+    longer resets memoization — the memoized instance survives any registration, and the
+    flake mechanism above is structurally gone. The scenario stays in the collection for
+    the registrations it performs, not the ones it fears.
 
 ## Where it runs
 

--- a/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
+++ b/test/Stella.Ergosfare.Contract.Test/Runtime/RuntimeRegistrationMutationTests.cs
@@ -12,14 +12,14 @@ using Stella.Ergosfare.Generated;
 namespace Stella.Ergosfare.Contract.Test.Runtime;
 
 /// <summary>
-/// Registering into a warm container: after the pipeline for a message has already run
-/// once, adding an interceptor through the public registry must change the next dispatch —
-/// under generated registration exactly as under runtime registration.
+/// Registering into a warm container: a message's pipeline freezes at its first dispatch.
+/// A registration made before that dispatch joins the pipeline; one made after it is not
+/// observed — under generated registration exactly as under runtime registration.
 /// </summary>
 /// <remarks>
-/// Serialized against the rest of the suite: these are the only scenarios that mutate the
-/// process-wide registry after a container is live, and the version bump they cause
-/// invalidates every container's cached pipeline.
+/// Serialized against the rest of the suite: these scenarios put types into the
+/// process-wide registry mid-test, and the freeze-order semantics they pin would blur
+/// beside parallel neighbors.
 /// </remarks>
 [Collection(RegistryMutationCollection.Name)]
 public sealed class RuntimeRegistrationMutationTests
@@ -43,7 +43,7 @@ public sealed class RuntimeRegistrationMutationTests
 
     /// <summary>
     /// Excluded from discovery so no registration path can install it early: the scenario
-    /// must observe a pipeline that genuinely lacked it before the mutation.
+    /// must observe a pipeline that genuinely lacked it when it froze.
     /// </summary>
     [ExcludeFromDiscovery]
     public sealed class GeneratedLatePre : ICommandPreInterceptor<GeneratedTarget>
@@ -81,7 +81,38 @@ public sealed class RuntimeRegistrationMutationTests
         }
     }
 
-    // --- unresolvable late registration ----------------------------------------
+    // --- registration before the freeze -----------------------------------------
+
+    /// <summary>
+    /// Its own message type: the positive control must own the first dispatch of the
+    /// message it registers into, or another scenario's freeze would decide its outcome.
+    /// </summary>
+    [ExcludeFromDiscovery]
+    public sealed class EarlyTarget : ICommand;
+
+    /// <inheritdoc cref="EarlyTarget"/>
+    [ExcludeFromDiscovery]
+    public sealed class EarlyTargetHandler : ICommandHandler<EarlyTarget>
+    {
+        public ValueTask HandleAsync(EarlyTarget command, IExecutionContext context)
+        {
+            context.Mark("handler");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="EarlyTarget"/>
+    [ExcludeFromDiscovery]
+    public sealed class EarlyPre : ICommandPreInterceptor<EarlyTarget>
+    {
+        public ValueTask<EarlyTarget> HandleAsync(EarlyTarget command, IExecutionContext context)
+        {
+            context.Mark("early");
+            return ValueTask.FromResult(command);
+        }
+    }
+
+    // --- unresolvable participant ----------------------------------------------
 
     /// <summary>
     /// Its own message type: the registry never forgets, so the scenario below leaves this
@@ -96,7 +127,7 @@ public sealed class RuntimeRegistrationMutationTests
         public ValueTask HandleAsync(PoisonTarget command, IExecutionContext context) => ValueTask.CompletedTask;
     }
 
-    /// <summary>Registered nowhere in DI, to pin what an unresolvable late type does.</summary>
+    /// <summary>Registered nowhere in DI, to pin what an unresolvable participant does.</summary>
     [ExcludeFromDiscovery]
     public sealed class UnresolvableLatePre : ICommandPreInterceptor<PoisonTarget>
     {
@@ -106,7 +137,7 @@ public sealed class RuntimeRegistrationMutationTests
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran()
+    public async Task A_registration_after_a_generated_pipelines_first_dispatch_is_not_observed()
     {
         await using var provider = new ServiceCollection()
             .AddTransient<GeneratedLatePre>()
@@ -121,14 +152,16 @@ public sealed class RuntimeRegistrationMutationTests
 
         provider.GetRequiredService<IMessageRegistry>().Register(typeof(GeneratedLatePre));
 
+        // The pipeline froze at the first dispatch: the interceptor is in the registry and
+        // resolvable from the container, and still does not run.
         var after = new PipelineRecorder();
         await mediator.SendAsync(new GeneratedTarget(), after.Commands());
-        after.AssertStages("late", "handler");
+        after.AssertStages("handler");
     }
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran()
+    public async Task A_registration_after_a_runtime_pipelines_first_dispatch_is_not_observed()
     {
         await using var provider = new ServiceCollection()
             .AddTransient<RuntimeLatePre>()
@@ -146,24 +179,44 @@ public sealed class RuntimeRegistrationMutationTests
 
         var after = new PipelineRecorder();
         await mediator.SendAsync(new RuntimeTarget(), after.Commands());
-        after.AssertStages("late", "handler");
+        after.AssertStages("handler");
     }
 
     [Fact]
     [Trait("Category", "Contract")]
-    public async Task A_late_registered_interceptor_the_container_cannot_resolve_fails_the_next_dispatch()
+    public async Task A_registration_before_the_first_dispatch_joins_the_pipeline()
+    {
+        await using var provider = new ServiceCollection()
+            .AddTransient<EarlyPre>()
+            .AddErgosfare(options => options
+                .AddCommandModule(commands => commands.Register<EarlyTargetHandler>()))
+            .BuildServiceProvider();
+
+        // The freeze happens at the first dispatch, not at container build: a registration
+        // landing between the two still joins the pipeline.
+        provider.GetRequiredService<IMessageRegistry>().Register(typeof(EarlyPre));
+
+        var recorder = new PipelineRecorder();
+        await provider.GetRequiredService<ICommandMediator>().SendAsync(new EarlyTarget(), recorder.Commands());
+
+        recorder.AssertStages("early", "handler");
+    }
+
+    [Fact]
+    [Trait("Category", "Contract")]
+    public async Task A_participant_the_container_cannot_resolve_fails_the_first_dispatch()
     {
         await using var provider = new ServiceCollection()
             .AddErgosfare(options => options
                 .AddCommandModule(commands => commands.Register<PoisonTargetHandler>()))
             .BuildServiceProvider();
 
-        var mediator = provider.GetRequiredService<ICommandMediator>();
-        await mediator.SendAsync(new PoisonTarget());
-
         // The registry accepts the type, but the container was built without it: the
-        // pipeline that now includes it cannot be constructed. See the README.
+        // pipeline that includes it cannot be constructed, and the first dispatch is
+        // where that is discovered. See the README.
         provider.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableLatePre));
+
+        var mediator = provider.GetRequiredService<ICommandMediator>();
 
         var thrown = await Assert.ThrowsAsync<UnresolvableParticipantException>(
             async () => await mediator.SendAsync(new PoisonTarget()));
@@ -171,72 +224,6 @@ public sealed class RuntimeRegistrationMutationTests
         Assert.Contains(nameof(UnresolvableLatePre), thrown.Message, StringComparison.Ordinal);
         Assert.Equal(typeof(PoisonTarget), thrown.MessageType);
         Assert.Equal(typeof(UnresolvableLatePre), thrown.ParticipantType);
-    }
-
-    // --- recovery from an unresolvable late registration -----------------------
-
-    /// <summary>
-    /// The recovery scenario keeps types of its own. Sharing <see cref="PoisonTarget"/>
-    /// would make each scenario's outcome depend on which ran first: the registry is
-    /// process-wide and never forgets, so whichever registered the unresolvable
-    /// interceptor first would break the other's opening dispatch.
-    /// </summary>
-    [ExcludeFromDiscovery]
-    public sealed class RecoveryTarget : ICommand;
-
-    /// <inheritdoc cref="RecoveryTarget"/>
-    [ExcludeFromDiscovery]
-    public sealed class RecoveryTargetHandler : ICommandHandler<RecoveryTarget>
-    {
-        public ValueTask HandleAsync(RecoveryTarget command, IExecutionContext context)
-        {
-            context.Mark("handler");
-            return ValueTask.CompletedTask;
-        }
-    }
-
-    /// <inheritdoc cref="RecoveryTarget"/>
-    [ExcludeFromDiscovery]
-    public sealed class UnresolvableRecoveryPre : ICommandPreInterceptor<RecoveryTarget>
-    {
-        public ValueTask<RecoveryTarget> HandleAsync(RecoveryTarget command, IExecutionContext context)
-        {
-            context.Mark("late");
-            return ValueTask.FromResult(command);
-        }
-    }
-
-    [Fact]
-    [Trait("Category", "Contract")]
-    public async Task A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not()
-    {
-        await using var missing = new ServiceCollection()
-            .AddErgosfare(options => options
-                .AddCommandModule(commands => commands.Register<RecoveryTargetHandler>()))
-            .BuildServiceProvider();
-
-        await missing.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget());
-
-        missing.GetRequiredService<IMessageRegistry>().Register(typeof(UnresolvableRecoveryPre));
-
-        await Assert.ThrowsAsync<UnresolvableParticipantException>(
-            async () => await missing.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget()));
-
-        // The registry entry is permanent, so registering the participant with a container
-        // is the only way back — and it has to work. Nothing about the failed build is
-        // cached, so this container reaches the same pipeline the broken one could not,
-        // interceptor included.
-        await using var repaired = new ServiceCollection()
-            .AddErgosfare(options => options
-                .AddCommandModule(commands => commands
-                    .Register<RecoveryTargetHandler>()
-                    .Register<UnresolvableRecoveryPre>()))
-            .BuildServiceProvider();
-
-        var recorder = new PipelineRecorder();
-        await repaired.GetRequiredService<ICommandMediator>().SendAsync(new RecoveryTarget(), recorder.Commands());
-
-        recorder.AssertStages("late", "handler");
     }
 }
 

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -328,6 +328,70 @@ GeneratedRegistrationPipelineExclusionTests — stages: [pre:direct, handler]
                      | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+AuditedHandlerBase`1.HandleAsync
                        | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
+GeneratedRegistrationPipelineTests — stages: [handler, exception, final]
+  1. handler  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot>d__36.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception  <- throw|null|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot>d__36.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedExceptionBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- throw|Unit|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot>d__36.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+GeneratedRegistrationPipelineTests — stages: [handler, post, final]
+  1. handler  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance>d__35.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post  <- ok|Unit
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance>d__35.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedPostBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- ok|Unit|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance>d__35.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+                   | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedFinalBase`1.HandleAsync
+                     | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
 GeneratedRegistrationPipelineTests — stages: [handler]
   1. handler  <- abort
      | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_handler_aborting_a_pipeline_with_no_interceptors_completes_the_dispatch
@@ -367,8 +431,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -379,8 +443,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -391,8 +455,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -403,8 +467,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -415,8 +479,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -427,8 +491,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -439,8 +503,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -451,8 +515,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|null|PipelineFailure
@@ -461,8 +525,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TCommand,TResult>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultExceptionBase`1.HandleAsync
@@ -473,8 +537,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -485,8 +549,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -497,8 +561,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|0|PipelineFailure
@@ -507,8 +571,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncExceptionInterceptor<TQuery,TResult>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryExceptionInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncExceptionInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueExceptionBase`1.HandleAsync
@@ -519,8 +583,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -531,8 +595,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -543,8 +607,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+rewritten|null|PipelineFailure
@@ -553,8 +617,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadExceptionBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+rewritten|Unit|PipelineFailure
@@ -563,8 +627,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -575,8 +639,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPreBase`1.HandleAsync
@@ -587,8 +651,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|ok+rewritten
@@ -597,8 +661,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TCommand,TResult>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TCommand\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultPostBase`1.HandleAsync
@@ -609,8 +673,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadResultFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -621,8 +685,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPreBase`1.HandleAsync
@@ -633,8 +697,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|Unit
@@ -643,8 +707,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+rewritten|Unit|none
@@ -653,8 +717,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan7+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -665,8 +729,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TQuery>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TQuery>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePreBase`1.HandleAsync
@@ -677,8 +741,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+rewritten|7
@@ -687,8 +751,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPostInterceptor<TQuery,TResult>.HandleAsync
                      | Stella.Ergosfare.Queries.Abstractions.IQueryPostInterceptor`2+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPostInterceptor<TQuery\,TResult>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValuePostBase`1.HandleAsync
@@ -699,8 +763,8 @@ GeneratedRegistrationPipelineTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Queries.QueryMediator.QueryAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan8+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.PayloadValueFinalBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -711,8 +775,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -723,8 +787,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -735,8 +799,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -747,8 +811,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPreBase`1.HandleAsync
@@ -759,8 +823,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   6. post:high
@@ -769,8 +833,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   7. post:low
@@ -779,8 +843,8 @@ GeneratedRegistrationPipelineTests — stages: [pre:heavy, pre:tie-alpha, pre:ti
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan5+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan6+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Pipeline.OrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1116,8 +1180,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
@@ -1126,8 +1190,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1138,8 +1202,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. final  <- abort|null|none
@@ -1148,8 +1212,8 @@ GeneratedRegistrationSyncTests — stages: [pre, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1160,8 +1224,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- throw+sync-pre
@@ -1170,8 +1234,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+sync-pre|null|SyncFailure
@@ -1180,8 +1244,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultExceptionBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+sync-pre|sync-fallback|SyncFailure
@@ -1190,8 +1254,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1202,8 +1266,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- throw+sync-pre
@@ -1212,8 +1276,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. exception  <- throw+sync-pre|null|SyncFailure
@@ -1222,8 +1286,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidExceptionBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- throw+sync-pre|null|SyncFailure
@@ -1232,8 +1296,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, exception, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1244,8 +1308,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- ok+sync-pre
@@ -1254,8 +1318,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+sync-pre|ok+sync-pre
@@ -1264,8 +1328,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+sync-pre|ok+sync-pre+sync-post|none
@@ -1274,8 +1338,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedResultPipelineExecutor`2.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan12+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncResultFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1286,8 +1350,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- ok+sync-pre
@@ -1296,8 +1360,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+sync-pre|Unit
@@ -1306,8 +1370,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+sync-pre|Unit|none
@@ -1316,8 +1380,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1328,8 +1392,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   2. handler  <- ok+sync-pre
@@ -1338,8 +1402,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. post  <- ok+sync-pre|Unit
@@ -1348,8 +1412,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   4. final  <- ok+sync-pre|Unit|none
@@ -1358,8 +1422,8 @@ GeneratedRegistrationSyncTests — stages: [pre, handler, post, final]
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan9+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidFinalBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1370,8 +1434,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
@@ -1382,8 +1446,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPreBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   3. pre:async-low
@@ -1392,8 +1456,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
                      | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
                        | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPreBase`1.HandleAsync
@@ -1404,8 +1468,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncVoidHandlerBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   5. post:sync-high
@@ -1414,8 +1478,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.SyncOrderedPostBase`1.Handle
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
   6. post:async-low
@@ -1424,8 +1488,8 @@ GeneratedRegistrationSyncTests — stages: [pre:async-high, pre:sync-mid, pre:as
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.StagedVoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10.ExecuteDirect
-                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan10+<ExecuteDirect>d__6.MoveNext
+               | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11.ExecuteDirect
+                 | Stella.Ergosfare.Generated.ErgosfareGeneratedRegistrations+StagedPlan11+<ExecuteDirect>d__6.MoveNext
                    | Stella.Ergosfare.Contract.Test.Sync.AsyncOrderedPostBase`1.HandleAsync
                      | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
@@ -1798,6 +1862,80 @@ RuntimeRegistrationPipelineExclusionTests — stages: [pre:direct, handler]
                    | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
                      | Stella.Ergosfare.Contract.Test.Exclusion.PipelineExclusionContract+AuditedHandlerBase`1.HandleAsync
                        | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [handler, exception, final]
+  1. handler  <- throw
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot>d__36.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. exception  <- throw|null|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot>d__36.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.ExceptionInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedExceptionBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- throw|Unit|PipelineFailure
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_exception_stage_sees_the_empty_slot>d__36.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+RuntimeRegistrationPipelineTests — stages: [handler, post, final]
+  1. handler  <- ok
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance>d__35.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Pipeline.PayloadHandlerBase`1.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. post  <- ok|Unit
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance>d__35.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PostInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedPostBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  3. final  <- ok|Unit|none
+     | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract.A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance
+       | Stella.Ergosfare.Contract.Test.Pipeline.PipelineSemanticsContract+<A_void_pipelines_async_typed_stages_are_handed_the_shared_unit_instance>d__35.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.FinalInterceptorInvocationStrategy`2+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Contract.Test.Pipeline.AsyncTypedFinalBase`1.HandleAsync
+                         | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 RuntimeRegistrationPipelineTests — stages: [handler]
   1. handler  <- abort

--- a/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
+++ b/test/Stella.Ergosfare.Contract.Test/baselines/lane-map.txt
@@ -3080,6 +3080,33 @@ stages: [direct:audit, direct:notify, indirect:interface]
                  | Stella.Ergosfare.Contract.Test.Polymorphism.PolymorphicDispatchTests+ShipmentInterfaceHandler.HandleAsync
                    | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
+stages: [early, handler]
+  1. early
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_registration_before_the_first_dispatch_joins_the_pipeline
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_registration_before_the_first_dispatch_joins_the_pipeline>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
+                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
+                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
+                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
+                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+EarlyPre.HandleAsync
+                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+  2. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_registration_before_the_first_dispatch_joins_the_pipeline
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_registration_before_the_first_dispatch_joins_the_pipeline>d__15.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
+                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
+                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
+                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+EarlyTargetHandler.HandleAsync
+                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
 stages: [handler, exception, final]
   1. handler
      | Stella.Ergosfare.Contract.Test.Events.EventPublishTests.A_failed_publishs_exception_and_final_stages_are_handed_the_shared_unit_instance
@@ -3237,8 +3264,8 @@ stages: [handler]
 
 stages: [handler]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_registration_after_a_generated_pipelines_first_dispatch_is_not_observed
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_registration_after_a_generated_pipelines_first_dispatch_is_not_observed>d__13.MoveNext
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
@@ -3247,8 +3274,28 @@ stages: [handler]
 
 stages: [handler]
   1. handler
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__11.MoveNext
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_registration_after_a_generated_pipelines_first_dispatch_is_not_observed
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_registration_after_a_generated_pipelines_first_dispatch_is_not_observed>d__13.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+GeneratedTargetHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_registration_after_a_runtime_pipelines_first_dispatch_is_not_observed
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_registration_after_a_runtime_pipelines_first_dispatch_is_not_observed>d__14.MoveNext
+         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
+           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
+             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
+               | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RuntimeTargetHandler.HandleAsync
+                 | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
+
+stages: [handler]
+  1. handler
+     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_registration_after_a_runtime_pipelines_first_dispatch_is_not_observed
+       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_registration_after_a_runtime_pipelines_first_dispatch_is_not_observed>d__14.MoveNext
          | Stella.Ergosfare.Commands.CommandMediator.SendAsync
            | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
              | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
@@ -3274,87 +3321,6 @@ stages: [invoice, warehouse]
                | Stella.Ergosfare.Events.EventBroadcastInvoker`1.Invoke
                  | Stella.Ergosfare.Contract.Test.Events.EventPublishTests+OrderPlacedWarehouseHandler.HandleAsync
                    | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-
-stages: [late, handler]
-  1. late
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not>d__16.MoveNext
-         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+UnresolvableRecoveryPre.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. handler
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_container_that_can_resolve_the_late_participant_builds_the_pipeline_the_broken_one_could_not>d__16.MoveNext
-         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
-                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RecoveryTargetHandler.HandleAsync
-                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-
-stages: [late, handler]
-  1. late
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
-         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+GeneratedLatePre.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. handler
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_generated_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__10.MoveNext
-         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
-                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+GeneratedTargetHandler.HandleAsync
-                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-
-stages: [late, handler]
-  1. late
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__11.MoveNext
-         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1.Invoke
-                     | Stella.Ergosfare.Core.Abstractions.Strategies.InvocationStrategies.PreInterceptorInvocationStrategy`1+<Invoke>d__0.MoveNext
-                       | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1.Stella.Ergosfare.Core.Abstractions.Handlers.IAsyncPreInterceptor<TCommand>.HandleAsync
-                         | Stella.Ergosfare.Commands.Abstractions.ICommandPreInterceptor`1+<Stella-Ergosfare-Core-Abstractions-Handlers-IAsyncPreInterceptor<TCommand>-HandleAsync>d__0.MoveNext
-                           | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RuntimeLatePre.HandleAsync
-                             | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
-  2. handler
-     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests.A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran
-       | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+<A_runtime_registered_pipeline_picks_up_an_interceptor_registered_after_it_ran>d__11.MoveNext
-         | Stella.Ergosfare.Commands.CommandMediator.SendAsync
-           | Stella.Ergosfare.Core.MessageDispatchEngine.DispatchAsync
-             | Stella.Ergosfare.Core.Internal.Mediator.VoidPipelineExecutor`1.Execute
-               | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.Mediate
-                 | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1+<Mediate>d__2.MoveNext
-                   | Stella.Ergosfare.Core.Abstractions.Strategies.SingleAsyncHandlerMediationStrategy`1.InvokeHandler
-                     | Stella.Ergosfare.Contract.Test.Runtime.RuntimeRegistrationMutationTests+RuntimeTargetHandler.HandleAsync
-                       | Stella.Ergosfare.Contract.Test.Harness.Recording.Mark
 
 stages: [pre:audited, handler]
   1. pre:audited


### PR DESCRIPTION
The registry version guard existed to observe a registration made after a message's pipeline first ran. That contract is retired: **dependencies resolve once per executor and freeze**. Registration keeps its full meaning up to the first dispatch; after it, nothing re-validates. Stacked on #161 (`fix/abort-engine-short-circuit`); three commits.

## Numbers — same machine, short-run, on top of the abort fix

| Row | Faz2 close | abort fix | **frozen** |
|---|---|---|---|
| Command_Void_Generated | 20.22 | 20.76 | **18.13** — best this codebase has measured |
| Command_Void_Intercepted | 185.72 | 143.15 | **139.31** |
| Query_Result_Generated | 23.91 | 24.51 | 24.17 |
| Command_Void | 29.92 | 28.84 | 29.98 |

The generated executors cache the whole fast-lane verdict: after the first dispatch validates planned type, direct construction and adapters, subsequent dispatches construct and invoke the planned handler without touching dependencies at all — no `GetDependencies`, no `FastSingleHandler` read, no adapter checks, no version compare.

## The contract cost, measured exactly

The blast radius was **four scenarios**, all in `RuntimeRegistrationMutationTests` — the late-registration-observability pins. None retires silently:

- The two `..._picks_up_an_interceptor_registered_after_it_ran` scenarios **invert** into `..._first_dispatch_is_not_observed` successors on both axes.
- A new positive control, `A_registration_before_the_first_dispatch_joins_the_pipeline`, pins the boundary: the freeze happens at the first dispatch, not at container build.
- The unresolvable-participant scenario becomes `A_participant_the_container_cannot_resolve_fails_the_first_dispatch` — resolvability is still validated, same named exception, now where the pipeline first materializes.
- The cross-container recovery pin is deferred to the per-container snapshot rework, where that contract gets a non-shared executor to stand on.

README entry 5 records the retirement and its reasoning. Entry 11 closes outright: a later registration no longer resets memoization, so that flake mechanism is structurally gone.

## Riding along

- **#144** — `[Serializable]` leaves `UnresolvableParticipantException`; it contradicted the recorded decision.
- **#153** — the async typed interceptor arm (`IAsyncXInterceptor<TMessage, Unit>`) gets its void-lane scenarios on both axes: a new Pipeline/ family closing the core contracts directly, pinning the shared `Unit` instance by reference and the empty slot at the exception stage. Suite grows 189 → 193.
- **#146 / #137** — F5's late-registration validation question dissolves: the validation moved to first-dispatch freeze, which is also where #137's fix now lives. Closing both manually on merge — feature-branch merges do not auto-close, which is the very lesson #146 records.

## Verification

- Contract suite **193/193 green on both TFMs**.
- Lane map re-captured twice, each diff the expected shape: first confined to the rewritten mutation class; then the #153-predicted uniform `StagedPlanN` renumbering plus the new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
