### PR TITLE
build: add net11.0 to the target framework list

### DIFF
--- a/.github/workflows/aot_smoke.yml
+++ b/.github/workflows/aot_smoke.yml
@@ -23,13 +23,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET
-        # Both SDKs: the referenced library projects multi-target net9.0 and net10.0, so
-        # restore needs to evaluate both even though the smoke app publishes net9.0.
+        # Every SDK: the referenced library projects multi-target net9.0, net10.0 and
+        # net11.0, so restore needs to evaluate all three even though the smoke app
+        # publishes net9.0.
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             9.0.x
             10.0.x
+
+      # The smoke app stays on net9.0: ILC compiles the framework in, so there is no
+      # roll-forward equivalent and probing .NET 11 AOT means retargeting the app to a
+      # preview TFM. Revisit at GA — NativeAOT's faster interface dispatch lands squarely
+      # on this library's interface-heavy hot path and deserves its own smoke then.
+      - name: Setup .NET 11 Preview
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
 
       - name: Publish NativeAOT Smoke App
         run: dotnet publish examples/AotSmoke/AotSmoke.csproj -c Release -r linux-x64

--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -19,8 +19,8 @@ on:
 
 jobs:
   Coverage:
-    # Single job with both SDKs installed: the solution multi-targets net9.0 and
-    # net10.0, so a per-SDK matrix cannot build it — and two parallel jobs racing
+    # Single job with every SDK installed: the solution multi-targets net9.0, net10.0
+    # and net11.0, so a per-SDK matrix cannot build it — and two parallel jobs racing
     # to push the badge branch caused non-fast-forward failures.
     runs-on: ubuntu-latest
     steps:
@@ -33,6 +33,15 @@ jobs:
           dotnet-version: |
             9.0.x
             10.0.x
+
+      # Separate step for net11.0: `dotnet-quality: preview` applies to every version in
+      # its step's list, so folding 11.0.x into the list above would pull pre-release
+      # patches of the shipping TFMs too. Merge it in once .NET 11 reaches GA.
+      - name: Setup .NET 11 Preview
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
 
       - name: Install Coverlet global tool
         run: dotnet tool install --global coverlet.console

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   release:
-    # Single job with both SDKs: the per-SDK matrix ran every step twice, and the
+    # Single job with every SDK: the per-SDK matrix ran every step twice, and the
     # duplicated release steps raced each other uploading the same assets — the
     # cause of the v1.4.0 failure.
     runs-on: ubuntu-latest
@@ -37,6 +37,13 @@ jobs:
           dotnet-version: |
             9.0.x
             10.0.x
+
+      # Separate step so `dotnet-quality: preview` does not pull pre-release patches of
+      # the shipping TFMs. Merge into the list above once .NET 11 reaches GA.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
 
       - name: Set version
         run: |

--- a/.github/workflows/nuget_release.yml
+++ b/.github/workflows/nuget_release.yml
@@ -18,8 +18,8 @@ on:
 
 jobs:
   release:
-    # Single job with both SDKs: the solution multi-targets net9.0/net10.0, and a
-    # per-SDK matrix packed and pushed every package twice.
+    # Single job with every SDK: the solution multi-targets net9.0/net10.0/net11.0, and
+    # a per-SDK matrix packed and pushed every package twice.
     runs-on: ubuntu-latest
     environment: publish
     permissions:
@@ -37,6 +37,17 @@ jobs:
           dotnet-version: |
             9.0.x
             10.0.x
+
+      # Separate step so `dotnet-quality: preview` does not pull pre-release patches of
+      # the shipping TFMs. Merge into the list above once .NET 11 reaches GA.
+      #
+      # Note this makes every package pushed from this line carry a lib/net11.0/ asset
+      # built against a preview ref pack — coherent on the preview line, which ships only
+      # -preview versions. It must not reach a stable tag before GA.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
 
       - name: Set version
         run: |

--- a/.github/workflows/nuget_release.yml
+++ b/.github/workflows/nuget_release.yml
@@ -41,9 +41,16 @@ jobs:
       # Separate step so `dotnet-quality: preview` does not pull pre-release patches of
       # the shipping TFMs. Merge into the list above once .NET 11 reaches GA.
       #
-      # Note this makes every package pushed from this line carry a lib/net11.0/ asset
-      # built against a preview ref pack — coherent on the preview line, which ships only
-      # -preview versions. It must not reach a stable tag before GA.
+      # Every package pushed from here — stable tags included — therefore carries a
+      # lib/net11.0/ asset compiled against a PREVIEW ref pack. That is a deliberate
+      # release decision, not an oversight: the contract suite passes on all three TFMs,
+      # and a net11.0 consumer that would otherwise roll forward onto lib/net10.0/ gets a
+      # matching asset instead.
+      #
+      # The obligation it creates: when .NET 11 reaches GA on 2026-11-10, any stable
+      # version already published carries a net11.0 asset built against preview bits. Re-
+      # pack and re-publish those against the GA ref pack rather than leaving consumers
+      # bound to preview-compiled assets.
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '11.0.x'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,8 +14,8 @@ on:
 
 jobs:
   unit-tests:
-    # Single job with both SDKs installed: the solution multi-targets net9.0 and
-    # net10.0, so a per-SDK matrix cannot restore/build it with only one SDK.
+    # Single job with every SDK installed: the solution multi-targets net9.0, net10.0
+    # and net11.0, so a per-SDK matrix cannot restore/build it with only one SDK.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -28,12 +28,23 @@ jobs:
             9.0.x
             10.0.x
 
+      # Separate step for net11.0: `dotnet-quality: preview` applies to every version in
+      # its step's list, so folding 11.0.x into the list above would pull pre-release
+      # patches of the shipping TFMs too. Drop this step and merge the version in once
+      # .NET 11 reaches GA (November 2026).
+      - name: Setup .NET 11 Preview
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
       - name: Restore Dependencies
         run: dotnet restore Stella.Ergosfare.slnx
 
       # Category=Contract is the core-modernization safety net
-      # (test/Stella.Ergosfare.Contract.Test): it runs both registration axes on both
-      # TFMs and is named here explicitly so it can never fall out of CI unnoticed.
+      # (test/Stella.Ergosfare.Contract.Test): it runs both registration axes on every
+      # TFM and is named here explicitly so it can never fall out of CI unnoticed.
+      # With net11.0 in the matrix this is also what proves .NET 11 keeps the lane map.
       - name: Run Unit Tests
         run: |
           dotnet test Stella.Ergosfare.slnx \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,16 @@
 <Project>
     <PropertyGroup>
-        <!-- net11.0 rides the preview line ahead of its November 2026 GA. It buys no
+        <!-- net11.0 ships ahead of its 2026-11-10 GA, stable line included. It buys no
              compatibility on its own — roll-forward already lets a net11.0 consumer bind
-             lib/net10.0/ — so it is here to prove the sources compile and the suite passes
-             on .NET 11, and to hold the slot for the one TFM-gated win worth having later:
-             Runtime Async, which needs the contract suite's lane map re-validated before it
-             can be trusted on the stable line. Consequence: building this repo now requires
-             the .NET 11 preview SDK. -->
+             lib/net10.0/ — so what it carries is proof: the sources compile under the C# 15
+             compiler and the contract suite's composition lanes hold on .NET 11, on every
+             run. It also holds the slot for the one TFM-gated win worth having later:
+             Runtime Async, not taken here because it rewrites async codegen and needs the
+             lane map re-validated against the abort semantics first.
+
+             Two consequences. Building this repo now requires the .NET 11 preview SDK.
+             And assets shipped for net11.0 before GA are compiled against preview ref
+             packs — see the re-pack obligation in .github/workflows/nuget_release.yml. -->
         <TargetFrameworks>net11.0;net10.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,26 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+        <!-- net11.0 rides the preview line ahead of its November 2026 GA. It buys no
+             compatibility on its own — roll-forward already lets a net11.0 consumer bind
+             lib/net10.0/ — so it is here to prove the sources compile and the suite passes
+             on .NET 11, and to hold the slot for the one TFM-gated win worth having later:
+             Runtime Async, which needs the contract suite's lane map re-validated before it
+             can be trusted on the stable line. Consequence: building this repo now requires
+             the .NET 11 preview SDK. -->
+        <TargetFrameworks>net11.0;net10.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         
         <Nullable>enable</Nullable>
+
+        <!-- Deliberately `latest`, not `latestMajor` or a pinned version: with the .NET 11
+             preview SDK now required by the TFM list above, this resolves to C# 15 — and it
+             does so for the net9.0 and net10.0 compilations too, since the language version
+             follows the compiler rather than the target framework. That is the intent: one
+             language version across all three TFMs, so a construct cannot compile on one and
+             fail on another. It also means a C# 15 feature used here silently applies to the
+             assets shipped for the older TFMs, which is fine for syntax but not for anything
+             requiring runtime support (union types, closed hierarchies) — those need the
+             runtime attributes and stay off the table until GA. -->
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adds `net11.0` alongside the shipping `net9.0` and `net10.0`, ahead of the 2026-11-10 GA. **Release decision: this ships on the stable line too** — v2.3.0 stable will carry the `net11.0` asset.

## What this does and does not buy

It does **not** widen the compatibility window. Roll-forward already lets a `net11.0` consumer bind `lib/net10.0/`, so that window was never closed. What the TFM buys is **proof** — the sources compile under the C# 15 compiler and the contract suite's composition lanes hold on the .NET 11 runtime, on every run.

## CI result

All three checks green, and every suite ran on all three TFMs:

| Suite | net9.0 | net10.0 | net11.0 |
|---|---|---|---|
| Contract.Test | 194 | 194 | 194 |
| Command.Test | 54 | 54 | 54 |
| Core.Test / Events.Test | 39 | 39 | 39 |
| Queries.Test | 24 | 24 | 24 |
| SourceGenerator.Test | 12 (+1 E2E) | 12 (+1 E2E) | 12 (+1 E2E) |

Zero failures. The C# 15 compiler broke nothing, and the lane map holds on .NET 11.

## Why no .NET 11 features are adopted

A survey of the feature set turned up nothing in this codebase to use:

| Area | Verdict |
|---|---|
| JIT, GC, NativeAOT interface dispatch | **No TFM needed** — a `net10.0` assembly already collects these running on the .NET 11 runtime |
| `EqualityComparer<T>.Create`, LINQ `FullJoin`, new `Stream` types, Zstandard, vector APIs | No call sites here |
| C# 15 union types | Payload lives in an `object?` field, value types box — precisely the object-typed bridge the dispatch hot path was built to avoid |
| C# 15 `closed` hierarchies | Applies to classes; the handler contracts are interfaces |
| Collection expression arguments | No capacity/comparer-carrying collection literals in the tree |

That leaves **Runtime Async** as the only TFM-gated win worth having, and this PR does not take it. It rewrites async codegen, so it needs the contract suite's lane map re-validated against the abort semantics first.

## Consequences

- **Building this repo now requires the .NET 11 preview SDK** — `NETSDK1045` without it. This affects contributors, not just CI.
- **`LangVersion` stays `latest`**, which now resolves to C# 15 — including for the `net9.0` and `net10.0` compilations, since the language version follows the compiler rather than the target framework. Deliberate, and documented in `Directory.Build.props`: one language version across all three TFMs so a construct cannot compile on one and fail on another.
- **Stable packages published before GA carry a `net11.0` asset compiled against preview ref packs.** Accepted deliberately. The obligation it creates — re-pack against the GA ref pack once .NET 11 ships on 2026-11-10 — is recorded in `nuget_release.yml` rather than left to memory.

## CI wiring

Every workflow that builds the solution gets a second `setup-dotnet` step for `11.0.x` with `dotnet-quality: preview`. It has to be a separate step: `dotnet-quality` applies to every version in its own step's list, so folding `11.0.x` into the existing list would pull pre-release patches of the shipping TFMs too. The steps collapse into one at GA.

The NativeAOT smoke stays on `net9.0` — ILC compiles the framework in, so there is no roll-forward equivalent and probing .NET 11 AOT would mean retargeting the smoke app to a preview TFM. Worth revisiting at GA, when NativeAOT's faster interface dispatch lands squarely on this library's interface-heavy hot path.

The benchmark project also stays on `net9.0`, because the published baseline in the readme is pinned to .NET 9.0.11. BenchmarkDotNet supports multi-runtime jobs natively, so this is a baseline decision rather than a tooling limit — it is the right instrument for measuring Runtime Async at GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)