### PR TITLE
docs: refresh XML reference and preview README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-
 # Ergosfare
 
 ![Ergosfare Logo](./7101c7df-6cac-4b25-994a-60e2adbdc546.png)
@@ -8,349 +7,334 @@
 ![Tests](https://img.shields.io/github/actions/workflow/status/stellayazilim/Ergosfare/coverage_tests.yml?branch=preview&label=tests)
 [![Coverage](https://raw.githubusercontent.com/stellayazilim/Ergosfare/badges/.badges/coverage.svg)](https://github.com/stellayazilim/Ergosfare/actions/workflows/coverage_tests.yml)
 
-> **You are on the `preview` branch.** Releases from here are `-preview` pre-releases and
-> APIs may change between them; install with `--prerelease`. The stable line is
-> [`main`](https://github.com/stellayazilim/Ergosfare/tree/main) — see
-> [Versioning & release model](#versioning--release-model).
+**Compile the pipeline. Dispatch the message.**
 
-- **Docs** → https://stellayazilim.github.io/ergosfare.docs
-- **Changelog** → https://stellayazilim.github.io/ergosfare.changelog
-- **Compatibility policy** → [COMPATIBILITY.md](COMPATIBILITY.md)
+Ergosfare is a source-generated mediator for modern .NET applications. Commands, queries,
+events, interceptors and nested dispatch share one type-safe pipeline model whose shape is
+decided at compile time—not rediscovered while your application is running.
 
-## Overview
+The result is a mediator built for applications that want rich CQRS pipelines without
+giving up predictable performance, dependency-injection lifetimes, Native AOT or explicit
+control over execution state.
 
-Ergosfare is a source-generated, high-performance mediator for CQRS-style messaging in
-.NET — commands, queries and events over one pipeline model, built around a single design
-premise: **all dispatch-shape work happens at compile time or once per message type, never
-per dispatch**.
+> **You are viewing the `preview` branch.** It contains the next generation of Ergosfare
+> and may introduce breaking changes between preview releases. For the current stable line,
+> see [`main`](https://github.com/stellayazilim/Ergosfare/tree/main).
 
-Registration is emitted by a Roslyn source generator; pipeline plans are computed once per
-`(message type, group set)` and cached process-wide; dispatch generics are closed at
-compile time; execution contexts are pooled. A dispatch resolves handler *instances* from
-the calling DI scope and walks a pre-built plan — no reflection, no `MakeGenericType`, no
-registry scan, no `AsyncLocal`, and no per-dispatch context allocation on the hot path.
+[Preview documentation](https://stellayazilim.github.io/ergosfare.docs/preview/) ·
+[Changelog](https://stellayazilim.github.io/ergosfare.changelog) ·
+[Compatibility policy](COMPATIBILITY.md) ·
+[NuGet](https://www.nuget.org/packages/Stella.Ergosfare/absoluteLatest)
 
-| Property | Mechanism |
-|----------|-----------|
-| Compile-time registration | Source generator discovers handlers in your compilation **and referenced assemblies**, pre-computes descriptors, emits `RegisterGenerated()` |
-| Reflection-free dispatch | Generated dispatch roots close executor generics at compile time; pipeline plans pre-close generic handler types |
-| ~1.9 ms · ~2.3 MB / 100k dispatches | Pooled execution contexts, `ValueTask`-first surface, straight-through dispatch for single-handler pipelines — generated plan lane (MediatR: ~6.5 ms · 18.3 MB) |
-| Nested dispatch | `context.CreateScope()` — isolated child context with inherited cancellation for mediator calls inside handlers |
-| DI-lifetime correctness | Instances resolve per dispatch from the calling scope: singleton → container-cached, scoped → one per scope, transient → one per dispatch |
-| Native AOT & trimming | Every construct referenced statically via `typeof`; dispatch roots anchor all generic instantiations, value-type messages included |
-| No ambient state | The execution context is a parameter, never an `AsyncLocal` |
-| Modular | Commands, Queries, Events are independent packages over a shared core |
+## Start in 60 seconds
 
-## Quick start
+Install the complete stack and its source generator:
 
 ```bash
 dotnet add package Stella.Ergosfare --prerelease
 dotnet add package Stella.Ergosfare.SourceGenerator --prerelease
 ```
 
+Declare a message and its handler:
+
 ```csharp
 public sealed record CreateProduct(string Name) : ICommand<Guid>;
 
-public sealed class CreateProductHandler : ICommandHandler<CreateProduct, Guid>
+public sealed class CreateProductHandler
+    : ICommandHandler<CreateProduct, Guid>
 {
-    public ValueTask<Guid> HandleAsync(CreateProduct command, IExecutionContext context)
-        => ValueTask.FromResult(Guid.NewGuid());
+    public ValueTask<Guid> HandleAsync(
+        CreateProduct command,
+        ErgosfareContext context)
+    {
+        return ValueTask.FromResult(Guid.NewGuid());
+    }
 }
-
-builder.Services.AddErgosfare(o => o
-    .AddCommandModule(c => c.RegisterGenerated())   // compile-time registration
-    .AddQueryModule(q => q.RegisterGenerated())
-    .AddEventModule(e => e.RegisterGenerated()));
-
-var mediator = provider.GetRequiredService<ICommandMediator>();
-var id = await mediator.SendAsync(new CreateProduct("Laptop"));
 ```
 
-`RegisterGenerated()` is emitted into your project by the source generator: every message,
-handler and interceptor in the compilation — and in referenced assemblies — registers with
-pre-computed descriptors, no reflection involved. `RegisterFromAssembly(...)` is still
-there as the runtime-scanning escape hatch, but it is on its way out — the stable line
-marks it `[Obsolete]` as of v2.2.0 and the preview line removes it next.
+Register the generated application composition:
 
-## Compile-time discovery
+```csharp
+builder.Services.AddErgosfare(ergosfare => ergosfare
+    .AddCommandModule(commands => commands.RegisterGenerated())
+    .AddQueryModule(queries => queries.RegisterGenerated())
+    .AddEventModule(events => events.RegisterGenerated()));
+```
 
-**Cross-assembly.** The generator also walks referenced assemblies: a library's handlers
-register through the app's generated code with zero registration code in the library.
-Internal types participate when the library grants `InternalsVisibleTo`; types generated
-code cannot name surface as an `ERGOSG002` diagnostic instead of silently diverging from
-runtime scanning. Opt out per project with
-`<ErgosfareSourceGeneratorScanReferences>false</ErgosfareSourceGeneratorScanReferences>`.
+Dispatch through the module facade:
 
-**Discovery keys — registration-time cherry-picking.**
+```csharp
+var id = await commandMediator.SendAsync(
+    new CreateProduct("Mechanical keyboard"));
+```
+
+`RegisterGenerated()` is emitted into your project. The generator discovers the relevant
+constructs in the compilation and its referenced assemblies, builds their pipeline
+compositions and leaves runtime registration to select from that frozen table. There is no
+assembly scan or mutable message registry behind the call.
+
+## Why Ergosfare
+
+| | What it means in an application |
+|---|---|
+| **Compile-time composition** | Handler and interceptor relationships become generated data. Missing or inaccessible constructs surface as build diagnostics instead of runtime discovery surprises. |
+| **Fast, typed dispatch** | Generated roots close dispatch generics ahead of time. Hot paths avoid reflection, `MakeGenericType`, registry scans and object-typed handler bridges. |
+| **Real DI semantics** | Participants resolve from the dispatching scope. Singleton, scoped, transient and keyed registrations retain the container semantics you chose. |
+| **One pipeline model** | Commands, queries, streams, events and POCO notifications use the same ordered interceptor stages and execution context. |
+| **Explicit execution state** | `ErgosfareContext` carries cancellation, shared items, abort signals and nested scopes without `AsyncLocal` or ambient service providers. |
+| **Native AOT ready** | Generated dispatch roots statically anchor the required generic instantiations, including value-type messages and results. |
+| **Modular by design** | Use the umbrella package or install Commands, Queries and Events independently over the shared core. |
+
+## A pipeline you can shape
+
+Ergosfare pipelines have a main-handler stage and four interceptor stages: pre, post,
+exception and final. Interceptors can be broad cross-cutting policies or narrowly typed
+participants that rewrite a specific message or result.
+
+- **Ordering:** `[Weight(n)]` orders participants within a stage.
+- **Groups:** `[Group("audit")]` and dispatch-time filters select a named slice of a
+  pipeline.
+- **Covariant matching:** an interceptor targeting a base contract can apply to every
+  assignable message.
+- **Opt-out:** `[ExcludeFromPipeline]` removes unwanted indirect interceptors globally or
+  by group.
+- **Typed exceptions:** `...ExceptionInterceptorFor<TException>` receives the matched
+  exception directly, following normal catch semantics.
+- **Intentional termination:** `context.Abort()` stops the remaining pipeline and reports
+  `ExecutionAbortedException` to the caller. Reason and value overloads can carry context.
+
+Cross-cutting policies can join every built-in module by carrying its marker interfaces:
+
+```csharp
+public sealed class LoggingInterceptor
+    : IAsyncPreInterceptor<IMessage>, ICommand, IQuery, IEvent
+{
+    public ValueTask<IMessage> HandleAsync(
+        IMessage message,
+        ErgosfareContext context)
+    {
+        // Log, enrich or reject before the main handler.
+        return ValueTask.FromResult<object>(message);
+    }
+}
+```
+
+The generator places this construct in the command, query and event partitions. Covariant
+rows connect it to assignable messages; `[ExcludeFromPipeline]` remains the escape hatch
+for messages that should not participate.
+
+## Context without ambient state
+
+Every handler and interceptor receives a concrete `ErgosfareContext`. It exposes the state
+that belongs to one dispatch and nothing broader:
+
+- a cancellation token;
+- a lazily created items dictionary;
+- explicit abort operations;
+- isolated child scopes for nested mediator calls.
+
+```csharp
+public async ValueTask HandleAsync(
+    PlaceOrder message,
+    ErgosfareContext context)
+{
+    using var scope = context.CreateScope();
+
+    await commandMediator.SendAsync(
+        new ReserveStock(message.OrderId),
+        scope.Context);
+
+    await eventMediator.PublishAsync(
+        new OrderPlaced(message.OrderId),
+        scope.Context);
+}
+```
+
+The child receives clean items and inherits cancellation. Disposing the struct scope
+returns its context to the pool. A directly constructed `new ErgosfareContext(...)` is
+caller-owned and can be passed to the engine-level dispatch overloads when the caller needs
+to provide state explicitly.
+
+## Events are the open message lane
+
+The event module is not limited to marker-based domain events. Its generic publish surface
+accepts any non-null type, making it the home for POCO notifications and other plain
+messages with broadcast semantics:
+
+```csharp
+public sealed record CacheInvalidated(string Key);
+
+public sealed class EvictLocalCache
+    : IEventHandler<CacheInvalidated>
+{
+    public ValueTask HandleAsync(
+        CacheInvalidated message,
+        ErgosfareContext context)
+    {
+        // ...
+        return ValueTask.CompletedTask;
+    }
+}
+
+await eventMediator.PublishAsync(new CacheInvalidated("products"));
+```
+
+## Discovery that scales past one project
+
+The generator walks the application compilation and referenced assemblies. A class library
+can declare handlers without carrying application-specific registration code; the final
+application emits the composition and registration entry point.
+
+Discovery keys provide opt-in slices for modular monoliths, feature sets and environment
+specific participants:
 
 ```csharp
 [DiscoveryKey("reporting.daily")]
-public sealed class DailyReportHandler : ICommandHandler<BuildDailyReport> { ... }
-
-builder.Services.AddErgosfare(o => o
-    .AddCommandModule(c => c
-        .RegisterGenerated()                    // default discovery: untagged types
-        .RegisterGenerated("reporting.*")));    // cherry-pick by exact key or prefix glob
-```
-
-A `[DiscoveryKey]` *gates* a type out of default discovery until a registration call
-selects one of its keys — feature-flagged handlers, environment-specific interceptors,
-modular-monolith slices. `[assembly: DiscoveryKey("payments")]` tags a whole library;
-`[ExcludeFromDiscovery]` removes a type (or assembly) from discovery entirely. The
-reflection path honors the same attributes, so generated and runtime registration stay in
-lockstep.
-
-## Pipeline control
-
-Interceptors run in four stages — pre (may rewrite the message), post (may rewrite the
-result), exception, final — each in non-generic, message-typed and fully typed forms.
-Selection and ordering are declarative:
-
-- **`[Weight(n)]`** orders interceptors within a stage (descending).
-- **`[Group("audit")]`** scopes handlers/interceptors to dispatch-time group filters:
-  `SendAsync(cmd, settings)` with a group filter runs only matching pipeline members.
-- **`[ExcludeFromPipeline]`** opts a *message* out of covariantly matched interceptors —
-  blanket or per group (`[ExcludeFromPipeline("logging")]`). Interceptors registered for
-  the message type itself always run; main handlers are never affected.
-- **Covariant matching.** An interceptor registered for a base type or interface
-  (`IEventPreInterceptor`, `ICommandPreInterceptor<IAuditedCommand>`) applies to every
-  assignable message. Main handlers match covariantly too: a handler registered against a
-  supertype serves every assignable message, and a message claimed by both a direct and a
-  covariant handler is contested (`MultipleHandlerFoundException`). Event broadcast
-  delivers to covariantly matched handlers, the event's own first.
-- **Typed exception interceptors.** `...ExceptionInterceptorFor<TException>` (message- and
-  result-typed arities too) receives the exception already typed — no opening `if (ex is
-  X)`. Matching follows catch semantics and leaves ordering alone; the filter decides only
-  who is *eligible*. An exception is swallowed when a **matching** interceptor ran — if
-  none matches, the original leaves the pipeline unwrapped, stack intact.
-- **`context.Abort()` stops the pipeline and tells the caller.** Nothing downstream runs —
-  not the exception stage (an abort is not a failure), not the final stage — and the
-  caller receives `ExecutionAbortedException` rather than a default it would have to tell
-  apart from a real result. `Abort(reason)` and `Abort(reason, value)` put something on the
-  signal for the caller to act on. A dispatch whose participants can abort is one you wrap
-  in a `try`; if you would rather carry outcomes as values, that is what result adapters
-  are for.
-- **A resultless pipeline carries `Unit.Value`.** Post, final and exception interceptors of
-  a void command or an event see that one shared instance where a result would be; `null`
-  means the slot before anything was produced — what the exception stage of a failed
-  dispatch sees.
-
-## Nested dispatch — scopes
-
-A handler can mediate further messages under an isolated child context — the pattern
-ambient-state mediators cannot offer safely:
-
-```csharp
-public async ValueTask HandleAsync(PlaceOrder msg, IExecutionContext ctx)
+public sealed class DailyReportHandler
+    : ICommandHandler<BuildDailyReport>
 {
-    using var scope = ctx.CreateScope();   // struct scope — allocation-free
-
-    var reserved = await _commands.SendAsync(new ReserveStock(msg.OrderId), scope.Context);
-    await _events.PublishAsync(new OrderPlaced(msg.OrderId), scope.Context);
+    // ...
 }
+
+builder.Services.AddErgosfare(ergosfare => ergosfare
+    .AddCommandModule(commands => commands
+        .RegisterGenerated()
+        .RegisterGenerated("reporting.*")));
 ```
 
-- The child starts with **clean items** — inner state never pollutes the outer scope —
-  and **inherits the parent's cancellation token**, so nested work can't escape the outer
-  cancellation chain (and forgetting to thread the token is impossible).
-- An inner `Abort()` surfaces to the outer handler — which is the inner dispatch's call
-  site, so it is who decides: catch it and carry on, or let it end the outer pipeline too.
-  Parallel inner dispatches with separate scopes are safe.
-- All facades accept the child: `SendAsync`, `QueryAsync`, `PublishAsync` overloads take
-  an `IExecutionContext`; disposal returns the pooled child.
+Untagged types join default discovery. A `[DiscoveryKey]` gates a construct until an exact
+key or prefix glob selects it. `[assembly: DiscoveryKey("payments")]` can tag a complete
+library, while `[ExcludeFromDiscovery]` removes a construct or assembly entirely.
+
+Reference scanning can be disabled per project:
+
+```xml
+<ErgosfareSourceGeneratorScanReferences>false</ErgosfareSourceGeneratorScanReferences>
+```
+
+## How dispatch is built
+
+```text
+compile time                         container setup                     every dispatch
+────────────                         ───────────────                     ──────────────
+source generator                     module registration                 mediator facade
+  discovers constructs        ───▶     selects generated rows    ───▶     rents context
+  emits frozen compositions           registers participants             finds typed executor
+  emits dispatch roots                 preserves DI lifetimes              runs selected pipeline
+```
+
+The source generator emits one frozen composition for each known message: the main-handler
+rows, four interceptor stages and their covariant rows. Module registration performs a
+set-like selection from this table for one container; repeated and overlapping selections
+are harmless unions. Runtime code cannot append a new pipeline row.
+
+For each dispatch, the mediator finds an executor closed over the message's concrete type,
+rents a context, resolves participant instances from the calling scope and executes the
+already ordered stages. Group filters and pipeline exclusions narrow that composition
+without turning dispatch back into discovery.
+
+This closed-world boundary is deliberate: dynamically loaded assemblies cannot introduce
+new message shapes after compilation. Plugin contracts should bind their constructs to a
+known command, query or event marker so the application generator can include them.
 
 ## Performance
 
-Executors and invokers are closed over each message's concrete runtime type — handlers are
-invoked through their typed members, with no object-typed bridge anywhere. Source-generated
-**dispatch roots** provide those generic closures at compile time (`MakeGenericType`
-remains only as a fallback for open generics and runtime-only registrations), which also
-gives Native AOT a static anchor for every instantiation — including `record struct`
-messages, which shared generic code cannot cover.
+Ergosfare is optimized around application semantics rather than a synthetic minimum API:
+scoped handlers remain scoped, execution state remains explicit and interceptor-rich
+pipelines remain first-class. The generated plan lanes remove infrastructure work around
+those semantics.
 
-Execution contexts are **pooled**: a dispatch rents a context and returns it on
-completion through a `[ThreadStatic]`-first pool (plain load/store on the common
-same-thread cycle), with a synchronous fast path that skips the async state machine
-entirely when the pipeline completes synchronously. A context is therefore only valid for
-the duration of its dispatch.
+BenchmarkDotNet v0.15.8, .NET 9.0.11, Windows 11, AMD Ryzen 7 7800X3D. Measured on the tree
+released as v2.7.0-preview; each row is one dispatch through the public mediator surface.
+Source: [`test/Stella.Ergosfare.Benchmarking`](test/Stella.Ergosfare.Benchmarking/Program.cs).
 
-### Benchmarks
+Mediators resolved once—typical of workers and message pumps:
 
-BenchmarkDotNet, `[MemoryDiagnoser]`. Source:
-[`test/Stella.Ergosfare.Benchmarking`](test/Stella.Ergosfare.Benchmarking/Program.cs).
+| Per dispatch | Ergosfare | MediatR | Mediator |
+|---|---:|---:|---:|
+| Command, no result | **19.9 ns / 24 B** | 60.4 ns / 192 B | 8.5 ns / 0 B |
+| Query with result | **24.0 ns / 24 B** | 54.9 ns / 192 B | 9.1 ns / 0 B |
+| Query through five participants | **120.2 ns / 96 B** | 205.6 ns / 1008 B | 61.4 ns / 0 B |
+| Event to two handlers | **50.5 ns / 48 B** | 89.7 ns / 440 B | 16.2 ns / 0 B |
+
+One DI scope per dispatch—typical of request processing, including scope creation and
+mediator resolution:
+
+| Per dispatch | Ergosfare | MediatR | Mediator |
+|---|---:|---:|---:|
+| Command | **92.5 ns / 192 B** | 113.2 ns / 352 B | 54.8 ns / 128 B |
+| Query | **90.6 ns / 200 B** | 110.0 ns / 352 B | 50.8 ns / 128 B |
+| Event | **106.4 ns / 232 B** | 146.3 ns / 600 B | 57.1 ns / 128 B |
+
+These tables need context. Mediator's default singleton lifetime does less scope-sensitive
+work and therefore sets a lower raw-overhead floor. Ergosfare and MediatR resolve according
+to the dispatching scope in these scenarios. Ergosfare's default transient participant is
+the source of the small happy-path allocation; singleton registrations or
+`ForceMemoizedHandlers()` can remove it when those semantics fit the application.
+
+Run the full benchmark suite locally:
 
 ```bash
 dotnet run -c Release -f net9.0 --project test/Stella.Ergosfare.Benchmarking
 ```
 
-Environment: BenchmarkDotNet v0.15.8 · Windows 11 · AMD Ryzen 7 7800X3D · .NET 9.0.11
-(RyuJIT x86-64-v4). Measured 2026-08-11, on the tree released as v2.7.0-preview. Every row
-is a **single dispatch** of a no-op handler through the public mediator interfaces.
+## Packages
 
-Four scenarios, each written the way the library in question would write it, at that
-library's default lifetime.
+`Stella.Ergosfare` is the convenience meta package. Applications can instead reference
+only the modules they use:
 
-Mediators resolved once — background workers, message-pump loops:
+- `Stella.Ergosfare.Commands`
+- `Stella.Ergosfare.Queries`
+- `Stella.Ergosfare.Events`
+- their `.Abstractions` and `.Extensions.MicrosoftDependencyInjection` companions
+- `Stella.Ergosfare.SourceGenerator` in the composing application
 
-| Per dispatch | Ergosfare | MediatR | Mediator (martinothamar) |
-|---|---:|---:|---:|
-| Command, nothing returned | **19.9 ns** / 24 B | 60.4 ns / 192 B | 8.5 ns / 0 B |
-| Query returning a value | **24.0 ns** / 24 B | 54.9 ns / 192 B | 9.1 ns / 0 B |
-| Query through five participants | **120.2 ns** / 96 B | 205.6 ns / 1008 B | 61.4 ns / 0 B |
-| Event to two handlers | **50.5 ns** / 48 B | 89.7 ns / 440 B | 16.2 ns / 0 B |
+Libraries that only declare messages and participants normally need the relevant
+`.Abstractions` package. The application owns source generation and DI composition.
 
-One DI scope per dispatch — the shape ASP.NET Core gives you, scope creation and mediator
-resolution included in every row:
+## Preview notes
 
-| Per dispatch | Ergosfare | MediatR | Mediator (martinothamar) |
-|---|---:|---:|---:|
-| Command | **92.5 ns** / 192 B | 113.2 ns / 352 B | 54.8 ns / 128 B |
-| Query | **90.6 ns** / 200 B | 110.0 ns / 352 B | 50.8 ns / 128 B |
-| Event | **106.4 ns** / 232 B | 146.3 ns / 600 B | 57.1 ns / 128 B |
+The current preview retires the mutable runtime message registry. The generated frozen
+composition table is now the source of pipeline truth, and module registration selects the
+parts a container runs. It also replaces `IExecutionContext` with the public sealed
+`ErgosfareContext` and moves plain/POCO message handling to the event module.
 
-Reading the rows:
+Notable removals include `IMessageRegistry`, descriptor APIs, `RegisterFromAssembly`,
+`RegisterDescriptors`, `MediateOptions`, the low-level `IMessageMediator.Mediate` surface,
+`AddCoreModule` and the old core-module builders. See the
+[v2.8.0-preview changelog](CHANGELOG.md) for the complete migration inventory.
 
-- **The five participants** are the same five purposes in all three libraries: validate the
-  message, rewrite the message, rewrite the result, an armed exception recovery that never
-  fires on the happy path, and an always-runs final touch. Ergosfare runs them as
-  interceptors through a source-generated staged plan; MediatR and Mediator run them as
-  pipeline behaviors. This is the row that says what a real pipeline costs.
-- **Against MediatR**, Ergosfare leads every scenario on both axes — 2–3× on time, 8–10× on
-  allocation — and stays ahead once a per-request scope dominates the measurement. Both
-  libraries are doing the same work there: resolving a mediator and a handler out of the
-  new scope on every dispatch.
-- **Mediator** (martinothamar's source-generated library) is faster on raw nanoseconds by
-  design: no execution context, no runtime registry, and singleton handlers resolved
-  without touching the container per dispatch.
-- **The scoped table is not like-for-like for Mediator, and it should not be read as one.**
-  Its default lifetime is singleton, so inside a per-request scope its mediator and
-  handlers are still the same instances — the row prices scope creation plus a singleton
-  dispatch, not per-scope resolution. Ergosfare's and MediatR's rows price the thing the
-  table is about. Read Mediator's numbers there as the floor a library pays when it opts
-  out of per-scope lifetimes, not as the same job done faster.
-- **Lifetimes are yours, not the mediator's.** Ergosfare resolves handler instances per
-  dispatch from the *dispatching scope's* provider, so the container's own rules apply:
-  singleton is container-cached, scoped is one per scope, transient is one per dispatch.
-  The module registers handlers transient by default, which is where the 24 B comes from —
-  it is the handler instance. Register them singleton, or call `ForceMemoizedHandlers()`,
-  and the rows drop to 0 B.
-- Ergosfare's command, query and pipeline rows register through `RegisterGenerated()`, what
-  the quick start sets up. The event row registers at runtime: a publish takes the same
-  broadcast lane either way, since generated registration changes what registration costs,
-  not how a publish runs.
+APIs marked `[Experimental]` and diagnostic IDs beginning with `ERGOEXP` sit outside the
+normal compatibility promise. Consuming one requires an explicit warning opt-in; see
+[COMPATIBILITY.md](COMPATIBILITY.md).
 
-The benchmark project carries more rows than these — the runtime-registration, memoized and
-grouped lanes exist to catch regressions in library development, and are not part of the
-comparison above.
-
-## Dispatch architecture
-
-```
-compile time                     once per (message type, groups)          every dispatch
-────────────                     ───────────────────────────────          ──────────────
-source generator          ──►    MessageRegistry ──► descriptor ──► plan   ──►  pooled context rented
-  descriptors pre-computed         │                                             │
-  dispatch roots emitted           │  six fixed stages, pre-ordered              │  executor closed over runtime type
-  RegisterGenerated()              │  (direct-first, weight-ordered)             │  IHandlerReference.Resolve(scopeProvider)
-                                   └─ closed generic types pre-computed          └─ pre → main → post/exception → final
-```
-
-- **Registry & descriptors.** Generated registration supplies pre-computed descriptors;
-  explicit `Register<T>()` and runtime scanning feed the same registry (idempotent, safe
-  to combine). **The registration window closes at a message's first dispatch:** whatever
-  is registered by then joins its pipeline, which is then frozen — later registrations are
-  not observed by it.
-- **Pipeline plan.** Six fixed stages per message: main handlers (direct/indirect split)
-  and four interceptor stages, each a pre-ordered array — direct entries first, then
-  covariant, ordered by weight. Group filters and `[ExcludeFromPipeline]` apply here,
-  once.
-- **Dispatch.** The mediator rents a pooled context, looks up the cached executor for the
-  message's runtime type (constructed through a generated dispatch root), and walks the
-  plan. Handler resolution belongs to the dispatcher — the execution context deliberately
-  exposes **no** service provider.
-
-## What changed in v2
-
-Tracked in [CHANGELOG.md](CHANGELOG.md) under *v2.0.0*. Highlights:
-
-- **Source-generated registration** (`Stella.Ergosfare.SourceGenerator`): compile-time
-  discovery with pre-computed descriptors, cross-assembly reference scanning, discovery
-  keys, and generated dispatch roots for reflection-free, AOT-complete dispatch.
-- **Nested dispatch scopes**: `IExecutionContext.CreateScope()` plus external-context
-  facade overloads; pooled execution contexts (contexts are valid only during their
-  dispatch).
-- **Pipeline exclusion**: `[ExcludeFromPipeline]` on message types; event broadcast now
-  delivers to covariantly matched handlers (direct-first).
-- **`AmbientExecutionContext` removed** (deprecated since v1.2.0). The context parameter
-  is the only access path; the dispatch path carries zero `AsyncLocal` state.
-- **Three-parameter `TModifiedResult` interceptor interfaces removed** (deprecated in
-  v1.4.0). The two-parameter typed interfaces expose the typed `HandleAsync` directly.
-- **`ValueTask`-first surface.** Handlers, interceptors and the mediator facades return
-  `ValueTask` / `ValueTask<TResult>`; synchronously completing handlers allocate nothing.
-- **Typed dispatch everywhere.** Interceptor object roots and DIM bridges removed;
-  invocation is generic end to end.
-- **`[Experimental]` gate introduced.** Unstable APIs ship marked
-  `[Experimental("ERGOEXPxxx")]` instead of blocking the release train — see below.
-
-## Experimental APIs
-
-APIs marked `[Experimental]` (diagnostic IDs prefixed `ERGOEXP`) are **outside the
-compatibility promise** ([COMPATIBILITY.md §4](COMPATIBILITY.md)): they may change or
-disappear in any release, including patch releases. Consuming one is a compile-time error
-until you opt in explicitly:
-
-```csharp
-#pragma warning disable ERGOEXP001 // example: opting into an experimental API
-```
-
-or per project:
-
-```xml
-<NoWarn>$(NoWarn);ERGOEXP001</NoWarn>
-```
-
-Current experimental surface: none — the gate is in place for future experimental APIs.
-
-## Installation
-
-Pre-release packages are published to nuget.org and GitHub Packages:
-
-```bash
-dotnet add package Stella.Ergosfare --prerelease
-```
-
-Module packages (`Stella.Ergosfare.Commands`, `.Queries`, `.Events`, plus their
-`.Abstractions` and `.Extensions.MicrosoftDependencyInjection` companions) can be
-installed independently — the umbrella package is a convenience bundle. Libraries that
-only declare messages or handlers need just the relevant `.Abstractions` package.
-
-## Versioning & release model
+## Versioning and releases
 
 | Branch | Line | Tags | NuGet |
-|--------|------|------|-------|
-| `main` | stable v2 | `vX.Y.Z` | stable |
-| `preview` | in development | `vX.Y.Z-preview` | pre-release |
+|---|---|---|---|
+| `main` | stable | `vX.Y.Z` | stable packages |
+| `preview` | next | `vX.Y.Z-preview` | prerelease packages |
 
-- **No release candidates.** Features mature on `preview` and graduate to stable
-  individually (rolling graduation) — there is no big-bang RC freeze.
-- Pre-release tags must point at `preview` commits, stable tags at `main` commits; the
-  release workflows enforce this by ancestry check.
-- Stable fixes land on `main` first; `main` is merged into `preview` regularly.
-- Genuinely unstable APIs are not blocked on graduation — they ship `[Experimental]`.
+Features mature on `preview` and graduate to stable through the project's rolling release
+process. Stable fixes land on `main` first and are merged forward. Release workflows enforce
+that stable and preview tags point to the correct branch history.
 
 ## Contributing
 
-v2 work targets `preview`, stable fixes target `main` — both through pull requests.
+Preview development targets `preview`; stable fixes target `main`. Both flow through pull
+requests.
 
 ```bash
-dotnet test Stella.Ergosfare.slnx            # full suite (net9.0 + net10.0)
+dotnet test Stella.Ergosfare.slnx
 ```
+
+The full suite runs on .NET 9 and .NET 10. Contributions that change dispatch semantics
+should update the public contract suite and its lane-map baseline together.
 
 ## Acknowledgments
 
-Ergosfare's design — including its public API surface, naming conventions, and module
-architecture — is heavily inspired by [LiteBus](https://github.com/litenova/LiteBus)
-by A. Shafie (MIT licensed).
+Ergosfare's public API and module architecture were originally inspired by
+[LiteBus](https://github.com/litenova/LiteBus) by A. Shafie (MIT licensed).
 
 ## License
 

--- a/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
+++ b/src/Stella.Ergosfare.Commands.Extensions.MicrosoftDependencyInjection/CommandModule.cs
@@ -23,7 +23,7 @@ internal class CommandModule : IModule
     /// <summary>
     /// Builds the module by applying the provided configuration and registering the <see cref="ICommandMediator"/>.
     /// </summary>
-    /// <param name="configuration">The module configuration containing services and message registry.</param>
+    /// <param name="configuration">The module configuration containing services and this container's frozen composition selection.</param>
     public void Build(IModuleConfiguration configuration)
     {
         _builder(new CommandModuleBuilder(configuration.Compositions));

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/FrozenComposition.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/FrozenComposition.cs
@@ -1,4 +1,6 @@
-﻿namespace Stella.Ergosfare.Core.Abstractions.DispatchRoots;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Stella.Ergosfare.Core.Abstractions.DispatchRoots;
 
 /// <summary>
 /// One participant row of a frozen composition: the handler type plus the group names it
@@ -8,15 +10,21 @@
 /// </summary>
 /// <param name="handlerType">
 /// The participant's type — a generic definition when the participant closes over the
-/// message's type arguments at dispatch time.
+/// message's type arguments at dispatch time. Public constructors are preserved under
+/// trimming: the generated table hands its <c>typeof</c> here, and this parameter is the
+/// only annotated slot on the path to the container's handler registrations, which
+/// activate the type reflectively.
 /// </param>
 /// <param name="groups">
 /// The participant's declared group names, or <c>null</c> for the default group alone —
 /// the overwhelmingly common case, carried without an allocation.
 /// </param>
-public sealed class FrozenParticipant(Type handlerType, string[]? groups = null)
+public sealed class FrozenParticipant(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type handlerType,
+    string[]? groups = null)
 {
     /// <summary>The participant's (possibly open) type.</summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     public Type HandlerType { get; } = handlerType;
 
     /// <summary>The declared group names; <c>null</c> means the default group alone.</summary>

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/FrozenCompositionCatalog.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/FrozenCompositionCatalog.cs
@@ -117,6 +117,12 @@ public sealed class FrozenCompositionCatalog
     /// <remarks>
     /// Setup-time only, and deliberately so: it reads the whole table once, while
     /// registration is still open and before any projection is cached.
+    /// <para>
+    /// Every type returned came through <see cref="FrozenParticipant.HandlerType"/>, so its
+    /// public constructors are preserved under trimming — the sequence itself cannot carry
+    /// the annotation, which is why the caller registering these as services suppresses the
+    /// dataflow warning rather than re-stating the requirement.
+    /// </para>
     /// </remarks>
     public IEnumerable<Type> SelectedParticipants()
     {

--- a/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/GeneratedDispatchRoots.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/DispatchRoots/GeneratedDispatchRoots.cs
@@ -53,10 +53,9 @@ public static class GeneratedDispatchRoots
     /// Roots a compile-time pipeline plan for a void message whose entire pipeline is a
     /// single async handler: the dispatch executor closes over both the message and the
     /// handler type, so the handler is invoked devirtualized — no contract pattern match.
-    /// The plan is advisory: the executor re-validates the actual pipeline against the
-    /// registry on every version change and falls back to the runtime dispatch shape
-    /// whenever the pipeline no longer matches (interceptors registered at runtime, a
-    /// different handler resolved, adapters configured). Idempotent.
+    /// The plan is advisory: the executor validates it against the container's selected
+    /// frozen composition and falls back to the general dispatch shape whenever the
+    /// composition does not match. Idempotent.
     /// </summary>
     public static void AddVoidPlan<TMessage, THandler>()
         where TMessage : IMessage
@@ -103,7 +102,8 @@ public static class GeneratedDispatchRoots
     /// Result-producing counterpart of <see cref="AddVoidPlan{TMessage, THandler}()"/>:
     /// roots a compile-time pipeline plan for a message whose entire pipeline is a single
     /// async result handler, so the dispatch executor invokes it devirtualized. The plan
-    /// is advisory and re-validated per registry version exactly like the void plan.
+    /// is advisory and validated against the container's selected frozen composition,
+    /// exactly like the void plan.
     /// Idempotent.
     /// </summary>
     public static void AddResultPlan<TMessage, TResult, THandler>()
@@ -141,8 +141,9 @@ public static class GeneratedDispatchRoots
     /// Roots a staged pipeline plan for a void message whose pipeline carries interceptor
     /// stages: bespoke straight-line code for the whole pipeline, replacing the runtime
     /// strategy's generic machinery. Advisory exactly like the single-handler plans — the
-    /// hosting executor re-validates the plan's <see cref="StagedPlanComposition"/> against
-    /// the registry per version and falls back to the runtime strategy on any mismatch.
+    /// hosting executor validates the plan's <see cref="StagedPlanComposition"/> against
+    /// the container's selected frozen composition and falls back to the general strategy
+    /// on any mismatch.
     /// Idempotent.
     /// </summary>
     public static void AddStagedPlan<TMessage>(StagedVoidPlan<TMessage> plan)
@@ -168,10 +169,9 @@ public static class GeneratedDispatchRoots
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, FrozenComposition?> FrozenCompositionLadder = new();
 
     /// <summary>
-    /// Roots a message's frozen pipeline composition — the compile-time image of the
-    /// registry-derived pipeline shape. Appended at load time by generated module
-    /// initializers (a plugin assembly loading later appends its own entries the same
-    /// way) and immutable afterwards. Idempotent.
+    /// Roots a message's frozen pipeline composition — the pipeline shape produced at
+    /// compile time. Generated module initializers populate the process-wide table as
+    /// assemblies load; each entry is immutable after publication. Idempotent.
     /// </summary>
     public static void AddFrozenComposition(FrozenComposition composition)
         => FrozenCompositions.TryAdd(composition.MessageType, composition);

--- a/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/Exceptions/UnresolvableParticipantException.cs
@@ -2,15 +2,14 @@
 namespace Stella.Ergosfare.Core.Abstractions.Exceptions;
 
 /// <summary>
-/// Exception thrown when a message's pipeline names a participant the dispatching
-/// container cannot resolve — typically a type added to the process-wide message registry
-/// after that container was built.
+/// Exception thrown when a message's selected frozen composition names a participant that
+/// the dispatching container cannot resolve.
 /// </summary>
 /// <remarks>
 /// Raised while the pipeline is being built rather than part-way through a dispatch, so no
-/// participant runs before the failure. Nothing is cached for the failed build: registering
-/// the participant with a container and dispatching again works, which is the only way back
-/// since the registry has no removal.
+/// participant runs before the failure. Nothing is cached for the failed build. Ensure the
+/// module that selected the participant also registers it with dependency injection before
+/// building the container.
 /// </remarks>
 /// <param name="messageType">The message type whose pipeline could not be built.</param>
 /// <param name="participantType">The participant the container cannot resolve.</param>

--- a/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan.cs
+++ b/src/Stella.Ergosfare.Core.Abstractions/StagedPlans/StagedVoidPlan.cs
@@ -7,10 +7,10 @@ namespace Stella.Ergosfare.Core.Abstractions.StagedPlans;
 /// pattern.
 /// </summary>
 /// <remarks>
-/// The plan is advisory: the hosting executor re-validates <see cref="Composition"/>
-/// against the live registry on every version change and falls back to the runtime
-/// strategy whenever the pipeline no longer matches, so a stale plan only loses its
-/// speedup, never changes behavior. <see cref="StagedVoidPlan{TMessage}.Execute"/> must
+/// The plan is advisory: the hosting executor validates <see cref="Composition"/> against
+/// the container's selected frozen composition and falls back to the general strategy on
+/// a mismatch, so a stale plan only loses its speedup, never changes behavior.
+/// <see cref="StagedVoidPlan{TMessage}.Execute"/> must
 /// resolve every participant from the provider it is handed — that is exactly what the
 /// runtime handler references do outside memoized mode, which the executor's gate
 /// excludes.

--- a/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
+++ b/src/Stella.Ergosfare.Core.Extensions.MicrosoftDependencyInjection/ModuleRegistry.cs
@@ -176,8 +176,9 @@ public class ModuleRegistry(
     /// message's arguments before resolving it.
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2072",
-        Justification = "Every element originates from a frozen participant row, whose handler type the generated " +
-                        "table references through typeof — statically rooted, so the constructors survive trimming.")]
+        Justification = "Every element originates from FrozenParticipant.HandlerType, which is annotated to " +
+                        "preserve public constructors; the HashSet the catalog collects them into only " +
+                        "deduplicates and cannot carry the annotation.")]
     private HashSet<Type> RegisterParticipants()
     {
         var registered = new HashSet<Type>();

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/EventModule.cs
@@ -24,7 +24,7 @@ internal class EventModule(Action<EventModuleBuilder> builder) : IModule
     /// <summary>
     /// Configures the event module using the specified module configuration.
     /// </summary>
-    /// <param name="configuration">The module configuration containing services and message registry.</param>
+    /// <param name="configuration">The module configuration containing services and this container's frozen composition selection.</param>
     public void Build(IModuleConfiguration configuration)
     {
         builder(new EventModuleBuilder(configuration.Compositions));

--- a/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/ModuleRegistryExtensions.cs
+++ b/src/Stella.Ergosfare.Events.Extensions.MicrosoftDependencyInjection/ModuleRegistryExtensions.cs
@@ -13,8 +13,8 @@ public static class ModuleRegistryExtensions
     /// </summary>
     /// <param name="registry">The module registry to which the event module will be added.</param>
     /// <param name="builder">
-    /// An action to configure the <see cref="EventModuleBuilder"/>, 
-    /// allowing registration of events in the message registry.
+    /// An action that configures the <see cref="EventModuleBuilder"/> by selecting event
+    /// participants from the compile-time frozen composition table.
     /// </param>
     /// <returns>The same <see cref="IModuleRegistry"/> instance for fluent chaining.</returns>
     public static IModuleRegistry AddEventModule(this IModuleRegistry registry, Action<EventModuleBuilder> builder)

--- a/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
+++ b/src/Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection/QueryModule.cs
@@ -5,8 +5,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace Stella.Ergosfare.Queries.Extensions.MicrosoftDependencyInjection;
 
 /// <summary>
-/// Represents the query module which registers query types and the query mediator
-/// within the dependency injection container and message registry.
+/// Represents the query module, which selects query participants from the frozen
+/// composition table and registers the query mediator with dependency injection.
 /// </summary>
 internal class QueryModule(
     Action<QueryModuleBuilder> builder
@@ -17,7 +17,8 @@ internal class QueryModule(
     /// Builds and initializes the module by registering queries and the query mediator.
     /// </summary>
     /// <param name="configuration">
-    /// The module configuration providing access to the service collection and message registry.
+    /// The module configuration providing access to the service collection and this
+    /// container's frozen composition selection.
     /// </param>
     public void Build(IModuleConfiguration configuration)
     {

--- a/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/ErgosfareRegistrationGenerator.cs
@@ -2278,8 +2278,8 @@ public sealed partial class ErgosfareRegistrationGenerator : IIncrementalGenerat
     ///     shape-builder, and every call's pattern-match arm is decidable at compile time.
     ///     Anything unmodelable disqualifies the message rather than risking divergence;
     ///     the runtime gate then simply never sees a staged plan for it. The plan stays
-    ///     advisory regardless: the hosting executor re-validates the composition per
-    ///     registry version.
+    ///     advisory regardless: the hosting executor validates it against the container's
+    ///     selected frozen composition.
     /// </summary>
     private static List<StagedPlanModel> ComputeStagedPlans(
         List<RegistrableTypeModel> types,
@@ -2751,10 +2751,10 @@ public sealed partial class ErgosfareRegistrationGenerator : IIncrementalGenerat
     ///     (<c>IAsyncHandler&lt;TMessage&gt;</c>), its handler participates in default
     ///     discovery in the default group, and no discovered interceptor targets the
     ///     message directly. The check is deliberately conservative and only ever costs
-    ///     the speedup when wrong: the runtime executor re-validates the actual pipeline
-    ///     per registry version and falls back to the runtime dispatch shape on any
-    ///     mismatch (covariant handlers or interceptors registered for base contracts,
-    ///     keyed selections, runtime registrations).
+    ///     the speedup when wrong: the runtime executor validates the actual pipeline
+    ///     against the container's selected frozen composition and falls back to the
+    ///     general dispatch shape on any mismatch (covariant handlers or interceptors
+    ///     selected through base contracts, or keyed selections).
     /// </summary>
     private static List<VoidPlanModel> ComputeVoidPlans(List<RegistrableTypeModel> types)
     {
@@ -2796,8 +2796,8 @@ public sealed partial class ErgosfareRegistrationGenerator : IIncrementalGenerat
     ///     Result-producing counterpart of <see cref="ComputeVoidPlans"/>: a dispatchable
     ///     command/query with exactly one closed, non-stream result contract qualifies
     ///     when its whole discovered pipeline is a single async handler producing exactly
-    ///     that result. Equally conservative and equally advisory — the runtime
-    ///     re-validates per registry version.
+    ///     that result. Equally conservative and equally advisory — the runtime validates
+    ///     it against the container's selected frozen composition.
     /// </summary>
     private static List<ResultPlanModel> ComputeResultPlans(List<RegistrableTypeModel> types)
     {

--- a/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/ResultPlanModel.cs
@@ -7,7 +7,8 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     <c>GeneratedDispatchRoots.AddResultPlan&lt;TMessage, TResult, THandler&gt;()</c> so
 ///     the runtime executor closes over all three types and calls the handler
 ///     devirtualized. Advisory exactly like the void plan: the runtime re-validates the
-///     pipeline per registry version and a mismatched plan only loses the speedup.
+///     pipeline against the container's selected frozen composition, and a mismatched plan
+///     only loses the speedup.
 /// </summary>
 /// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
 /// <param name="ResultTypeExpression">Fully qualified expression of the closed result type.</param>

--- a/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
+++ b/src/Stella.Ergosfare.SourceGenerator/Models/VoidPlanModel.cs
@@ -5,8 +5,8 @@ namespace Stella.Ergosfare.SourceGenerator.Models;
 ///     discovered pipeline is a single default-discovery, default-group async handler.
 ///     Emitted as <c>GeneratedDispatchRoots.AddVoidPlan&lt;TMessage, THandler&gt;()</c> so
 ///     the runtime executor closes over both types and calls the handler devirtualized.
-///     The runtime re-validates the pipeline per registry version, so a plan that turns
-///     out not to match the actual registrations only loses the speedup, never behavior.
+///     The runtime validates the pipeline against the container's selected frozen
+///     composition, so a plan that does not match only loses the speedup, never behavior.
 /// </summary>
 /// <param name="MessageTypeExpression">Fully qualified expression of the closed message type.</param>
 /// <param name="HandlerTypeExpression">Fully qualified expression of the sole handler type.</param>


### PR DESCRIPTION
## Summary
- replace obsolete runtime/message registry XML language with the frozen composition model
- document container selection and DI responsibilities for modules and unresolved participants
- reshape the preview README into a product-first introduction with a current quick start
- retain the technical depth around pipelines, contexts, discovery, AOT, DI lifetimes and benchmarks
- explain the v2.8 frozen-composition boundary and migration surface

## Verification
- dotnet build --no-restore (0 warnings, 0 errors)
- stale XML terminology scan clean
- README examples checked against the current public contracts
- git diff --check clean


---

> **AI transparency:** The documentation copy and pull request description in this change were prepared with OpenAI Codex and are subject to maintainer review.
